### PR TITLE
Apptainer support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .python-version
 *.out
+*.sif
 multirun
 outputs
 uv.lock

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ bash docker/build.sh
 
 ### Using the OS-level sandbox (legacy)
 
-The original macOS Seatbelt / Linux bubblewrap sandbox is still available (`use_docker: false` in `agentic.yaml`) but has a known limitation: it restricts filesystem *writes* but allows *reads* of the entire host filesystem.
+The original macOS Seatbelt / Linux bubblewrap sandbox is still available (`container_backend: local` in `agentic.yaml`) but has a known limitation: it restricts filesystem *writes* but allows *reads* of the entire host filesystem.
 
 Red team the sandbox:
 ```bash
@@ -280,7 +280,7 @@ Available backend presets: `claude_sonnet` (default), `claude_opus`, `opencode_g
 
 To use the legacy OS-level sandbox instead:
 ```bash
-python experiments/run_experiment.py approach=agentic environment=small_maze approach.use_docker=false
+python experiments/run_experiment.py approach=agentic environment=small_maze approach.container_backend=local
 ```
 
 To skip re-generation and load a previously generated approach:
@@ -298,7 +298,7 @@ Use the [joblib launcher](https://hydra.cc/docs/plugins/joblib_launcher/) to run
 ```bash
 python experiments/run_experiment.py -m \
     approach=agentic \
-    approach.use_docker=true \
+    approach.container_backend=docker \
     seed=42,24,424,444,222 \
     'primitives=[]' \
     environment=motion2d_easy,obstruction2d_easy,clutteredretrieval2d_easy,clutteredstorage2d_easy,stickbutton2d_easy,pushpullhook2d \

--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ The agent runs inside a Docker container (`robocode-sandbox`) that provides full
 | Network | `init-firewall.sh` whitelists API endpoints for the configured provider (Anthropic, OpenAI, Google, etc.), GitHub IPs, and telemetry; blocks everything else via iptables. Extra domains are passed via `ROBOCODE_FIREWALL_EXTRA_DOMAINS`. |
 | Write hook | Claude backend: `PreToolUse` hook in `.claude/settings.json` double-checks Write/Edit paths stay inside `/sandbox`. OpenCode backend: `"permission": "allow"` in `opencode.json` (Docker provides the isolation). |
 
+The Apptainer backend (`container_backend=apptainer`, for HPC clusters with no Docker daemon) keeps the same filesystem isolation but has **no network firewall**: unprivileged Apptainer cannot grant `CAP_NET_ADMIN`, so `init-firewall.sh` is skipped and generated code runs with unrestricted network egress. Use Docker where the iptables allowlist matters.
+
 ### What the agent sees
 
 | Path | Contents |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,6 +29,17 @@ ENV TZ="$TZ"
 ARG CLAUDE_CODE_VERSION=latest
 ARG OPENCODE_VERSION=latest
 
+# Remap the node user's UID/GID to match the host's at build time so that
+# bind-mounted host files (e.g. ~/.claude) are readable inside the container
+# without needing host UID 1000. build.sh / build_sif.sh pass
+# --build-arg USER_UID=$(id -u) USER_GID=$(id -g).
+ARG USER_UID=1000
+ARG USER_GID=1000
+RUN if [ "$USER_GID" != "1000" ] || [ "$USER_UID" != "1000" ]; then \
+        groupmod --gid "$USER_GID" node \
+        && usermod --uid "$USER_UID" --gid "$USER_GID" node; \
+    fi
+
 # ---------------------------------------------------------------------------
 # System packages
 #   - git, sudo, curl: basic dev tools

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -15,5 +15,7 @@ echo "Building robocode-sandbox from ${REPO_ROOT} ..."
 docker build \
     --tag robocode-sandbox \
     --file "${REPO_ROOT}/docker/Dockerfile" \
+    --build-arg "USER_UID=$(id -u)" \
+    --build-arg "USER_GID=$(id -g)" \
     "${REPO_ROOT}"
 echo "Done. Image tagged: robocode-sandbox"

--- a/docker/build_sif.sh
+++ b/docker/build_sif.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Build the robocode-sandbox Apptainer/Singularity image (SIF).
+#
+# Uses the EXISTING docker/Dockerfile (no separate definition file).
+# Pipeline:
+#   1. podman build  -> OCI image (rootless, no docker daemon needed)
+#   2. podman save   -> docker-archive tarball
+#   3. apptainer build -> SIF from the tarball
+#
+# Run from anywhere inside the repository:
+#   bash docker/build_sif.sh
+#
+# Rebuild when PyPI dependencies in pyproject.toml / uv.lock change.
+# No rebuild needed for src/ or third-party/kindergarden/ code changes
+# (bind-mounted at runtime).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SIF_PATH="${REPO_ROOT}/robocode-sandbox.sif"
+TMP_DIR="$(mktemp -d -t robocode-sif-XXXXXX)"
+TAR_PATH="${TMP_DIR}/robocode-sandbox.tar"
+
+cleanup() {
+    rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+echo "[1/3] Building OCI image with podman from ${REPO_ROOT} ..."
+podman build \
+    --tag robocode-sandbox \
+    --file "${REPO_ROOT}/docker/Dockerfile" \
+    --build-arg "USER_UID=$(id -u)" \
+    --build-arg "USER_GID=$(id -g)" \
+    "${REPO_ROOT}"
+
+echo "[2/3] Saving OCI image to ${TAR_PATH} ..."
+podman save robocode-sandbox -o "${TAR_PATH}"
+
+echo "[3/3] Converting to SIF at ${SIF_PATH} ..."
+apptainer build --force "${SIF_PATH}" "docker-archive://${TAR_PATH}"
+
+echo "Done. SIF written to: ${SIF_PATH}"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -17,7 +17,13 @@ uv sync --frozen --python python3.11
 cd /sandbox
 
 # Pass ROBOCODE_FIREWALL_EXTRA_DOMAINS through sudo (sudo strips env by default).
-sudo ROBOCODE_FIREWALL_EXTRA_DOMAINS="${ROBOCODE_FIREWALL_EXTRA_DOMAINS:-}" \
-    /usr/local/bin/init-firewall.sh
+# Skipped under apptainer (--fakeroot doesn't grant real CAP_NET_ADMIN for iptables),
+# in which case ROBOCODE_SKIP_FIREWALL=1 is set by apptainer_sandbox.py.
+if [ "${ROBOCODE_SKIP_FIREWALL:-0}" = "1" ]; then
+    echo "entrypoint: ROBOCODE_SKIP_FIREWALL=1, skipping firewall init" >&2
+else
+    sudo ROBOCODE_FIREWALL_EXTRA_DOMAINS="${ROBOCODE_FIREWALL_EXTRA_DOMAINS:-}" \
+        /usr/local/bin/init-firewall.sh
+fi
 
 exec "$@"

--- a/experiments/conf/approach/agentic.yaml
+++ b/experiments/conf/approach/agentic.yaml
@@ -6,7 +6,7 @@ max_budget_usd: 5.0
 max_turns: 0
 output_dir: ${hydra:runtime.output_dir}
 load_dir: null
-use_docker: true
+container_backend: docker  # docker | apptainer | local
 geometry_prompt: true
 modular_code_prompt: false
 max_output_tokens: 16384

--- a/experiments/conf/approach/agentic_cdl.yaml
+++ b/experiments/conf/approach/agentic_cdl.yaml
@@ -6,7 +6,7 @@ max_budget_usd: 5.0
 max_turns: 0
 output_dir: ${hydra:runtime.output_dir}
 load_dir: null
-use_docker: true
+container_backend: docker  # docker | apptainer | local
 geometry_prompt: true
 max_output_tokens: 32000
 autocompact_pct: 80

--- a/experiments/conf/approach/llm_genplan.yaml
+++ b/experiments/conf/approach/llm_genplan.yaml
@@ -11,6 +11,7 @@ max_debug_attempts: 4
 skip_chain_of_thought: false
 episode_timeout_s: 30.0
 # Run the whole genplan loop inside one sandbox container (like the agentic
-# approach), so generated code never executes on the host. false runs on the host.
-use_docker: true
+# approach), so generated code never executes on the host. local runs in-process.
+container_backend: docker  # docker | apptainer | local
 docker_image: robocode-sandbox
+sif_path: null  # null -> <repo_root>/robocode-sandbox.sif

--- a/experiments/run_experiment.py
+++ b/experiments/run_experiment.py
@@ -3,14 +3,17 @@
 Example usage:
 
     python experiments/run_experiment.py approach=agentic environment=motion2d_easy
-    python experiments/run_experiment.py approach=agentic approach.use_docker=true \
-        'primitives=[]' environment=motion2d_easy
+    python experiments/run_experiment.py approach=agentic \
+        approach.container_backend=docker 'primitives=[]' environment=motion2d_easy
+
+The sandbox backend is selected with approach.container_backend=docker|apptainer|local
+(default docker for agentic and llm_genplan; local runs unsandboxed in-process).
 
 Parallel sweep with joblib launcher:
 
     python experiments/run_experiment.py -m \
         approach=agentic \
-        approach.use_docker=true \
+        approach.container_backend=docker \
         seed=42,24,424,444,222 \
         'primitives=[]' \
         environment=motion2d_easy,obstruction2d_easy,clutteredretrieval2d_easy \

--- a/scripts/analysis_history.sh
+++ b/scripts/analysis_history.sh
@@ -6,7 +6,7 @@ ENV=obstruction2d_medium
 
 python experiments/run_experiment.py \
     approach=agentic_cdl \
-    approach.use_docker=true \
+    approach.container_backend=docker \
     approach.max_budget_usd=20.0 \
     environment=stickbutton2d_medium \
     record_approach_history=true \

--- a/scripts/run_cdl_agent_mp.sh
+++ b/scripts/run_cdl_agent_mp.sh
@@ -6,7 +6,7 @@ DATE=$(date +%m-%d)
 
 python experiments/run_experiment.py -m \
     approach=agentic_cdl \
-    approach.use_docker=true \
+    approach.container_backend=docker \
     approach.max_budget_usd=20.0 \
     seed=42,24,444 \
     num_eval_tasks=100 \

--- a/scripts/run_cdl_agent_no_primitives.sh
+++ b/scripts/run_cdl_agent_no_primitives.sh
@@ -6,7 +6,7 @@ DATE=$(date +%m-%d)
 
 python experiments/run_experiment.py -m \
     approach=agentic_cdl \
-    approach.use_docker=true \
+    approach.container_backend=docker \
     approach.max_budget_usd=20.0 \
     seed=42,24,444 \
     num_eval_tasks=100 \

--- a/scripts/run_easy2d_all_primitives.sh
+++ b/scripts/run_easy2d_all_primitives.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 python experiments/run_experiment.py -m \
     approach=agentic \
-    approach.use_docker=true \
+    approach.container_backend=docker \
     seed=42,24,424,444,222 \
     'primitives=[check_action_collision,render_state,csp,BiRRT]' \
     environment=motion2d_easy,obstruction2d_easy,clutteredretrieval2d_easy,clutteredstorage2d_easy,stickbutton2d_easy,pushpullhook2d \

--- a/scripts/run_easy2d_all_primitives_25d.sh
+++ b/scripts/run_easy2d_all_primitives_25d.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 python experiments/run_experiment.py -m \
     approach=agentic \
-    approach.use_docker=true \
+    approach.container_backend=docker \
     approach.max_budget_usd=25 \
     seed=42,24,424,444,222 \
     'primitives=[check_action_collision,render_state,csp,BiRRT]' \

--- a/scripts/run_easy2d_all_primitives_25d_a.sh
+++ b/scripts/run_easy2d_all_primitives_25d_a.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 python experiments/run_experiment.py -m \
     approach=agentic \
-    approach.use_docker=true \
+    approach.container_backend=docker \
     approach.max_budget_usd=25 \
     seed=24,444 \
     'primitives=[check_action_collision,render_state,csp,BiRRT]' \

--- a/scripts/run_easy2d_all_primitives_25d_b.sh
+++ b/scripts/run_easy2d_all_primitives_25d_b.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 python experiments/run_experiment.py -m \
     approach=agentic \
-    approach.use_docker=true \
+    approach.container_backend=docker \
     approach.max_budget_usd=25 \
     seed=424,222 \
     'primitives=[check_action_collision,render_state,csp,BiRRT]' \

--- a/scripts/run_easy2d_all_primitives_a.sh
+++ b/scripts/run_easy2d_all_primitives_a.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 python experiments/run_experiment.py -m \
     approach=agentic \
-    approach.use_docker=true \
+    approach.container_backend=docker \
     seed=24,444 \
     'primitives=[check_action_collision,render_state,csp,BiRRT]' \
     environment=motion2d_easy,obstruction2d_easy,clutteredretrieval2d_easy,clutteredstorage2d_easy,stickbutton2d_easy,pushpullhook2d \

--- a/scripts/run_easy2d_all_primitives_b.sh
+++ b/scripts/run_easy2d_all_primitives_b.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 python experiments/run_experiment.py -m \
     approach=agentic \
-    approach.use_docker=true \
+    approach.container_backend=docker \
     seed=424,222 \
     'primitives=[check_action_collision,render_state,csp,BiRRT]' \
     environment=motion2d_easy,obstruction2d_easy,clutteredretrieval2d_easy,clutteredstorage2d_easy,stickbutton2d_easy,pushpullhook2d \

--- a/scripts/run_easy2d_no_primitives.sh
+++ b/scripts/run_easy2d_no_primitives.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 python experiments/run_experiment.py -m \
     approach=agentic \
-    approach.use_docker=true \
+    approach.container_backend=docker \
     seed=42,24,424,444,222 \
     'primitives=[]' \
     environment=motion2d_easy,obstruction2d_easy,clutteredretrieval2d_easy,clutteredstorage2d_easy,stickbutton2d_easy,pushpullhook2d \

--- a/scripts/run_easy2d_no_primitives_25d.sh
+++ b/scripts/run_easy2d_no_primitives_25d.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 python experiments/run_experiment.py -m \
     approach=agentic \
-    approach.use_docker=true \
+    approach.container_backend=docker \
     approach.max_budget_usd=25 \
     seed=42,24,424,444,222 \
     'primitives=[]' \

--- a/scripts/run_easy2d_no_primitives_25d_a.sh
+++ b/scripts/run_easy2d_no_primitives_25d_a.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 python experiments/run_experiment.py -m \
     approach=agentic \
-    approach.use_docker=true \
+    approach.container_backend=docker \
     approach.max_budget_usd=25 \
     seed=24,444 \
     'primitives=[]' \

--- a/scripts/run_easy2d_no_primitives_25d_b.sh
+++ b/scripts/run_easy2d_no_primitives_25d_b.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 python experiments/run_experiment.py -m \
     approach=agentic \
-    approach.use_docker=true \
+    approach.container_backend=docker \
     approach.max_budget_usd=25 \
     seed=424,222 \
     'primitives=[]' \

--- a/scripts/run_easy2d_no_primitives_a.sh
+++ b/scripts/run_easy2d_no_primitives_a.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 python experiments/run_experiment.py -m \
     approach=agentic \
-    approach.use_docker=true \
+    approach.container_backend=docker \
     seed=24,444 \
     'primitives=[]' \
     environment=motion2d_easy,obstruction2d_easy,clutteredretrieval2d_easy,clutteredstorage2d_easy,stickbutton2d_easy,pushpullhook2d \

--- a/scripts/run_easy2d_no_primitives_a_no_geometry.sh
+++ b/scripts/run_easy2d_no_primitives_a_no_geometry.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 python experiments/run_experiment.py -m \
     approach=agentic \
-    approach.use_docker=true \
+    approach.container_backend=docker \
     approach.geometry_prompt=false \
     seed=24,444 \
     'primitives=[]' \

--- a/scripts/run_easy2d_no_primitives_b.sh
+++ b/scripts/run_easy2d_no_primitives_b.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 python experiments/run_experiment.py -m \
     approach=agentic \
-    approach.use_docker=true \
+    approach.container_backend=docker \
     seed=424,222 \
     'primitives=[]' \
     environment=motion2d_easy,obstruction2d_easy,clutteredretrieval2d_easy,clutteredstorage2d_easy,stickbutton2d_easy,pushpullhook2d \

--- a/scripts/run_easy2d_no_primitives_b_no_geometry.sh
+++ b/scripts/run_easy2d_no_primitives_b_no_geometry.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 python experiments/run_experiment.py -m \
     approach=agentic \
-    approach.use_docker=true \
+    approach.container_backend=docker \
     approach.geometry_prompt=false \
     seed=424,222 \
     'primitives=[]' \

--- a/scripts/run_easy2d_no_primitives_parallel.sh
+++ b/scripts/run_easy2d_no_primitives_parallel.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 python experiments/run_experiment.py -m \
     approach=agentic \
-    approach.use_docker=true \
+    approach.container_backend=docker \
     seed=42,24,424,444,222 \
     'primitives=[]' \
     environment=motion2d_easy,obstruction2d_easy,clutteredretrieval2d_easy,clutteredstorage2d_easy,stickbutton2d_easy,pushpullhook2d \

--- a/scripts/run_missing_evals.sh
+++ b/scripts/run_missing_evals.sh
@@ -11,7 +11,7 @@ run_eval() {
     echo ">>> Running: $dir (env=$env, seed=$seed, primitives=$primitives)"
     python experiments/run_experiment.py \
         approach=agentic_cdl \
-        approach.use_docker=true \
+        approach.container_backend=docker \
         approach.max_budget_usd=20.0 \
         seed="$seed" \
         num_eval_tasks=100 \

--- a/scripts/test_cdl_agent_no_primitives.sh
+++ b/scripts/test_cdl_agent_no_primitives.sh
@@ -7,7 +7,7 @@ DATE=$(date +%Y-%m-%d)
 
 python experiments/run_experiment.py \
     approach=agentic_cdl \
-    approach.use_docker=true \
+    approach.container_backend=docker \
     approach.max_budget_usd=20.0 \
     seed="$SEED" \
     num_eval_tasks=100 \

--- a/src/robocode/approaches/agentic_approach.py
+++ b/src/robocode/approaches/agentic_approach.py
@@ -25,6 +25,7 @@ from robocode.utils.docker_sandbox import (
 from robocode.utils.episode import load_generated_approach
 from robocode.utils.rate_limit import run_with_rate_limit_retry
 from robocode.utils.sandbox import SandboxConfig
+from robocode.utils.sandbox_types import resolve_container_backend
 
 logger = logging.getLogger(__name__)
 
@@ -230,15 +231,9 @@ class AgenticApproach(BaseApproach[_ObsType, _ActType]):
         self._max_turns = max_turns
         self._output_dir = Path(output_dir)
         self._load_dir = Path(load_dir) if load_dir is not None else None
-        # container_backend takes precedence; use_docker kept for back-compat.
-        if container_backend is None:
-            container_backend = "docker" if use_docker else "local"
-        if container_backend not in ("docker", "apptainer", "local"):
-            raise ValueError(
-                f"Invalid container_backend {container_backend!r}; "
-                "expected 'docker', 'apptainer', or 'local'"
-            )
-        self._container_backend = container_backend
+        self._container_backend = resolve_container_backend(
+            container_backend, use_docker
+        )
         self._geometry_prompt = geometry_prompt
         self._modular_code_prompt = modular_code_prompt
         self._mcp_tools = mcp_tools

--- a/src/robocode/approaches/agentic_approach.py
+++ b/src/robocode/approaches/agentic_approach.py
@@ -12,6 +12,7 @@ from omegaconf import DictConfig
 from robocode.approaches.base_approach import BaseApproach
 from robocode.mcp import MCP_TOOLS_SYSTEM_PROMPT_SUFFIX, mcp_tool_descriptions
 from robocode.primitives import format_primitives_description
+from robocode.utils.apptainer_sandbox import ApptainerSandboxConfig
 from robocode.utils.backends import (
     CLAUDE_PROMPT_SUFFIX,
     OPENCODE_PROMPT_SUFFIX,
@@ -207,6 +208,7 @@ class AgenticApproach(BaseApproach[_ObsType, _ActType]):
         output_dir: str = ".",
         load_dir: str | None = None,
         use_docker: bool = False,
+        container_backend: str | None = None,
         geometry_prompt: bool = True,
         modular_code_prompt: bool = False,
         mcp_tools: tuple[str, ...] = (),
@@ -228,7 +230,15 @@ class AgenticApproach(BaseApproach[_ObsType, _ActType]):
         self._max_turns = max_turns
         self._output_dir = Path(output_dir)
         self._load_dir = Path(load_dir) if load_dir is not None else None
-        self._use_docker = use_docker
+        # container_backend takes precedence; use_docker kept for back-compat.
+        if container_backend is None:
+            container_backend = "docker" if use_docker else "local"
+        if container_backend not in ("docker", "apptainer", "local"):
+            raise ValueError(
+                f"Invalid container_backend {container_backend!r}; "
+                "expected 'docker', 'apptainer', or 'local'"
+            )
+        self._container_backend = container_backend
         self._geometry_prompt = geometry_prompt
         self._modular_code_prompt = modular_code_prompt
         self._mcp_tools = mcp_tools
@@ -265,7 +275,9 @@ class AgenticApproach(BaseApproach[_ObsType, _ActType]):
                     mcp_lines.append(f"- {tool_descs[name]}")
             primitives_desc += "\n".join(mcp_lines)
 
-        python_exe = DOCKER_PYTHON if self._use_docker else sys.executable
+        python_exe = (
+            DOCKER_PYTHON if self._container_backend != "local" else sys.executable
+        )
         interface_spec = _INTERFACE_SPEC.format(
             python_executable=python_exe,
             primitives_description=primitives_desc,
@@ -289,6 +301,7 @@ class AgenticApproach(BaseApproach[_ObsType, _ActType]):
             )
 
         docker_config: DockerSandboxConfig | None = None
+        apptainer_config: ApptainerSandboxConfig | None = None
         config: SandboxConfig | None = None
         system_prompt = _SYSTEM_PROMPT
         backend_name = self._backend_cfg["backend"]
@@ -299,7 +312,7 @@ class AgenticApproach(BaseApproach[_ObsType, _ActType]):
         if self._mcp_tools:
             system_prompt += MCP_TOOLS_SYSTEM_PROMPT_SUFFIX
 
-        if self._use_docker:
+        if self._container_backend == "docker":
             docker_config = DockerSandboxConfig(
                 sandbox_dir=sandbox_dir,
                 output_filename="approach.py",
@@ -314,6 +327,21 @@ class AgenticApproach(BaseApproach[_ObsType, _ActType]):
                 autocompact_pct=self._autocompact_pct,
             )
             sandbox_logger = logging.getLogger("robocode.utils.docker_sandbox")
+        elif self._container_backend == "apptainer":
+            apptainer_config = ApptainerSandboxConfig(
+                sandbox_dir=sandbox_dir,
+                output_filename="approach.py",
+                prompt=prompt,
+                system_prompt=system_prompt,
+                model=self._model,
+                max_budget_usd=self._max_budget_usd,
+                max_turns=self._max_turns,
+                primitive_names=tuple(self._primitives),
+                mcp_tools=self._mcp_tools,
+                max_output_tokens=self._max_output_tokens,
+                autocompact_pct=self._autocompact_pct,
+            )
+            sandbox_logger = logging.getLogger("robocode.utils.apptainer_sandbox")
         else:
             config = SandboxConfig(
                 sandbox_dir=sandbox_dir,
@@ -338,9 +366,10 @@ class AgenticApproach(BaseApproach[_ObsType, _ActType]):
         sandbox_logger.addHandler(file_handler)
         try:
             result = run_with_rate_limit_retry(
-                docker_config if self._use_docker else None,
-                config if not self._use_docker else None,
+                docker_config,
+                config,
                 backend=self._backend,
+                apptainer_config=apptainer_config,
             )
         finally:
             sandbox_logger.removeHandler(file_handler)

--- a/src/robocode/approaches/agentic_cdl_approach.py
+++ b/src/robocode/approaches/agentic_cdl_approach.py
@@ -36,6 +36,7 @@ from robocode.utils.docker_sandbox import (
 from robocode.utils.episode import load_generated_approach
 from robocode.utils.rate_limit import run_with_rate_limit_retry
 from robocode.utils.sandbox import SandboxConfig
+from robocode.utils.sandbox_types import resolve_container_backend
 
 logger = logging.getLogger(__name__)
 
@@ -337,14 +338,9 @@ class AgenticCDLApproach(BaseApproach[_ObsType, _ActType]):
         self._max_turns = max_turns
         self._output_dir = Path(output_dir)
         self._load_dir = Path(load_dir) if load_dir is not None else None
-        if container_backend is None:
-            container_backend = "docker" if use_docker else "local"
-        if container_backend not in ("docker", "apptainer", "local"):
-            raise ValueError(
-                f"Invalid container_backend {container_backend!r}; "
-                "expected 'docker', 'apptainer', or 'local'"
-            )
-        self._container_backend = container_backend
+        self._container_backend = resolve_container_backend(
+            container_backend, use_docker
+        )
         self._geometry_prompt = geometry_prompt
         self._mcp_tools = mcp_tools
         self._max_output_tokens = max_output_tokens

--- a/src/robocode/approaches/agentic_cdl_approach.py
+++ b/src/robocode/approaches/agentic_cdl_approach.py
@@ -23,6 +23,7 @@ from omegaconf import DictConfig
 from robocode.approaches.base_approach import BaseApproach
 from robocode.mcp import MCP_TOOLS_SYSTEM_PROMPT_SUFFIX, mcp_tool_descriptions
 from robocode.primitives import PRIMITIVE_DESCRIPTIONS
+from robocode.utils.apptainer_sandbox import ApptainerSandboxConfig
 from robocode.utils.backends import (
     CLAUDE_PROMPT_SUFFIX,
     OPENCODE_PROMPT_SUFFIX,
@@ -313,6 +314,7 @@ class AgenticCDLApproach(BaseApproach[_ObsType, _ActType]):
         output_dir: str = ".",
         load_dir: str | None = None,
         use_docker: bool = False,
+        container_backend: str | None = None,
         geometry_prompt: bool = True,
         mcp_tools: tuple[str, ...] = (),
         max_output_tokens: int = 16384,
@@ -335,7 +337,14 @@ class AgenticCDLApproach(BaseApproach[_ObsType, _ActType]):
         self._max_turns = max_turns
         self._output_dir = Path(output_dir)
         self._load_dir = Path(load_dir) if load_dir is not None else None
-        self._use_docker = use_docker
+        if container_backend is None:
+            container_backend = "docker" if use_docker else "local"
+        if container_backend not in ("docker", "apptainer", "local"):
+            raise ValueError(
+                f"Invalid container_backend {container_backend!r}; "
+                "expected 'docker', 'apptainer', or 'local'"
+            )
+        self._container_backend = container_backend
         self._geometry_prompt = geometry_prompt
         self._mcp_tools = mcp_tools
         self._max_output_tokens = max_output_tokens
@@ -406,7 +415,9 @@ class AgenticCDLApproach(BaseApproach[_ObsType, _ActType]):
                     mcp_lines.append(f"- {tool_descs[name]}")
             primitives_desc += "\n".join(mcp_lines)
 
-        python_exe = DOCKER_PYTHON if self._use_docker else sys.executable
+        python_exe = (
+            DOCKER_PYTHON if self._container_backend != "local" else sys.executable
+        )
         interface_spec = _INTERFACE_SPEC.format(
             python_executable=python_exe,
             primitives_description=primitives_desc,
@@ -460,8 +471,9 @@ class AgenticCDLApproach(BaseApproach[_ObsType, _ActType]):
             system_prompt += MCP_TOOLS_SYSTEM_PROMPT_SUFFIX
 
         docker_config: DockerSandboxConfig | None = None
+        apptainer_config: ApptainerSandboxConfig | None = None
         config: SandboxConfig | None = None
-        if self._use_docker:
+        if self._container_backend == "docker":
             docker_config = DockerSandboxConfig(
                 sandbox_dir=sandbox_dir,
                 init_files=init_files,
@@ -477,6 +489,22 @@ class AgenticCDLApproach(BaseApproach[_ObsType, _ActType]):
                 autocompact_pct=self._autocompact_pct,
             )
             sandbox_logger = logging.getLogger("robocode.utils.docker_sandbox")
+        elif self._container_backend == "apptainer":
+            apptainer_config = ApptainerSandboxConfig(
+                sandbox_dir=sandbox_dir,
+                init_files=init_files,
+                output_filename="approach.py",
+                prompt=prompt,
+                system_prompt=system_prompt,
+                model=self._model,
+                max_budget_usd=self._max_budget_usd,
+                max_turns=self._max_turns,
+                primitive_names=tuple(self._primitives),
+                mcp_tools=self._mcp_tools,
+                max_output_tokens=self._max_output_tokens,
+                autocompact_pct=self._autocompact_pct,
+            )
+            sandbox_logger = logging.getLogger("robocode.utils.apptainer_sandbox")
         else:
             config = SandboxConfig(
                 sandbox_dir=sandbox_dir,
@@ -501,9 +529,10 @@ class AgenticCDLApproach(BaseApproach[_ObsType, _ActType]):
         sandbox_logger.addHandler(file_handler)
         try:
             result = run_with_rate_limit_retry(
-                docker_config if self._use_docker else None,
-                config if not self._use_docker else None,
+                docker_config,
+                config,
                 backend=self._backend,
+                apptainer_config=apptainer_config,
             )
         finally:
             sandbox_logger.removeHandler(file_handler)

--- a/src/robocode/approaches/genplan_driver.py
+++ b/src/robocode/approaches/genplan_driver.py
@@ -47,7 +47,7 @@ def main() -> None:
         max_debug_attempts=cfg["max_debug_attempts"],
         skip_chain_of_thought=cfg["skip_chain_of_thought"],
         episode_timeout_s=cfg["episode_timeout_s"],
-        use_docker=False,  # already isolated; run the loop in-process here
+        container_backend="local",  # already isolated; run the loop in-process
     )
     approach.train()
     # The host approach reads this back; the container is the only place the

--- a/src/robocode/approaches/llm_genplan_approach.py
+++ b/src/robocode/approaches/llm_genplan_approach.py
@@ -23,6 +23,7 @@ from omegaconf import DictConfig, OmegaConf
 
 from robocode.approaches.base_approach import BaseApproach
 from robocode.primitives import format_primitives_description
+from robocode.utils.apptainer_sandbox import _DEFAULT_SIF, run_genplan_in_apptainer
 from robocode.utils.docker_sandbox import run_genplan_in_docker
 from robocode.utils.episode import load_generated_approach
 from robocode.utils.genplan_validate import render_state, validate_tasks
@@ -88,7 +89,9 @@ class LLMGenPlanApproach(BaseApproach[_ObsType, _ActType]):
         skip_chain_of_thought: bool = False,
         episode_timeout_s: float = 30.0,
         use_docker: bool = True,
+        container_backend: str | None = None,
         docker_image: str = "robocode-sandbox",
+        sif_path: str | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(
@@ -96,10 +99,19 @@ class LLMGenPlanApproach(BaseApproach[_ObsType, _ActType]):
         )
         self._seed = seed
         self._completion_cfg = completion
-        # With use_docker the loop runs inside the container (the driver builds
-        # the client there), so the host needs no client/key.
+        # container_backend takes precedence; use_docker kept for back-compat.
+        if container_backend is None:
+            container_backend = "docker" if use_docker else "local"
+        if container_backend not in ("docker", "apptainer", "local"):
+            raise ValueError(
+                f"Invalid container_backend {container_backend!r}; "
+                "expected 'docker', 'apptainer', or 'local'"
+            )
+        self._container_backend = container_backend
+        # Sandboxed runs build the client inside the container, so the host
+        # needs no client/key.
         self._client: LLMClient | None = (
-            None if use_docker else create_llm_client(completion)
+            create_llm_client(completion) if container_backend == "local" else None
         )
         self._env = env
         self._env_cfg = env_cfg
@@ -111,8 +123,8 @@ class LLMGenPlanApproach(BaseApproach[_ObsType, _ActType]):
         self._max_debug_attempts = max_debug_attempts
         self._skip_chain_of_thought = skip_chain_of_thought
         self._episode_timeout_s = episode_timeout_s
-        self._use_docker = use_docker
         self._docker_image = docker_image
+        self._sif_path = Path(sif_path) if sif_path is not None else _DEFAULT_SIF
         self._generated: Any = None
         self.total_cost_usd: float | None = None
 
@@ -121,11 +133,10 @@ class LLMGenPlanApproach(BaseApproach[_ObsType, _ActType]):
             self._load_generated(self._load_dir / "sandbox" / "approach.py")
             return
 
-        # Run the whole loop inside one sandbox container (like the agentic
-        # approach), launching the genplan driver. The driver reruns train()
-        # with use_docker=False to do the loop in-process there.
-        if self._use_docker:
-            self._train_in_docker()
+        # Sandboxed: run the whole loop inside one container (docker/apptainer)
+        # via the genplan driver; the driver reruns train() locally inside.
+        if self._container_backend in ("docker", "apptainer"):
+            self._train_in_container()
             self._load_generated(self._output_dir / "sandbox" / "approach.py")
             return
 
@@ -157,9 +168,9 @@ class LLMGenPlanApproach(BaseApproach[_ObsType, _ActType]):
         self._debug_loop(messages, approach_path, sandbox_dir, train_seeds)
         self._load_generated(approach_path)
 
-    def _train_in_docker(self) -> None:
+    def _train_in_container(self) -> None:
         """Write the driver config and run the loop in one sandbox container."""
-        assert self._env_cfg is not None, "use_docker needs env_cfg"
+        assert self._env_cfg is not None, "container runs need env_cfg"
         sandbox_dir = self._output_dir / "sandbox"
         sandbox_dir.mkdir(parents=True, exist_ok=True)
         completion = cast(
@@ -178,7 +189,10 @@ class LLMGenPlanApproach(BaseApproach[_ObsType, _ActType]):
             "episode_timeout_s": self._episode_timeout_s,
         }
         (sandbox_dir / "genplan_config.json").write_text(json.dumps(config))
-        run_genplan_in_docker(sandbox_dir, completion, image=self._docker_image)
+        if self._container_backend == "apptainer":
+            run_genplan_in_apptainer(sandbox_dir, completion, sif_path=self._sif_path)
+        else:
+            run_genplan_in_docker(sandbox_dir, completion, image=self._docker_image)
         cost = json.loads((sandbox_dir / "cost.json").read_text(encoding="utf-8"))
         self.total_cost_usd = cost["total_cost_usd"]
 

--- a/src/robocode/approaches/llm_genplan_approach.py
+++ b/src/robocode/approaches/llm_genplan_approach.py
@@ -28,6 +28,7 @@ from robocode.utils.docker_sandbox import run_genplan_in_docker
 from robocode.utils.episode import load_generated_approach
 from robocode.utils.genplan_validate import render_state, validate_tasks
 from robocode.utils.llm import LLMClient, LLMResponse, create_llm_client
+from robocode.utils.sandbox_types import resolve_container_backend
 from robocode.utils.source_deps import collect_local_deps
 
 logger = logging.getLogger(__name__)
@@ -99,15 +100,9 @@ class LLMGenPlanApproach(BaseApproach[_ObsType, _ActType]):
         )
         self._seed = seed
         self._completion_cfg = completion
-        # container_backend takes precedence; use_docker kept for back-compat.
-        if container_backend is None:
-            container_backend = "docker" if use_docker else "local"
-        if container_backend not in ("docker", "apptainer", "local"):
-            raise ValueError(
-                f"Invalid container_backend {container_backend!r}; "
-                "expected 'docker', 'apptainer', or 'local'"
-            )
-        self._container_backend = container_backend
+        self._container_backend = resolve_container_backend(
+            container_backend, use_docker
+        )
         # Sandboxed runs build the client inside the container, so the host
         # needs no client/key.
         self._client: LLMClient | None = (

--- a/src/robocode/approaches/llm_genplan_approach.py
+++ b/src/robocode/approaches/llm_genplan_approach.py
@@ -265,8 +265,9 @@ class LLMGenPlanApproach(BaseApproach[_ObsType, _ActType]):
     def _validate(self, approach_path: Path, seeds: list[int]) -> dict[str, str] | None:
         """Run the policy on the training tasks in-process; return first failure.
 
-        When ``use_docker`` is set this runs inside the sandbox container (the
-        whole loop does), so it is always isolated from the host there.
+        When ``container_backend`` is docker/apptainer this runs inside the
+        sandbox container (the whole loop does), so it is always isolated from
+        the host there.
         """
         assert self._env is not None
         return validate_tasks(

--- a/src/robocode/utils/apptainer_sandbox.py
+++ b/src/robocode/utils/apptainer_sandbox.py
@@ -112,10 +112,13 @@ def _build_apptainer_auth_args(
 ) -> tuple[list[str], dict[str, str]]:
     """Return Apptainer CLI args and env vars for backend authentication.
 
-    Mirrors :func:`docker_sandbox._build_docker_auth_args` but emits
-    ``--env`` / ``--bind`` flags. Apptainer doesn't read host env vars
-    automatically (we pass ``--cleanenv``), so the actual value is passed
-    via ``--env KEY=val``.
+    Mirrors :func:`docker_sandbox._build_docker_auth_args`. Secrets (the
+    Claude OAuth token, provider API keys) are returned as host env vars
+    with Apptainer's ``APPTAINERENV_`` prefix rather than inline ``--env``
+    flags: Apptainer injects ``APPTAINERENV_*`` into the container even
+    under ``--cleanenv``, and the value never reaches argv (world-readable
+    via ``ps`` / ``/proc/<pid>/cmdline`` on shared nodes). Only non-secret
+    bind mounts are returned as CLI args.
 
     The ``~/.claude`` bind-mount fallback relies on the image being built
     with build.sh / build_sif.sh (which pass USER_UID/USER_GID build args
@@ -129,8 +132,10 @@ def _build_apptainer_auth_args(
     if backend_name == "claude":
         oauth_token = _get_claude_oauth_token()
         if oauth_token:
-            apptainer_args += ["--env", f"CLAUDE_CODE_OAUTH_TOKEN={oauth_token}"]
-            extra_env["CLAUDE_CODE_OAUTH_TOKEN"] = oauth_token
+            # APPTAINERENV_ prefix, not an inline --env flag, so the secret is
+            # injected into the container (surviving --cleanenv) without ever
+            # appearing on the command line.
+            extra_env["APPTAINERENV_CLAUDE_CODE_OAUTH_TOKEN"] = oauth_token
         else:
             logger.warning(
                 "No Claude OAuth token found; falling back to ~/.claude "
@@ -154,8 +159,9 @@ def _build_apptainer_auth_args(
             if info.api_key_env:
                 val = os.environ.get(info.api_key_env)
                 if val:
-                    apptainer_args += ["--env", f"{info.api_key_env}={val}"]
-                    extra_env[info.api_key_env] = val
+                    # APPTAINERENV_ prefix keeps the key off argv (see the
+                    # OAuth token note above).
+                    extra_env[f"APPTAINERENV_{info.api_key_env}"] = val
 
     return apptainer_args, extra_env
 

--- a/src/robocode/utils/apptainer_sandbox.py
+++ b/src/robocode/utils/apptainer_sandbox.py
@@ -1,0 +1,377 @@
+"""Apptainer/Singularity-based sandboxed agent runner.
+
+Mirror of :mod:`robocode.utils.docker_sandbox` for environments where the
+Docker daemon is unavailable (typical on HPC clusters). The SIF image is
+built from the existing ``docker/Dockerfile`` via ``docker/build_sif.sh``
+(podman build + apptainer build) -- no separate definition file.
+
+The container interior (entrypoint, firewall script, /robocode/.venv,
+bind-mount layout) is byte-for-byte identical to the Docker image. The
+only differences are at the host invocation layer:
+
+* ``--bind`` instead of ``-v``
+* ``--env KEY=val`` instead of ``-e KEY=val``
+* ``--pwd`` instead of ``-w``
+* ``--writable-tmpfs`` so the entrypoint's ``uv sync`` can write to
+  ``/robocode/.venv`` (the SIF rootfs is read-only)
+* ``--no-home`` so the host home doesn't shadow ``/home/node``
+* ``--cleanenv`` so the host env doesn't leak in
+
+``init-firewall.sh`` is skipped via ``ROBOCODE_SKIP_FIREWALL=1``: the
+unprivileged apptainer install on the target cluster can't grant real
+``CAP_NET_ADMIN``, so iptables would fail.
+
+The image ENTRYPOINT is invoked explicitly rather than via
+``apptainer run`` so behaviour does not depend on Apptainer's runscript
+translation of Docker images.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from robocode.primitives import PRIMITIVE_NAME_TO_FILE
+from robocode.utils.backends import (
+    PROVIDERS,
+    AgentBackend,
+    firewall_domains_for_provider,
+    provider_from_model,
+)
+from robocode.utils.docker_sandbox import (
+    _PRIMITIVES_SRC,
+    DOCKER_PYTHON,
+    _filtered_repo_mounts,
+    _find_repo_root,
+    _get_claude_oauth_token,
+)
+from robocode.utils.sandbox import (
+    SandboxConfig,
+    SandboxResult,
+    _final_commit,
+    _initial_commit,
+    _setup_sandbox_common,
+    _stream_result_to_sandbox_result,
+)
+
+logger = logging.getLogger(__name__)
+
+# Python interpreter inside the SIF (same path as in the Docker image).
+APPTAINER_PYTHON: str = DOCKER_PYTHON
+
+# Default SIF path: <repo_root>/robocode-sandbox.sif.
+_DEFAULT_SIF: Path = _find_repo_root() / "robocode-sandbox.sif"
+
+
+@dataclass(frozen=True)
+class ApptainerSandboxConfig(SandboxConfig):
+    """Configuration for an Apptainer-sandboxed agent run.
+
+    Extends :class:`~robocode.utils.sandbox.SandboxConfig` with ``sif_path``
+    for the SIF image and ``primitive_names`` to control which primitive
+    source files are copied into the sandbox.
+    """
+
+    sif_path: Path = _DEFAULT_SIF
+    primitive_names: tuple[str, ...] = ()
+    mcp_tools: tuple[str, ...] = ()
+
+
+def _setup_sandbox_dir(config: ApptainerSandboxConfig) -> None:
+    """Populate ``config.sandbox_dir`` with the standard sandbox scaffolding.
+
+    Mirrors :func:`robocode.utils.docker_sandbox._setup_sandbox_dir`; kept
+    separate so it accepts :class:`ApptainerSandboxConfig` without making
+    docker_sandbox.py aware of this module.
+    """
+    _setup_sandbox_common(config.sandbox_dir, config.init_files)
+
+    if config.primitive_names:
+        primitives_dest = config.sandbox_dir / "primitives"
+        primitives_dest.mkdir(exist_ok=True)
+        for name in config.primitive_names:
+            file_stem = PRIMITIVE_NAME_TO_FILE.get(name)
+            if file_stem is None:
+                logger.warning("No source file mapping for primitive %r", name)
+                continue
+            src_file = _PRIMITIVES_SRC / f"{file_stem}.py"
+            if src_file.exists():
+                shutil.copy2(src_file, primitives_dest / src_file.name)
+            else:
+                raise RuntimeError(f"Primitive source file not found: {src_file}")
+
+
+def _build_apptainer_auth_args(
+    backend_name: str,
+) -> tuple[list[str], dict[str, str]]:
+    """Return Apptainer CLI args and env vars for backend authentication.
+
+    Mirrors :func:`docker_sandbox._build_docker_auth_args` but emits
+    ``--env`` / ``--bind`` flags. Apptainer doesn't read host env vars
+    automatically (we pass ``--cleanenv``), so the actual value is passed
+    via ``--env KEY=val``.
+
+    The ``~/.claude`` bind-mount fallback relies on the image being built
+    with build.sh / build_sif.sh (which pass USER_UID/USER_GID build args
+    so the in-container node user matches the host's UID and can read host
+    files). Without that, the in-container CLI would see the host config
+    as inaccessible and overwrite it.
+    """
+    apptainer_args: list[str] = []
+    extra_env: dict[str, str] = {}
+
+    if backend_name == "claude":
+        oauth_token = _get_claude_oauth_token()
+        if oauth_token:
+            apptainer_args += ["--env", f"CLAUDE_CODE_OAUTH_TOKEN={oauth_token}"]
+            extra_env["CLAUDE_CODE_OAUTH_TOKEN"] = oauth_token
+        else:
+            logger.warning(
+                "No Claude OAuth token found; falling back to ~/.claude "
+                "bind-mount. Requires the image to be built via build_sif.sh "
+                "(matching host UID/GID). Run `claude login` on the host "
+                "if the container cannot authenticate."
+            )
+            host_claude_cfg = Path(
+                os.environ.get("CLAUDE_CONFIG_DIR", str(Path.home() / ".claude"))
+            )
+            apptainer_args += ["--bind", f"{host_claude_cfg}:/home/node/.claude"]
+    else:
+        opencode_data = Path.home() / ".local" / "share" / "opencode"
+        if opencode_data.exists():
+            apptainer_args += [
+                "--bind",
+                f"{opencode_data}:/home/node/.local/share/opencode",
+            ]
+
+        for info in PROVIDERS.values():
+            if info.api_key_env:
+                val = os.environ.get(info.api_key_env)
+                if val:
+                    apptainer_args += ["--env", f"{info.api_key_env}={val}"]
+                    extra_env[info.api_key_env] = val
+
+    return apptainer_args, extra_env
+
+
+def _build_apptainer_cmd(
+    config: ApptainerSandboxConfig,
+    sandbox_abs: str,
+    src_abs: str,
+    kindergarden_abs: str,
+    auth_args: list[str],
+    firewall_domains: list[str],
+    agent_cmd: list[str],
+) -> list[str]:
+    """Assemble the full ``apptainer exec`` command line.
+
+    Split out from :func:`run_agent_in_apptainer_sandbox` so unit tests
+    can inspect the constructed command without running anything.
+    """
+    cmd: list[str] = [
+        "apptainer",
+        "exec",
+        "--writable-tmpfs",
+        "--no-home",
+        "--cleanenv",
+        "--pwd",
+        "/sandbox",
+        "--env",
+        f"CLAUDE_CODE_MAX_OUTPUT_TOKENS={config.max_output_tokens}",
+        "--env",
+        f"CLAUDE_AUTOCOMPACT_PCT_OVERRIDE={config.autocompact_pct}",
+        "--env",
+        "ROBOCODE_SKIP_FIREWALL=1",
+    ]
+
+    if firewall_domains:
+        cmd += [
+            "--env",
+            f"ROBOCODE_FIREWALL_EXTRA_DOMAINS={','.join(firewall_domains)}",
+        ]
+
+    cmd += auth_args
+
+    cmd += [
+        "--bind",
+        f"{sandbox_abs}:/sandbox",
+        "--bind",
+        f"{src_abs}:/robocode/src",
+        "--bind",
+        f"{kindergarden_abs}:/robocode/third-party/kindergarden",
+        str(config.sif_path),
+        "/usr/local/bin/entrypoint.sh",
+    ]
+    cmd += agent_cmd
+    return cmd
+
+
+async def run_agent_in_apptainer_sandbox(
+    config: ApptainerSandboxConfig,
+    backend: AgentBackend,
+) -> SandboxResult:
+    """Run an agent inside the ``robocode-sandbox`` SIF via apptainer.
+
+    Step-for-step parallel of
+    :func:`~robocode.utils.docker_sandbox.run_agent_in_docker_sandbox`.
+    See the module docstring for the docker -> apptainer flag mapping.
+    """
+    backend_name = backend.name
+
+    if not config.sif_path.exists():
+        raise RuntimeError(
+            f"SIF image not found at {config.sif_path}; "
+            "build it with: bash docker/build_sif.sh"
+        )
+
+    _setup_sandbox_dir(config)
+
+    sandbox_abs = str(config.sandbox_dir.resolve())
+    run_id = f"apptainer-sandbox-{uuid.uuid4().hex[:8]}"
+
+    with _filtered_repo_mounts() as (filtered_src, filtered_kindergarden):
+        auth_args, auth_env = _build_apptainer_auth_args(backend_name)
+
+        firewall_domains: list[str] = []
+        if backend_name == "opencode":
+            firewall_domains = firewall_domains_for_provider(
+                provider_from_model(config.model)
+            )
+
+        agent_cmd = backend.build_cli_cmd(
+            config,
+            mcp_python_cmd=APPTAINER_PYTHON,
+            mcp_env_config_path="/sandbox/.mcp/env_config.json",
+            mcp_config_cli_path="/sandbox/.mcp/mcp_config.json",
+            mcp_log_file_path="/sandbox/.mcp/mcp_server.log",
+        )
+
+        apptainer_cmd = _build_apptainer_cmd(
+            config,
+            sandbox_abs=sandbox_abs,
+            src_abs=str(filtered_src.resolve()),
+            kindergarden_abs=str(filtered_kindergarden.resolve()),
+            auth_args=auth_args,
+            firewall_domains=firewall_domains,
+            agent_cmd=agent_cmd,
+        )
+
+        backend.setup_sandbox_files(
+            config,
+            docker_python=APPTAINER_PYTHON,
+            primitive_names=config.primitive_names,
+        )
+        _initial_commit(config.sandbox_dir)
+
+        env = backend.build_env(config, auth_env if auth_env else None)
+
+        logger.info(
+            "Starting Apptainer sandbox: run_id=%s sif=%s sandbox=%s",
+            run_id,
+            config.sif_path,
+            sandbox_abs,
+        )
+        logger.info("System prompt:\n%s", config.system_prompt)
+        logger.info("Prompt:\n%s", config.prompt)
+
+        proc = subprocess.Popen(  # pylint: disable=consider-using-with
+            apptainer_cmd,
+            env=env,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+        stream = backend.parse_stream(
+            proc,
+            stream_log_path=config.sandbox_dir.parent / "stream.jsonl",
+        )
+
+        logger.info(
+            "Apptainer session done: run_id=%s turns=%d cost=$%s error=%s",
+            run_id,
+            stream.num_turns,
+            stream.total_cost,
+            stream.is_error,
+        )
+
+        _final_commit(config.sandbox_dir)
+
+        return _stream_result_to_sandbox_result(
+            stream, config.sandbox_dir, config.output_filename
+        )
+
+
+def run_genplan_in_apptainer(
+    sandbox_dir: Path,
+    completion_cfg: dict[str, Any],
+    sif_path: Path = _DEFAULT_SIF,
+    timeout: float = 3600.0,
+) -> None:
+    """Apptainer analog of :func:`docker_sandbox.run_genplan_in_docker`.
+
+    Mirrors the docker function: runs the whole LLM-GenPlan loop inside one
+    sandbox container via the genplan driver, which reads
+    ``sandbox_dir/genplan_config.json`` and writes ``sandbox_dir/approach.py``
+    and ``sandbox_dir/cost.json``. Keeps ``primitives`` in the source mount so
+    the policy can build/use them as eval does on the host.
+    """
+    if not sif_path.exists():
+        raise RuntimeError(
+            f"SIF image not found at {sif_path}; build it with: bash docker/build_sif.sh"
+        )
+    run_id = f"apptainer-genplan-{uuid.uuid4().hex[:8]}"
+    with _filtered_repo_mounts(keep_primitives=True) as (
+        filtered_src,
+        filtered_kindergarden,
+    ):
+        auth_backend = "claude" if completion_cfg["provider"] == "cli" else "opencode"
+        auth_args, auth_env = _build_apptainer_auth_args(auth_backend)
+        firewall_domains = firewall_domains_for_provider(
+            completion_cfg["provider"], completion_cfg.get("base_url", "")
+        )
+        firewall_env: list[str] = []
+        if firewall_domains:
+            firewall_env = [
+                "--env",
+                f"ROBOCODE_FIREWALL_EXTRA_DOMAINS={','.join(firewall_domains)}",
+            ]
+        apptainer_cmd = [
+            "apptainer",
+            "exec",
+            "--writable-tmpfs",
+            "--no-home",
+            "--cleanenv",
+            "--pwd",
+            "/sandbox",
+            "--env",
+            "ROBOCODE_SKIP_FIREWALL=1",
+            *firewall_env,
+            *auth_args,
+            "--bind",
+            f"{sandbox_dir.resolve()}:/sandbox",
+            "--bind",
+            f"{filtered_src.resolve()}:/robocode/src",
+            "--bind",
+            f"{filtered_kindergarden.resolve()}:/robocode/third-party/kindergarden",
+            str(sif_path),
+            "/usr/local/bin/entrypoint.sh",
+            APPTAINER_PYTHON,
+            "-m",
+            "robocode.approaches.genplan_driver",
+        ]
+        logger.info("Starting genplan Apptainer run %s sif=%s", run_id, sif_path)
+        subprocess.run(
+            apptainer_cmd,
+            env={**os.environ, **auth_env},
+            stdin=subprocess.DEVNULL,
+            check=True,
+            timeout=timeout,
+        )

--- a/src/robocode/utils/docker_sandbox.py
+++ b/src/robocode/utils/docker_sandbox.py
@@ -79,17 +79,20 @@ _DEFAULT_IMAGE: str = "robocode-sandbox"
 
 
 def _get_claude_oauth_token() -> str | None:
-    """Extract the Claude Code OAuth access token from the macOS Keychain.
+    """Resolve the Claude Code OAuth access token.
 
-    Returns ``None`` on non-macOS platforms or when the token cannot be
-    found or parsed.  On macOS, ``claude login`` stores credentials in the
-    Keychain under the service name ``"Claude Code-credentials"`` as a JSON
-    object with key ``claudeAiOauth.accessToken``.
+    Checked in order:
+      1. ``CLAUDE_CODE_OAUTH_TOKEN`` env var (works on every platform).
+      2. macOS Keychain (service ``"Claude Code-credentials"``, key
+         ``claudeAiOauth.accessToken``) populated by ``claude login``.
 
-    The returned token is forwarded to the container via the
-    ``CLAUDE_CODE_OAUTH_TOKEN`` environment variable, which the Claude CLI
-    checks before any filesystem credential store.
+    Returns ``None`` when neither is available. The returned token is
+    forwarded to the container via the ``CLAUDE_CODE_OAUTH_TOKEN`` env var,
+    which the Claude CLI checks before any filesystem credential store.
     """
+    env_token = os.environ.get("CLAUDE_CODE_OAUTH_TOKEN")
+    if env_token:
+        return env_token
     platform: str = sys.platform
     if platform != "darwin":
         return None

--- a/src/robocode/utils/genplan_validate.py
+++ b/src/robocode/utils/genplan_validate.py
@@ -2,7 +2,8 @@
 
 Used by the LLM-GenPlan debug loop. Each episode runs in a ``multiprocessing``
 worker so an infinite-looping ``get_action`` can be killed by timeout. When the
-loop runs inside the sandbox container (``use_docker``), this runs there too.
+loop runs inside the sandbox container (``container_backend`` docker/apptainer),
+this runs there too.
 """
 
 from __future__ import annotations

--- a/src/robocode/utils/rate_limit.py
+++ b/src/robocode/utils/rate_limit.py
@@ -11,6 +11,10 @@ from collections.abc import Callable
 from datetime import datetime, timedelta
 from typing import Any
 
+from robocode.utils.apptainer_sandbox import (
+    ApptainerSandboxConfig,
+    run_agent_in_apptainer_sandbox,
+)
 from robocode.utils.backends import AgentBackend
 from robocode.utils.docker_sandbox import (
     DockerSandboxConfig,
@@ -63,10 +67,15 @@ def run_with_rate_limit_retry(
     docker_config: DockerSandboxConfig | None,
     local_config: SandboxConfig | None,
     backend: AgentBackend,
+    apptainer_config: ApptainerSandboxConfig | None = None,
 ) -> SandboxResult:
     """Run the sandbox, retrying on rate-limit by sleeping until reset."""
     while True:
-        if docker_config is not None:
+        if apptainer_config is not None:
+            result = run_async(
+                lambda: run_agent_in_apptainer_sandbox(apptainer_config, backend)
+            )
+        elif docker_config is not None:
             result = run_async(
                 lambda: run_agent_in_docker_sandbox(docker_config, backend)
             )

--- a/src/robocode/utils/sandbox.py
+++ b/src/robocode/utils/sandbox.py
@@ -11,7 +11,7 @@ the working directory.
 WARNING: The OS-level sandbox restricts filesystem *writes* to the sandbox
 directory, but allows *reads* of the entire filesystem. Bash commands like
 ``cat /etc/passwd`` or ``python -c "open('/etc/hosts').read()"`` will succeed.
-Use Docker-based sandboxing (``use_docker: true``) for full isolation.
+Use container sandboxing (``container_backend: docker``) for full isolation.
 
 Set ROBOCODE_CLAUDE_CMD or ROBOCODE_OPENCODE_CMD environment variables
 to override the default binary paths.

--- a/src/robocode/utils/sandbox_types.py
+++ b/src/robocode/utils/sandbox_types.py
@@ -7,6 +7,24 @@ the sandbox module and the backend implementations.
 from dataclasses import dataclass, field
 from pathlib import Path
 
+CONTAINER_BACKENDS = ("docker", "apptainer", "local")
+
+
+def resolve_container_backend(container_backend: str | None, use_docker: bool) -> str:
+    """Resolve and validate an approach's sandbox backend selection.
+
+    ``container_backend`` takes precedence; ``use_docker`` is the legacy
+    boolean kept for back-compat (True -> docker, False -> local).
+    """
+    if container_backend is None:
+        container_backend = "docker" if use_docker else "local"
+    if container_backend not in CONTAINER_BACKENDS:
+        raise ValueError(
+            f"Invalid container_backend {container_backend!r}; "
+            f"expected one of {CONTAINER_BACKENDS}"
+        )
+    return container_backend
+
 
 @dataclass(frozen=True)
 class SandboxConfig:

--- a/tests/utils/test_apptainer_sandbox.py
+++ b/tests/utils/test_apptainer_sandbox.py
@@ -114,9 +114,9 @@ def test_build_cmd_no_firewall_when_empty(tmp_path: Path) -> None:
 
 
 def test_build_cmd_auth_args_inserted(tmp_path: Path) -> None:
-    """Caller-supplied auth args (e.g. --env or --bind) appear in the cmd."""
+    """Caller-supplied auth args (e.g. a --bind) appear in the cmd."""
     config = ApptainerSandboxConfig(sandbox_dir=tmp_path / "sandbox")
-    auth_args = ["--env", "CLAUDE_CODE_OAUTH_TOKEN=tok-123"]
+    auth_args = ["--bind", "/home/u/.claude:/home/node/.claude"]
     cmd = _build_apptainer_cmd(
         config,
         sandbox_abs="/host/sandbox",
@@ -126,24 +126,25 @@ def test_build_cmd_auth_args_inserted(tmp_path: Path) -> None:
         firewall_domains=[],
         agent_cmd=["claude"],
     )
-    assert "CLAUDE_CODE_OAUTH_TOKEN=tok-123" in cmd
+    assert "/home/u/.claude:/home/node/.claude" in cmd
 
 
 def test_opencode_auth_passes_api_keys(monkeypatch) -> None:  # type: ignore
-    """For OpenCode, set provider API keys become --env KEY=val entries."""
+    """Provider API keys are forwarded via APPTAINERENV_ env vars, not argv."""
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-value")
     args, env = _build_apptainer_auth_args("opencode")
-    assert env.get("ANTHROPIC_API_KEY") == "sk-test-value"
-    assert "--env" in args
-    assert "ANTHROPIC_API_KEY=sk-test-value" in args
+    assert env.get("APPTAINERENV_ANTHROPIC_API_KEY") == "sk-test-value"
+    # The secret must not appear on the command line.
+    assert not any("sk-test-value" in a for a in args)
 
 
 def test_claude_auth_uses_env_token(monkeypatch) -> None:  # type: ignore
-    """CLAUDE_CODE_OAUTH_TOKEN, when set, is forwarded via --env (no bind)."""
+    """CLAUDE_CODE_OAUTH_TOKEN is forwarded via APPTAINERENV_, never on argv."""
     monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-test")
     args, env = _build_apptainer_auth_args("claude")
-    assert env.get("CLAUDE_CODE_OAUTH_TOKEN") == "sk-ant-oat01-test"
-    assert "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-test" in args
+    assert env.get("APPTAINERENV_CLAUDE_CODE_OAUTH_TOKEN") == "sk-ant-oat01-test"
+    # The token must not appear on the command line (visible via `ps`).
+    assert not any("sk-ant-oat01-test" in a for a in args)
     assert not any("--bind" in a for a in args)
 
 

--- a/tests/utils/test_apptainer_sandbox.py
+++ b/tests/utils/test_apptainer_sandbox.py
@@ -1,0 +1,161 @@
+"""Tests for apptainer_sandbox.py.
+
+Unit-level coverage only: verifies config defaults, that
+:func:`_setup_sandbox_dir` is reused (sanity), and that
+:func:`_build_apptainer_cmd` assembles the expected ``apptainer exec``
+command line. No SIF or apptainer binary is invoked.
+"""
+
+from pathlib import Path
+
+from robocode.utils.apptainer_sandbox import (
+    APPTAINER_PYTHON,
+    ApptainerSandboxConfig,
+    _build_apptainer_auth_args,
+    _build_apptainer_cmd,
+)
+from robocode.utils.docker_sandbox import DOCKER_PYTHON, _find_repo_root
+
+
+def test_apptainer_python_matches_docker_python() -> None:
+    """The interpreter path inside the container is the same for both backends."""
+    assert APPTAINER_PYTHON == DOCKER_PYTHON
+
+
+def test_config_defaults() -> None:
+    """ApptainerSandboxConfig fields have the expected defaults."""
+    config = ApptainerSandboxConfig(sandbox_dir=Path("/tmp/test"))
+    assert config.sif_path == _find_repo_root() / "robocode-sandbox.sif"
+    assert config.model == "sonnet"
+    assert config.max_budget_usd == 5.0
+    assert config.system_prompt == ""
+    assert config.prompt == ""
+    assert config.output_filename == ""
+    assert not config.init_files
+    assert not config.primitive_names
+    assert not config.mcp_tools
+
+
+def test_build_cmd_basic_shape(tmp_path: Path) -> None:
+    """_build_apptainer_cmd produces the expected flag layout."""
+    config = ApptainerSandboxConfig(
+        sandbox_dir=tmp_path / "sandbox",
+        sif_path=tmp_path / "robocode-sandbox.sif",
+        max_output_tokens=8192,
+        autocompact_pct=70,
+    )
+    cmd = _build_apptainer_cmd(
+        config,
+        sandbox_abs="/host/sandbox",
+        src_abs="/host/src",
+        kindergarden_abs="/host/kindergarden",
+        auth_args=[],
+        firewall_domains=[],
+        agent_cmd=["claude", "--print", "hello"],
+    )
+
+    assert cmd[0] == "apptainer"
+    assert cmd[1] == "exec"
+    assert "--writable-tmpfs" in cmd
+    assert "--fakeroot" not in cmd
+    assert "--no-home" in cmd
+    assert "--cleanenv" in cmd
+    pwd_idx = cmd.index("--pwd")
+    assert cmd[pwd_idx + 1] == "/sandbox"
+
+    # Env vars are passed as `--env KEY=val` pairs.
+    assert "CLAUDE_CODE_MAX_OUTPUT_TOKENS=8192" in cmd
+    assert "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=70" in cmd
+    # init-firewall.sh is skipped (apptainer can't grant CAP_NET_ADMIN).
+    assert "ROBOCODE_SKIP_FIREWALL=1" in cmd
+
+    # Bind mounts.
+    assert "/host/sandbox:/sandbox" in cmd
+    assert "/host/src:/robocode/src" in cmd
+    assert "/host/kindergarden:/robocode/third-party/kindergarden" in cmd
+
+    # SIF path appears before the entrypoint invocation.
+    sif_idx = cmd.index(str(config.sif_path))
+    entrypoint_idx = cmd.index("/usr/local/bin/entrypoint.sh")
+    assert sif_idx < entrypoint_idx
+
+    # Agent command is appended at the end.
+    assert cmd[-3:] == ["claude", "--print", "hello"]
+
+
+def test_build_cmd_firewall_domains(tmp_path: Path) -> None:
+    """Firewall domains, when present, are forwarded via --env."""
+    config = ApptainerSandboxConfig(sandbox_dir=tmp_path / "sandbox")
+    cmd = _build_apptainer_cmd(
+        config,
+        sandbox_abs="/host/sandbox",
+        src_abs="/host/src",
+        kindergarden_abs="/host/kindergarden",
+        auth_args=[],
+        firewall_domains=["api.example.com", "cdn.example.com"],
+        agent_cmd=["claude"],
+    )
+    assert "ROBOCODE_FIREWALL_EXTRA_DOMAINS=api.example.com,cdn.example.com" in cmd
+
+
+def test_build_cmd_no_firewall_when_empty(tmp_path: Path) -> None:
+    """When no extra domains are requested, the env var is not added."""
+    config = ApptainerSandboxConfig(sandbox_dir=tmp_path / "sandbox")
+    cmd = _build_apptainer_cmd(
+        config,
+        sandbox_abs="/host/sandbox",
+        src_abs="/host/src",
+        kindergarden_abs="/host/kindergarden",
+        auth_args=[],
+        firewall_domains=[],
+        agent_cmd=["claude"],
+    )
+    assert not any("ROBOCODE_FIREWALL_EXTRA_DOMAINS" in arg for arg in cmd)
+
+
+def test_build_cmd_auth_args_inserted(tmp_path: Path) -> None:
+    """Caller-supplied auth args (e.g. --env or --bind) appear in the cmd."""
+    config = ApptainerSandboxConfig(sandbox_dir=tmp_path / "sandbox")
+    auth_args = ["--env", "CLAUDE_CODE_OAUTH_TOKEN=tok-123"]
+    cmd = _build_apptainer_cmd(
+        config,
+        sandbox_abs="/host/sandbox",
+        src_abs="/host/src",
+        kindergarden_abs="/host/kindergarden",
+        auth_args=auth_args,
+        firewall_domains=[],
+        agent_cmd=["claude"],
+    )
+    assert "CLAUDE_CODE_OAUTH_TOKEN=tok-123" in cmd
+
+
+def test_opencode_auth_passes_api_keys(monkeypatch) -> None:  # type: ignore
+    """For OpenCode, set provider API keys become --env KEY=val entries."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-value")
+    args, env = _build_apptainer_auth_args("opencode")
+    assert env.get("ANTHROPIC_API_KEY") == "sk-test-value"
+    assert "--env" in args
+    assert "ANTHROPIC_API_KEY=sk-test-value" in args
+
+
+def test_claude_auth_uses_env_token(monkeypatch) -> None:  # type: ignore
+    """CLAUDE_CODE_OAUTH_TOKEN, when set, is forwarded via --env (no bind)."""
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-test")
+    args, env = _build_apptainer_auth_args("claude")
+    assert env.get("CLAUDE_CODE_OAUTH_TOKEN") == "sk-ant-oat01-test"
+    assert "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-test" in args
+    assert not any("--bind" in a for a in args)
+
+
+def test_claude_auth_falls_back_to_bind(monkeypatch) -> None:  # type: ignore
+    """When no token is found, falls back to bind-mounting ~/.claude."""
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    # Force the resolver to report no token (avoid Keychain hit on dev macOS).
+    monkeypatch.setattr(
+        "robocode.utils.apptainer_sandbox._get_claude_oauth_token",
+        lambda: None,
+    )
+    args, env = _build_apptainer_auth_args("claude")
+    assert not env  # no env vars when bind is used
+    assert "--bind" in args
+    assert any(arg.endswith(":/home/node/.claude") for arg in args)


### PR DESCRIPTION
Quick implementation (fixes #84) of apptainer/singularity support for containers instead of docker, mainly so that I can use the codebase on our internal cluster which doesn't have docker to run experiments overnight. Everything was tested with both apptainer and docker, we now change the `use_docker` arg but it should be backwards compatible in case that's needed.