### PR TITLE
Agentic eval reliability + headless mujoco/Dynamic3D in sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ All environments are available as Hydra configs via `environment=<config_name>`.
 | `packing3d_medium` | `kinder/Packing3D-p2-v0` | Medium (2 parts) |
 | `packing3d_hard` | `kinder/Packing3D-p3-v0` | Hard (3 parts) |
 
+> **Realistic 3D backgrounds (optional):** dynamic3d / TidyBot envs (e.g. `ConstrainedCupboard3D`) render on a plain white background by default. For the realistic room scene (floor/wall textures), download the MimicLabs assets once (~1 GB, gitignored): `python third-party/kindergarden/scripts/download_mimiclabs_assets.py`, then set `scene_bg: mimiclabs-lab2` in the env config (already set for `constrainedcupboard3d_easy`).
+
 ### LIBERO-PRO (manipulation benchmark, optional extra)
 
 [LIBERO-PRO](https://github.com/uynitsuj/LIBERO-PRO) is a Franka tabletop manipulation benchmark (~80 task suites covering goal / spatial / object / 10-task mixes plus OOD and perturbation variants) built on MuJoCo via robosuite. It is vendored as a submodule under `third-party/LIBERO-PRO/` and gated behind the optional `libero` extra — it is **not** installed by default because it pins old upstreams (`robosuite==1.4.0`, `gym==0.25.2`, `robomimic==0.2.0`, `bddl==1.0.1`) and drags in a CUDA-enabled torch.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,6 +45,10 @@ RUN if [ "$USER_GID" != "1000" ] || [ "$USER_UID" != "1000" ]; then \
 #   - git, sudo, curl: basic dev tools
 #   - jq, dnsutils (dig), aggregate, iptables, ipset, iproute2: firewall
 #   - python3.11, python3.11-venv, python3.11-dev: Python runtime
+#   - libegl1, libegl-mesa0, libgl1, libgl1-mesa-dri, libgles2, libglvnd0,
+#     libosmesa6: headless GL runtime so mujoco can initialize (kinder only
+#     registers Dynamic3D envs, e.g. ConstrainedCupboard3D, when `import mujoco`
+#     succeeds; without an EGL/GL backend it fails and those envs are skipped).
 # ---------------------------------------------------------------------------
 RUN apt-get update && apt-get install -y --no-install-recommends \
         git \
@@ -59,6 +63,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         python3.11 \
         python3.11-venv \
         python3.11-dev \
+        libegl1 \
+        libegl-mesa0 \
+        libgl1 \
+        libgl1-mesa-dri \
+        libgles2 \
+        libglvnd0 \
+        libosmesa6 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/experiments/conf/approach/agentic.yaml
+++ b/experiments/conf/approach/agentic.yaml
@@ -9,6 +9,6 @@ load_dir: null
 container_backend: docker  # docker | apptainer | local
 geometry_prompt: true
 modular_code_prompt: false
-max_output_tokens: 16384
+max_output_tokens: 32768
 autocompact_pct: 80
 blackbox: false  # hide env source; interact via host-side env server

--- a/experiments/conf/environment/constrainedcupboard3d_easy.yaml
+++ b/experiments/conf/environment/constrainedcupboard3d_easy.yaml
@@ -1,2 +1,6 @@
 _target_: robocode.environments.kinder_geom3d_env.KinderGeom3DEnv
 env_id: kinder/ConstrainedCupboard3D-o1-v0
+# Realistic background (floor/wall textures) instead of the plain white "simple"
+# scene. Purely cosmetic: observations and the task are unchanged. Requires the
+# mimiclabs assets (see README); falls back with an error if they are missing.
+scene_bg: mimiclabs-lab2

--- a/experiments/conf/environment/constrainedcupboard3d_easy.yaml
+++ b/experiments/conf/environment/constrainedcupboard3d_easy.yaml
@@ -1,0 +1,2 @@
+_target_: robocode.environments.kinder_geom3d_env.KinderGeom3DEnv
+env_id: kinder/ConstrainedCupboard3D-o1-v0

--- a/experiments/run_experiment.py
+++ b/experiments/run_experiment.py
@@ -119,15 +119,19 @@ def _main(cfg: DictConfig) -> float:
                 env, approach, s, cfg.max_steps, render=render
             )
         except Exception as exc:  # pylint: disable=broad-exception-caught
-            # A generated policy can raise on an unseen eval seed; count that as a
-            # failed episode instead of aborting the whole evaluation. Record the
-            # error so a crash is distinguishable from an ordinary unsolved episode.
-            logger.exception("Eval episode (seed %d) crashed; counting as unsolved", s)
+            # A loaded policy can raise on an unseen eval seed. We cannot fairly
+            # score a crash without the env's worst-case return (not available
+            # per env), so flag it and exclude it from the aggregate metrics
+            # rather than inventing a score that could flatter a crashy policy.
+            logger.exception(
+                "Eval episode (seed %d) crashed; excluding from metrics", s
+            )
             per_episode.append(
                 {
-                    "total_reward": 0.0,
-                    "num_steps": 0,
+                    "total_reward": None,
+                    "num_steps": None,
                     "solved": False,
+                    "crashed": True,
                     "error": f"{type(exc).__name__}: {exc}",
                 }
             )
@@ -138,15 +142,34 @@ def _main(cfg: DictConfig) -> float:
             video_dir.mkdir(exist_ok=True)
             save_video(frames, video_dir / f"episode_{i}.gif")
 
-    mean_reward = float(np.mean([e["total_reward"] for e in per_episode]))
-    mean_steps = float(np.mean([e["num_steps"] for e in per_episode]))
-    solve_rate = float(np.mean([e["solved"] for e in per_episode]))
+    # Aggregate over episodes that actually ran; crashed episodes are reported
+    # separately so partial evaluations stay honest (see the crash handler above).
+    evaluated = [e for e in per_episode if not e.get("crashed")]
+    num_crashed = len(per_episode) - len(evaluated)
+    if num_crashed:
+        logger.warning(
+            "%d/%d eval episodes crashed and are excluded from the metrics; see "
+            "per_episode errors in results.json.",
+            num_crashed,
+            len(per_episode),
+        )
+
+    def _mean(key: str) -> float:
+        return (
+            float(np.mean([e[key] for e in evaluated])) if evaluated else float("nan")
+        )
+
+    mean_reward = _mean("total_reward")
+    mean_steps = _mean("num_steps")
+    solve_rate = _mean("solved")
 
     results: dict[str, Any] = {
         "mean_eval_reward": mean_reward,
         "mean_eval_steps": mean_steps,
         "solve_rate": solve_rate,
         "num_eval_tasks": num_eval,
+        "num_evaluated_episodes": len(evaluated),
+        "num_crashed_episodes": num_crashed,
         "per_episode": per_episode,
     }
     agent_cost = getattr(approach, "total_cost_usd", None)

--- a/src/robocode/approaches/agentic_approach.py
+++ b/src/robocode/approaches/agentic_approach.py
@@ -554,9 +554,15 @@ class AgenticApproach(BaseApproach[_ObsType, _ActType]):
         self.total_cost_usd = result.total_cost_usd
 
         if result.success and result.output_file is not None:
+            if result.error:
+                logger.info(
+                    "Agent stopped early (%s) but committed an approach; "
+                    "evaluating it.",
+                    result.error,
+                )
             self._load_generated(result.output_file)
         else:
-            logger.warning("Agent failed to generate approach: %s", result.error)
+            raise RuntimeError(f"Agent failed to generate an approach: {result.error}")
 
     def _load_generated(self, path: Path) -> None:
         """Load a GeneratedApproach class from the given file."""
@@ -583,9 +589,14 @@ class AgenticApproach(BaseApproach[_ObsType, _ActType]):
             self._generated.update(state, reward, done, info)
 
     def _get_action(self) -> _ActType:
-        if self._generated is not None:
-            try:
-                return self._generated.get_action(self._last_state)
-            except Exception:  # pylint: disable=broad-exception-caught
-                logger.exception("Generated approach failed, using random")
-        return self._action_space.sample()
+        # Never silently fall back to random: a random eval would propagate a
+        # misleading 0 through the results as if the generated approach had been
+        # measured. Fail loudly instead. Use approach=random for a random
+        # baseline. A runtime error in the generated approach also propagates.
+        if self._generated is None:
+            raise RuntimeError(
+                "No generated approach is loaded (the agent did not produce a "
+                "usable approach.py). Refusing to evaluate a silent random "
+                "policy; use approach=random for a random baseline."
+            )
+        return self._generated.get_action(self._last_state)

--- a/src/robocode/approaches/llm_genplan_approach.py
+++ b/src/robocode/approaches/llm_genplan_approach.py
@@ -10,9 +10,11 @@ writes and self-tests the policy with tools.
 
 from __future__ import annotations
 
+import ast
 import inspect
 import json
 import logging
+import re
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any, TypeVar, cast
@@ -412,11 +414,76 @@ def _source_targets(env: gymnasium.Env) -> list[tuple[Any, str]]:
     return targets
 
 
+_REQUIRED_METHODS = ("__init__", "reset", "get_action")
+
+
+def _is_stub_body(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """True if the method body is only a docstring and/or `pass`/`...`."""
+    body = [
+        node
+        for node in fn.body
+        if not (
+            isinstance(node, ast.Expr)
+            and isinstance(node.value, ast.Constant)
+            and isinstance(node.value.value, str)
+        )
+    ]
+    if not body:
+        return True
+    return all(
+        isinstance(node, ast.Pass)
+        or (
+            isinstance(node, ast.Expr)
+            and isinstance(node.value, ast.Constant)
+            and node.value.value is Ellipsis
+        )
+        for node in body
+    )
+
+
+def _has_complete_approach(code: str) -> bool:
+    """True if code defines GeneratedApproach with all required methods implemented."""
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return False
+    cls = next(
+        (
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ClassDef) and node.name == "GeneratedApproach"
+        ),
+        None,
+    )
+    if cls is None:
+        return False
+    methods = {
+        node.name: node
+        for node in cls.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    if not all(name in methods for name in _REQUIRED_METHODS):
+        return False
+    return all(not _is_stub_body(methods[name]) for name in _REQUIRED_METHODS)
+
+
 def _parse_python_code(response: str) -> str:
-    """Extract the first ```python fenced block, else the raw response."""
-    marker = "```python"
-    if marker in response:
-        rest = response[response.index(marker) + len(marker) :]
-        end = rest.index("```") if "```" in rest else len(rest)
-        return rest[:end].strip()
-    return response.strip()
+    """Extract the fenced Python block holding the GeneratedApproach implementation.
+
+    Models sometimes emit a short illustrative snippet (sometimes even a stubbed class
+    with empty method bodies) before the full implementation, so the first block is not
+    reliable. Scanning longest-first, prefer the block that defines GeneratedApproach
+    with all required methods implemented; otherwise fall back to the longest block that
+    at least names the class, then the longest block, then the raw response.
+    """
+    blocks = re.findall(r"```(?:python)?\n(.*?)```", response, re.DOTALL)
+    blocks = sorted((b.strip() for b in blocks if b.strip()), key=len, reverse=True)
+    if not blocks:
+        return response.strip()
+    for block in blocks:
+        if _has_complete_approach(block):
+            return block
+    for block in blocks:
+        if "class GeneratedApproach" in block:
+            return block
+    return blocks[0]

--- a/src/robocode/approaches/llm_genplan_approach.py
+++ b/src/robocode/approaches/llm_genplan_approach.py
@@ -10,7 +10,6 @@ writes and self-tests the policy with tools.
 
 from __future__ import annotations
 
-import ast
 import inspect
 import json
 import logging
@@ -414,78 +413,23 @@ def _source_targets(env: gymnasium.Env) -> list[tuple[Any, str]]:
     return targets
 
 
-_REQUIRED_METHODS = ("__init__", "reset", "get_action")
-
-
-def _is_stub_body(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
-    """True if the method body is only a docstring and/or `pass`/`...`."""
-    body = [
-        node
-        for node in fn.body
-        if not (
-            isinstance(node, ast.Expr)
-            and isinstance(node.value, ast.Constant)
-            and isinstance(node.value.value, str)
-        )
-    ]
-    if not body:
-        return True
-    return all(
-        isinstance(node, ast.Pass)
-        or (
-            isinstance(node, ast.Expr)
-            and isinstance(node.value, ast.Constant)
-            and node.value.value is Ellipsis
-        )
-        for node in body
-    )
-
-
-def _has_complete_approach(code: str) -> bool:
-    """True if code defines GeneratedApproach with all required methods implemented."""
-    try:
-        tree = ast.parse(code)
-    except SyntaxError:
-        return False
-    cls = next(
-        (
-            node
-            for node in ast.walk(tree)
-            if isinstance(node, ast.ClassDef) and node.name == "GeneratedApproach"
-        ),
-        None,
-    )
-    if cls is None:
-        return False
-    methods = {
-        node.name: node
-        for node in cls.body
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
-    }
-    if not all(name in methods for name in _REQUIRED_METHODS):
-        return False
-    return all(not _is_stub_body(methods[name]) for name in _REQUIRED_METHODS)
+_FENCE = r"```[ \t]*[a-zA-Z0-9]*[ \t]*\r?\n"
 
 
 def _parse_python_code(response: str) -> str:
-    """Extract the fenced Python block holding the GeneratedApproach implementation.
+    """Extract the GeneratedApproach implementation from a model response.
 
-    Models sometimes emit a short illustrative snippet (sometimes even a stubbed class
-    with empty method bodies) before the full implementation, so the first block is not
-    reliable. Scanning longest-first, prefer the block that defines GeneratedApproach
-    with all required methods implemented; otherwise fall back to the longest block that
-    at least names the class, then the longest block, then the raw response.
+    Models sometimes emit an illustrative snippet before the real implementation,
+    so prefer the last fenced block that defines GeneratedApproach, then the last
+    fenced block. If the response was truncated at the token limit (an opening
+    fence with no close), recover the code after the last opening fence.
     """
-    blocks = re.findall(
-        r"```[ \t]*[a-zA-Z0-9]*[ \t]*\r?\n(.*?)```", response, re.DOTALL
-    )
-    blocks = sorted((b.strip() for b in blocks if b.strip()), key=len, reverse=True)
-    if not blocks:
-        return response.strip()
-    for block in blocks:
-        if _has_complete_approach(block):
-            return block
-    for block in blocks:
-        if "class GeneratedApproach" in block:
-            return block
-    return blocks[0]
+    blocks = [b.strip() for b in re.findall(_FENCE + r"(.*?)```", response, re.DOTALL)]
+    blocks = [b for b in blocks if b]
+    generated = [b for b in blocks if "class GeneratedApproach" in b]
+    if generated:
+        return generated[-1]
+    if blocks:
+        return blocks[-1]
+    opens = list(re.finditer(_FENCE, response))
+    return response[opens[-1].end() :].strip() if opens else response.strip()

--- a/src/robocode/approaches/llm_genplan_approach.py
+++ b/src/robocode/approaches/llm_genplan_approach.py
@@ -476,7 +476,9 @@ def _parse_python_code(response: str) -> str:
     with all required methods implemented; otherwise fall back to the longest block that
     at least names the class, then the longest block, then the raw response.
     """
-    blocks = re.findall(r"```(?:python)?\n(.*?)```", response, re.DOTALL)
+    blocks = re.findall(
+        r"```[ \t]*[a-zA-Z0-9]*[ \t]*\r?\n(.*?)```", response, re.DOTALL
+    )
     blocks = sorted((b.strip() for b in blocks if b.strip()), key=len, reverse=True)
     if not blocks:
         return response.strip()

--- a/src/robocode/environments/kinder_geom2d_env.py
+++ b/src/robocode/environments/kinder_geom2d_env.py
@@ -13,7 +13,13 @@ import os
 # to egl and break the Dynamic3D mujoco renderer. Capture the chosen backend,
 # preempt-import mujoco so PyOpenGL locks to it, restore it after kinder runs.
 os.environ.setdefault("MUJOCO_GL", "egl")
-os.environ.setdefault("PYOPENGL_PLATFORM", "egl")
+# PyOpenGL must agree with the chosen MUJOCO_GL backend, so derive its platform
+# from it rather than defaulting independently (glfw is on-screen and uses GLX
+# on Linux). This keeps a caller-set MUJOCO_GL=osmesa from pairing with egl.
+_PYOPENGL_FOR_MUJOCO = {"egl": "egl", "osmesa": "osmesa", "glfw": "glx"}
+os.environ.setdefault(
+    "PYOPENGL_PLATFORM", _PYOPENGL_FOR_MUJOCO.get(os.environ["MUJOCO_GL"], "egl")
+)
 _MUJOCO_GL = os.environ["MUJOCO_GL"]
 _PYOPENGL_PLATFORM = os.environ["PYOPENGL_PLATFORM"]
 try:

--- a/src/robocode/environments/kinder_geom2d_env.py
+++ b/src/robocode/environments/kinder_geom2d_env.py
@@ -4,13 +4,18 @@ import os
 
 # kinder.register_all_environments() (below) hardcodes MUJOCO_GL=osmesa and
 # PYOPENGL_PLATFORM=osmesa on headless Linux and then imports mujoco to probe
-# for Dynamic3D support, which permanently locks PyOpenGL to OSMesaPlatform.
-# OSMesa isn't installed on every dev machine (EGL from libegl1 is), and later
-# mujoco users in the same process (e.g. robosuite via LIBERO) expect EGL too.
-# Pin MUJOCO_GL=egl and preempt-import mujoco here so PyOpenGL locks to
-# EGLPlatform before kinder runs.
+# for Dynamic3D support, which permanently locks PyOpenGL to that platform.
+# Default to EGL (present on most dev machines via libegl1, and expected by
+# robosuite via LIBERO), but honor an explicit MUJOCO_GL chosen by the caller:
+# the sandbox sets osmesa because headless EGL device displays need a GPU. This
+# matters even in the 2D wrapper, since importing it (e.g. via robocode.rendering,
+# which always imports this module) would otherwise flip a sandbox's osmesa back
+# to egl and break the Dynamic3D mujoco renderer. Capture the chosen backend,
+# preempt-import mujoco so PyOpenGL locks to it, restore it after kinder runs.
 os.environ.setdefault("MUJOCO_GL", "egl")
 os.environ.setdefault("PYOPENGL_PLATFORM", "egl")
+_MUJOCO_GL = os.environ["MUJOCO_GL"]
+_PYOPENGL_PLATFORM = os.environ["PYOPENGL_PLATFORM"]
 try:
     import mujoco  # pylint: disable=unused-import
 
@@ -34,10 +39,10 @@ from numpy.typing import NDArray
 from robocode.environments.base_env import BaseEnv
 
 kinder.register_all_environments()
-# Restore the EGL pin (kinder flipped to osmesa) so later robosuite imports
-# in the same process also pick EGL.
-os.environ["MUJOCO_GL"] = "egl"
-os.environ["PYOPENGL_PLATFORM"] = "egl"
+# kinder flips these to osmesa on headless Linux; restore the chosen backend so
+# later mujoco/robosuite users in this process pick it up.
+os.environ["MUJOCO_GL"] = _MUJOCO_GL
+os.environ["PYOPENGL_PLATFORM"] = _PYOPENGL_PLATFORM
 
 
 def _unwrap_to_kinder(env: gymnasium.Env) -> ConstantObjectKinDEREnv:

--- a/src/robocode/environments/kinder_geom3d_env.py
+++ b/src/robocode/environments/kinder_geom3d_env.py
@@ -4,13 +4,17 @@ import os
 
 # kinder.register_all_environments() (below) hardcodes MUJOCO_GL=osmesa and
 # PYOPENGL_PLATFORM=osmesa on headless Linux and then imports mujoco to probe
-# for Dynamic3D support, which permanently locks PyOpenGL to OSMesaPlatform.
-# OSMesa isn't installed on every dev machine (EGL from libegl1 is), and later
-# mujoco users in the same process (e.g. robosuite via LIBERO) expect EGL too.
-# Pin MUJOCO_GL=egl and preempt-import mujoco here so PyOpenGL locks to
-# EGLPlatform before kinder runs.
+# for Dynamic3D support, which permanently locks PyOpenGL to that platform.
+# Default to EGL (present on most dev machines via libegl1, and expected by
+# robosuite via LIBERO), but honor an explicit MUJOCO_GL chosen by the caller:
+# the sandbox sets osmesa because headless EGL device displays need a GPU, which
+# the container does not have, so the Dynamic3D mujoco offscreen renderer fails
+# under EGL. Capture the chosen backend, preempt-import mujoco so PyOpenGL locks
+# to it, then restore it after kinder flips the env vars.
 os.environ.setdefault("MUJOCO_GL", "egl")
 os.environ.setdefault("PYOPENGL_PLATFORM", "egl")
+_MUJOCO_GL = os.environ["MUJOCO_GL"]
+_PYOPENGL_PLATFORM = os.environ["PYOPENGL_PLATFORM"]
 try:
     import mujoco  # pylint: disable=unused-import
 
@@ -34,10 +38,10 @@ from numpy.typing import NDArray
 from robocode.environments.base_env import BaseEnv
 
 kinder.register_all_environments()
-# Restore the EGL pin (kinder flipped to osmesa) so later robosuite imports
-# in the same process also pick EGL.
-os.environ["MUJOCO_GL"] = "egl"
-os.environ["PYOPENGL_PLATFORM"] = "egl"
+# kinder flips these to osmesa on headless Linux; restore the chosen backend so
+# later mujoco/robosuite users in this process pick it up.
+os.environ["MUJOCO_GL"] = _MUJOCO_GL
+os.environ["PYOPENGL_PLATFORM"] = _PYOPENGL_PLATFORM
 
 
 def _unwrap_to_kinder(env: gymnasium.Env) -> ConstantObjectKinDEREnv:

--- a/src/robocode/environments/kinder_geom3d_env.py
+++ b/src/robocode/environments/kinder_geom3d_env.py
@@ -55,9 +55,18 @@ def _unwrap_to_kinder(env: gymnasium.Env) -> ConstantObjectKinDEREnv:
 class KinderGeom3DEnv(BaseEnv[NDArray[Any], NDArray[Any]]):
     """A robocode environment backed by a kinder geom3d environment."""
 
-    def __init__(self, env_id: str) -> None:
+    def __init__(self, env_id: str, scene_bg: str | bool | None = None) -> None:
         self._env_id = env_id
-        self._kinder_env = _unwrap_to_kinder(kinder.make(env_id))
+        # scene_bg selects the background scene for dynamic3d (TidyBot) envs:
+        # None/False is the plain white "simple" ground, while "mimiclabs-labN"
+        # (or True) loads a realistic room with floor/wall textures. It only
+        # applies to dynamic3d envs, so it is only forwarded when set. The
+        # mimiclabs assets are gitignored and must be fetched once via
+        # third-party/kindergarden/scripts/download_mimiclabs_assets.py (README).
+        make_kwargs: dict[str, Any] = {}
+        if scene_bg is not None:
+            make_kwargs["scene_bg"] = scene_bg
+        self._kinder_env = _unwrap_to_kinder(kinder.make(env_id, **make_kwargs))
         self.observation_space = self._kinder_env.observation_space
         self.action_space = self._kinder_env.action_space
         self._current_obs: NDArray[Any] | None = None

--- a/src/robocode/environments/kinder_geom3d_env.py
+++ b/src/robocode/environments/kinder_geom3d_env.py
@@ -12,7 +12,13 @@ import os
 # under EGL. Capture the chosen backend, preempt-import mujoco so PyOpenGL locks
 # to it, then restore it after kinder flips the env vars.
 os.environ.setdefault("MUJOCO_GL", "egl")
-os.environ.setdefault("PYOPENGL_PLATFORM", "egl")
+# PyOpenGL must agree with the chosen MUJOCO_GL backend, so derive its platform
+# from it rather than defaulting independently (glfw is on-screen and uses GLX
+# on Linux). This keeps a caller-set MUJOCO_GL=osmesa from pairing with egl.
+_PYOPENGL_FOR_MUJOCO = {"egl": "egl", "osmesa": "osmesa", "glfw": "glx"}
+os.environ.setdefault(
+    "PYOPENGL_PLATFORM", _PYOPENGL_FOR_MUJOCO.get(os.environ["MUJOCO_GL"], "egl")
+)
 _MUJOCO_GL = os.environ["MUJOCO_GL"]
 _PYOPENGL_PLATFORM = os.environ["PYOPENGL_PLATFORM"]
 try:

--- a/src/robocode/mcp/__init__.py
+++ b/src/robocode/mcp/__init__.py
@@ -30,6 +30,13 @@ MCP_HTTP_HOST = "127.0.0.1"
 MCP_HTTP_PORT = 8765
 MCP_START_SCRIPT = "start_server.sh"
 
+# Seconds the launch flow waits for the render server to bind its port before
+# giving up and aborting the run. The server imports the full env/render stack
+# first, which for heavy envs (e.g. the dynamic3d TidyBot mujoco scenes) can take
+# well over a minute, so this is generous; the wait ends as soon as the port is
+# up, so it only costs real time when the env is genuinely slow to load.
+MCP_RENDER_BIND_TIMEOUT_S = 120
+
 # Tool description templates. Use {render_state} and {render_policy}
 # placeholders for the backend-specific tool names (Claude uses
 # ``mcp__robocode-tools__render_state``, OpenCode uses

--- a/src/robocode/mcp/__init__.py
+++ b/src/robocode/mcp/__init__.py
@@ -30,13 +30,6 @@ MCP_HTTP_HOST = "127.0.0.1"
 MCP_HTTP_PORT = 8765
 MCP_START_SCRIPT = "start_server.sh"
 
-# Seconds the launch flow waits for the render server to bind its port before
-# giving up and aborting the run. The server imports the full env/render stack
-# first, which for heavy envs (e.g. the dynamic3d TidyBot mujoco scenes) can take
-# well over a minute, so this is generous; the wait ends as soon as the port is
-# up, so it only costs real time when the env is genuinely slow to load.
-MCP_RENDER_BIND_TIMEOUT_S = 120
-
 # Tool description templates. Use {render_state} and {render_policy}
 # placeholders for the backend-specific tool names (Claude uses
 # ``mcp__robocode-tools__render_state``, OpenCode uses

--- a/src/robocode/utils/apptainer_sandbox.py
+++ b/src/robocode/utils/apptainer_sandbox.py
@@ -178,6 +178,12 @@ def _build_apptainer_cmd(
         f"MCP_TIMEOUT={MCP_STARTUP_TIMEOUT_MS}",
         "--env",
         "ROBOCODE_SKIP_FIREWALL=1",
+        # Headless container has no GPU, so mujoco's Dynamic3D offscreen renderer
+        # must use OSMesa (software); EGL device displays fail without a GPU.
+        "--env",
+        "MUJOCO_GL=osmesa",
+        "--env",
+        "PYOPENGL_PLATFORM=osmesa",
     ]
 
     if firewall_domains:

--- a/src/robocode/utils/backends/claude.py
+++ b/src/robocode/utils/backends/claude.py
@@ -29,7 +29,8 @@ from robocode.utils.sandbox_types import SandboxConfig, _StreamParseResult
 logger = logging.getLogger(__name__)
 
 _RATE_LIMIT_RE = re.compile(
-    r"(?:out of extra usage|hit your limit).*resets\s+(\d{1,2}(?:am|pm))",
+    r"(?:out of extra usage|hit your (?:\w+\s+)*limit)"
+    r".*?resets\s+(\d{1,2}(?:am|pm))(?:\s*\(?([A-Za-z][A-Za-z/_]*)\)?)?",
     re.IGNORECASE,
 )
 
@@ -326,8 +327,11 @@ class ClaudeBackend(AgentBackend):
                         meta.get("trigger"),
                         meta.get("pre_tokens"),
                     )
-                elif subtype != "status":
-                    logger.info("System event: subtype=%s", subtype)
+                elif subtype not in ("status", "thinking_tokens"):
+                    # thinking_tokens fires on every reasoning chunk and floods
+                    # the logs; other system events are rare diagnostics, so keep
+                    # them at debug rather than info.
+                    logger.debug("System event: subtype=%s", subtype)
 
             if msg_type == "assistant":
                 num_turns += 1
@@ -351,7 +355,7 @@ class ClaudeBackend(AgentBackend):
                         logger.info("Agent: %s", text)
                         m = _RATE_LIMIT_RE.search(text)
                         if m:
-                            rate_limit_reset = m.group(1)
+                            rate_limit_reset = m.group(0)
                     elif block.get("type") == "tool_use":
                         input_str = json.dumps(block.get("input", {}))
                         if len(input_str) > 300:
@@ -394,7 +398,7 @@ class ClaudeBackend(AgentBackend):
                     if not rate_limit_reset:
                         m = _RATE_LIMIT_RE.search(error_text)
                         if m:
-                            rate_limit_reset = m.group(1)
+                            rate_limit_reset = m.group(0)
 
         proc.wait()
 
@@ -413,7 +417,7 @@ class ClaudeBackend(AgentBackend):
             if not rate_limit_reset and stderr_output:
                 m = _RATE_LIMIT_RE.search(stderr_output)
                 if m:
-                    rate_limit_reset = m.group(1)
+                    rate_limit_reset = m.group(0)
 
         if rate_limit_reset and not is_error:
             is_error = True

--- a/src/robocode/utils/docker_sandbox.py
+++ b/src/robocode/utils/docker_sandbox.py
@@ -53,7 +53,6 @@ from typing import Any
 from robocode.mcp import (
     MCP_HTTP_HOST,
     MCP_HTTP_PORT,
-    MCP_RENDER_BIND_TIMEOUT_S,
     MCP_START_SCRIPT,
     MCP_STARTUP_TIMEOUT_MS,
 )
@@ -388,8 +387,7 @@ def _mcp_prestart_wrapper(agent_cmd: list[str], port: int = MCP_HTTP_PORT) -> li
 
     Returns a container command that starts ``.mcp/<MCP_START_SCRIPT>`` in the
     background (its output redirected to a file so it cannot hold the CLI's
-    stdout pipe), waits (up to MCP_RENDER_BIND_TIMEOUT_S) for *port* to accept
-    connections, then runs
+    stdout pipe), waits (up to ~20s) for *port* to accept connections, then runs
     the agent CLI in the foreground and kills the server when it exits. Starting
     and health-checking the server before the CLI is what makes the render tools
     connected on the agent's first turn. If the server dies or never binds the
@@ -409,7 +407,7 @@ def _mcp_prestart_wrapper(agent_cmd: list[str], port: int = MCP_HTTP_PORT) -> li
     )
     script = (
         f"bash {start_script} >>{server_log} 2>&1 & srv=$!; ok=0; "
-        f"for _ in $(seq 1 {int(MCP_RENDER_BIND_TIMEOUT_S * 10)}); do "
+        f"for _ in $(seq 1 200); do "
         f'kill -0 "$srv" 2>/dev/null || break; '
         f"{probe} 2>/dev/null && {{ ok=1; break; }}; sleep 0.1; "
         f"done; "

--- a/src/robocode/utils/docker_sandbox.py
+++ b/src/robocode/utils/docker_sandbox.py
@@ -53,6 +53,7 @@ from typing import Any
 from robocode.mcp import (
     MCP_HTTP_HOST,
     MCP_HTTP_PORT,
+    MCP_RENDER_BIND_TIMEOUT_S,
     MCP_START_SCRIPT,
     MCP_STARTUP_TIMEOUT_MS,
 )
@@ -387,7 +388,8 @@ def _mcp_prestart_wrapper(agent_cmd: list[str], port: int = MCP_HTTP_PORT) -> li
 
     Returns a container command that starts ``.mcp/<MCP_START_SCRIPT>`` in the
     background (its output redirected to a file so it cannot hold the CLI's
-    stdout pipe), waits (up to ~20s) for *port* to accept connections, then runs
+    stdout pipe), waits (up to MCP_RENDER_BIND_TIMEOUT_S) for *port* to accept
+    connections, then runs
     the agent CLI in the foreground and kills the server when it exits. Starting
     and health-checking the server before the CLI is what makes the render tools
     connected on the agent's first turn. If the server dies or never binds the
@@ -407,7 +409,7 @@ def _mcp_prestart_wrapper(agent_cmd: list[str], port: int = MCP_HTTP_PORT) -> li
     )
     script = (
         f"bash {start_script} >>{server_log} 2>&1 & srv=$!; ok=0; "
-        f"for _ in $(seq 1 200); do "
+        f"for _ in $(seq 1 {int(MCP_RENDER_BIND_TIMEOUT_S * 10)}); do "
         f'kill -0 "$srv" 2>/dev/null || break; '
         f"{probe} 2>/dev/null && {{ ok=1; break; }}; sleep 0.1; "
         f"done; "

--- a/src/robocode/utils/docker_sandbox.py
+++ b/src/robocode/utils/docker_sandbox.py
@@ -499,6 +499,12 @@ async def run_agent_in_docker_sandbox(
                 # snapshots its tools, else render tools race and can vanish.
                 "-e",
                 f"MCP_TIMEOUT={MCP_STARTUP_TIMEOUT_MS}",
+                # Headless container has no GPU, so mujoco's Dynamic3D offscreen
+                # renderer must use OSMesa (software); EGL device displays fail.
+                "-e",
+                "MUJOCO_GL=osmesa",
+                "-e",
+                "PYOPENGL_PLATFORM=osmesa",
             ],
             # Map the host gateway for blackbox (env server) and local model
             # runs (ollama/vLLM on the host), which both reach host loopback.

--- a/src/robocode/utils/rate_limit.py
+++ b/src/robocode/utils/rate_limit.py
@@ -8,7 +8,7 @@ import logging
 import re
 import time
 from collections.abc import Callable
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from robocode.utils.apptainer_sandbox import (
@@ -25,6 +25,9 @@ from robocode.utils.sandbox import SandboxConfig, SandboxResult, run_agent_in_sa
 logger = logging.getLogger(__name__)
 
 _DEFAULT_RESET_HOUR = 3  # fallback hour if we can't parse the reset time
+# Subscription usage caps reset on a 5-hour window, so a wait longer than this
+# means we mis-parsed the reset time. Cap the sleep; the retry loop re-checks.
+_MAX_WAIT_SECS = 5.5 * 3600
 
 
 def run_async(make_coro: Callable[[], Any]) -> SandboxResult:
@@ -41,26 +44,39 @@ def run_async(make_coro: Callable[[], Any]) -> SandboxResult:
         return pool.submit(_run).result()
 
 
-def parse_reset_hour(reset_str: str) -> int:
-    """Parse a reset time like '3am' or '11pm' into a 24-hour int."""
-    reset_str = reset_str.strip().lower()
-    match = re.match(r"(\d{1,2})(am|pm)", reset_str)
+def parse_reset_hour(reset_str: str) -> tuple[int, bool]:
+    """Parse a reset message into (hour_24, is_utc).
+
+    Handles bare times like '3am' as well as full messages such as "You've hit your
+    session limit . resets 11pm (UTC)". The timezone flag matters because the box may
+    not be in UTC.
+    """
+    text = reset_str.strip().lower()
+    match = re.search(r"(\d{1,2})\s*(am|pm)", text)
     if not match:
-        return _DEFAULT_RESET_HOUR
+        return _DEFAULT_RESET_HOUR, False
     hour = int(match.group(1))
     period = match.group(2)
     if period == "am":
-        return 0 if hour == 12 else hour
-    return hour if hour == 12 else hour + 12
+        hour = 0 if hour == 12 else hour
+    else:
+        hour = hour if hour == 12 else hour + 12
+    return hour, "utc" in text
 
 
-def seconds_until_reset(reset_hour: int) -> float:
-    """Return seconds until the given hour (local time), plus a small buffer."""
-    now = datetime.now()
+def seconds_until_reset(reset_hour: int, is_utc: bool = False) -> float:
+    """Return seconds until the given reset hour, capped at the window length.
+
+    When ``is_utc`` the hour is interpreted in UTC (and compared against UTC
+    now); otherwise it is local time. The result is clamped to _MAX_WAIT_SECS
+    so a misparsed time cannot cause a multi-hour oversleep.
+    """
+    now = datetime.now(timezone.utc) if is_utc else datetime.now().astimezone()
     target = now.replace(hour=reset_hour, minute=5, second=0, microsecond=0)
     if target <= now:
         target += timedelta(days=1)
-    return (target - now).total_seconds()
+    wait = (target - now).total_seconds()
+    return min(wait, _MAX_WAIT_SECS)
 
 
 def run_with_rate_limit_retry(
@@ -86,14 +102,15 @@ def run_with_rate_limit_retry(
         if result.rate_limit_reset is None:
             return result
 
-        reset_hour = parse_reset_hour(result.rate_limit_reset)
-        wait_secs = seconds_until_reset(reset_hour)
+        reset_hour, is_utc = parse_reset_hour(result.rate_limit_reset)
+        wait_secs = seconds_until_reset(reset_hour, is_utc)
         hours = wait_secs / 3600
         logger.warning(
-            "Rate-limited (%s). Sleeping %.1f hours until %d:05 ...",
+            "Rate-limited (%s). Sleeping %.1f hours until %d:05 %s ...",
             result.error,
             hours,
             reset_hour,
+            "UTC" if is_utc else "local",
         )
         time.sleep(wait_secs)
         logger.info("Woke up after rate-limit sleep, retrying...")

--- a/src/robocode/utils/sandbox.py
+++ b/src/robocode/utils/sandbox.py
@@ -27,7 +27,7 @@ import sys
 import time
 from pathlib import Path
 
-from robocode.mcp import MCP_RENDER_BIND_TIMEOUT_S, MCP_START_SCRIPT
+from robocode.mcp import MCP_START_SCRIPT
 from robocode.primitive_specs import (
     ENV_DEPENDENT_PRIMITIVES,
     PRIMITIVE_NAME_TO_FILE,
@@ -76,7 +76,7 @@ def _start_local_http_mcp(
         stderr=subprocess.DEVNULL,
         start_new_session=True,
     )
-    deadline = time.monotonic() + MCP_RENDER_BIND_TIMEOUT_S
+    deadline = time.monotonic() + 30
     while time.monotonic() < deadline:
         if proc.poll() is not None:
             raise RuntimeError(
@@ -89,10 +89,7 @@ def _start_local_http_mcp(
         except OSError:
             time.sleep(0.1)
     proc.terminate()
-    raise RuntimeError(
-        f"render MCP server did not bind port {port} within "
-        f"{MCP_RENDER_BIND_TIMEOUT_S}s"
-    )
+    raise RuntimeError(f"render MCP server did not bind port {port} within 30s")
 
 
 _SANDBOX_GITIGNORE = """\

--- a/src/robocode/utils/sandbox.py
+++ b/src/robocode/utils/sandbox.py
@@ -217,7 +217,9 @@ def _stream_result_to_sandbox_result(
     """Convert a :class:`_StreamParseResult` to a :class:`SandboxResult`."""
     cost = stream.total_cost
 
-    if stream.is_error:
+    # A rate-limit error must propagate so the retry loop can wait and rerun the
+    # whole sandbox; never evaluate a partial approach from a rate-limited run.
+    if stream.rate_limit_reset is not None:
         return SandboxResult(
             success=False,
             output_file=None,
@@ -226,18 +228,22 @@ def _stream_result_to_sandbox_result(
             rate_limit_reset=stream.rate_limit_reset,
         )
 
+    # The agent commits its best-effort approach.py as it iterates, so if that
+    # file exists we evaluate it even when the run ended on an error such as the
+    # budget or turn cap being hit. Those are normal stopping conditions, not a
+    # reason to throw away a working approach and fall back to a random policy.
     output_path = sandbox_dir / output_filename
     if output_path.exists():
         return SandboxResult(
             success=True,
             output_file=output_path,
-            error=None,
+            error=stream.error_text,
             total_cost_usd=cost,
         )
     return SandboxResult(
         success=False,
         output_file=None,
-        error=f"Output file not found: {output_filename}",
+        error=stream.error_text or f"Output file not found: {output_filename}",
         total_cost_usd=cost,
     )
 

--- a/src/robocode/utils/sandbox.py
+++ b/src/robocode/utils/sandbox.py
@@ -27,7 +27,7 @@ import sys
 import time
 from pathlib import Path
 
-from robocode.mcp import MCP_START_SCRIPT
+from robocode.mcp import MCP_RENDER_BIND_TIMEOUT_S, MCP_START_SCRIPT
 from robocode.primitive_specs import (
     ENV_DEPENDENT_PRIMITIVES,
     PRIMITIVE_NAME_TO_FILE,
@@ -76,7 +76,7 @@ def _start_local_http_mcp(
         stderr=subprocess.DEVNULL,
         start_new_session=True,
     )
-    deadline = time.monotonic() + 30
+    deadline = time.monotonic() + MCP_RENDER_BIND_TIMEOUT_S
     while time.monotonic() < deadline:
         if proc.poll() is not None:
             raise RuntimeError(
@@ -89,7 +89,10 @@ def _start_local_http_mcp(
         except OSError:
             time.sleep(0.1)
     proc.terminate()
-    raise RuntimeError(f"render MCP server did not bind port {port} within 30s")
+    raise RuntimeError(
+        f"render MCP server did not bind port {port} within "
+        f"{MCP_RENDER_BIND_TIMEOUT_S}s"
+    )
 
 
 _SANDBOX_GITIGNORE = """\

--- a/tests/approaches/test_agentic_approach.py
+++ b/tests/approaches/test_agentic_approach.py
@@ -21,8 +21,9 @@ _BLACKBOX_ENV_CFG = json.dumps(
 )
 
 
-def test_agentic_approach_fallback():
-    """Without training, AgenticApproach falls back to random actions."""
+def test_agentic_approach_no_silent_random():
+    """Without a generated approach, AgenticApproach fails loudly rather than silently
+    evaluating a random policy (which would propagate a misleading 0)."""
     env = MazeEnv(5, 8, 5, 8)
     approach = AgenticApproach(
         action_space=env.action_space,
@@ -33,8 +34,8 @@ def test_agentic_approach_fallback():
     )
     state, info = env.reset(seed=123)
     approach.reset(state, info)
-    action = approach.step()
-    assert env.action_space.contains(action)
+    with pytest.raises(RuntimeError, match="random"):
+        approach.step()
 
 
 def test_agentic_approach_with_generated():
@@ -216,7 +217,17 @@ def test_blackbox_train_wires_sandbox(tmp_path, monkeypatch):
         # The env server must be live while the agent would run.
         meta = json.loads((docker_config.sandbox_dir / "env_spaces.json").read_text())
         socket.create_connection(("127.0.0.1", meta["port"]), timeout=5).close()
-        return SandboxResult(success=False, output_file=None, error="skipped")
+        approach_file = docker_config.sandbox_dir / "approach.py"
+        approach_file.write_text(
+            "class GeneratedApproach:\n"
+            "    def __init__(self, action_space, observation_space, primitives):\n"
+            "        self._action_space = action_space\n"
+            "    def reset(self, state, info):\n"
+            "        pass\n"
+            "    def get_action(self, state):\n"
+            "        return self._action_space.sample()\n"
+        )
+        return SandboxResult(success=True, output_file=approach_file, error=None)
 
     monkeypatch.setattr(
         "robocode.approaches.agentic_approach.run_with_rate_limit_retry",

--- a/tests/approaches/test_llm_genplan_approach.py
+++ b/tests/approaches/test_llm_genplan_approach.py
@@ -98,35 +98,19 @@ def test_parse_python_code_prefers_generated_approach_block():
     assert _parse_python_code(response) == _FULL_APPROACH.strip()
 
 
-def test_parse_python_code_skips_stub_class():
-    """A stubbed class signature loses to the fully implemented block."""
-    stub = (
-        "class GeneratedApproach:\n"
-        "    def __init__(self, action_space, observation_space, primitives):\n"
-        "        ...\n"
-        "    def reset(self, state, info):\n"
-        "        pass\n"
-        "    def get_action(self, state):\n"
-        "        pass\n"
-    )
+def test_parse_python_code_prefers_last_class_over_trailing_snippet():
+    """A trailing non-class snippet does not shadow the real implementation."""
     response = (
-        f"Here is the skeleton:\n```python\n{stub}```\n"
-        f"And the implementation:\n```python\n{_FULL_APPROACH}```\n"
+        f"The implementation:\n```python\n{_FULL_APPROACH}```\n"
+        "For reference, the action space is Discrete(4):\n```python\nn = 4\n```\n"
     )
     assert _parse_python_code(response) == _FULL_APPROACH.strip()
 
 
-def test_parse_python_code_falls_back_to_longest_block_with_class():
-    """If nothing is fully implemented, keep the longest class block for feedback."""
-    partial = (
-        "class GeneratedApproach:\n"
-        "    def __init__(self, action_space, observation_space, primitives):\n"
-        "        self.x = 1\n"
-        "    def get_action(self, state):\n"
-        "        return 0\n"
-    )
-    response = f"```python\nx = 1\n```\n```python\n{partial}```\n"
-    assert _parse_python_code(response) == partial.strip()
+def test_parse_python_code_recovers_truncated_block():
+    """A response cut off mid-block (no closing fence) still yields the code."""
+    response = f"Here is the approach:\n```python\n{_FULL_APPROACH}"
+    assert _parse_python_code(response) == _FULL_APPROACH.strip()
 
 
 def test_create_llm_client_dispatch(monkeypatch):

--- a/tests/approaches/test_llm_genplan_approach.py
+++ b/tests/approaches/test_llm_genplan_approach.py
@@ -68,6 +68,59 @@ def test_parse_python_code():
     assert _parse_python_code("no fence here") == "no fence here"
 
 
+_FULL_APPROACH = (
+    "class GeneratedApproach:\n"
+    "    def __init__(self, action_space, observation_space, primitives):\n"
+    "        self.action_space = action_space\n"
+    "    def reset(self, state, info):\n"
+    "        self.plan = [0, 1]\n"
+    "    def get_action(self, state):\n"
+    "        return self.plan.pop(0)\n"
+)
+
+
+def test_parse_python_code_prefers_generated_approach_block():
+    """A leading illustrative snippet does not shadow the real block."""
+    response = (
+        "First, a sketch:\n"
+        "```python\nsuction_cx = base_x + 1\n```\n"
+        "Now the full thing:\n"
+        f"```python\n{_FULL_APPROACH}```\n"
+    )
+    assert _parse_python_code(response) == _FULL_APPROACH.strip()
+
+
+def test_parse_python_code_skips_stub_class():
+    """A stubbed class signature loses to the fully implemented block."""
+    stub = (
+        "class GeneratedApproach:\n"
+        "    def __init__(self, action_space, observation_space, primitives):\n"
+        "        ...\n"
+        "    def reset(self, state, info):\n"
+        "        pass\n"
+        "    def get_action(self, state):\n"
+        "        pass\n"
+    )
+    response = (
+        f"Here is the skeleton:\n```python\n{stub}```\n"
+        f"And the implementation:\n```python\n{_FULL_APPROACH}```\n"
+    )
+    assert _parse_python_code(response) == _FULL_APPROACH.strip()
+
+
+def test_parse_python_code_falls_back_to_longest_block_with_class():
+    """If nothing is fully implemented, keep the longest class block for feedback."""
+    partial = (
+        "class GeneratedApproach:\n"
+        "    def __init__(self, action_space, observation_space, primitives):\n"
+        "        self.x = 1\n"
+        "    def get_action(self, state):\n"
+        "        return 0\n"
+    )
+    response = f"```python\nx = 1\n```\n```python\n{partial}```\n"
+    assert _parse_python_code(response) == partial.strip()
+
+
 def test_create_llm_client_dispatch(monkeypatch):
     """The factory routes providers and rejects unknown ones."""
     monkeypatch.setenv("ANTHROPIC_API_KEY", "test")

--- a/tests/approaches/test_llm_genplan_approach.py
+++ b/tests/approaches/test_llm_genplan_approach.py
@@ -68,6 +68,14 @@ def test_parse_python_code():
     assert _parse_python_code("no fence here") == "no fence here"
 
 
+def test_parse_python_code_tolerates_fence_variants():
+    """Capitalized tags, bare fences, trailing spaces, and CRLF all parse."""
+    assert _parse_python_code("```Python\nx = 1\n```") == "x = 1"
+    assert _parse_python_code("```py \nx = 1\n```") == "x = 1"
+    assert _parse_python_code("```\nx = 1\n```") == "x = 1"
+    assert _parse_python_code("```python\r\nx = 1\r\n```") == "x = 1"
+
+
 _FULL_APPROACH = (
     "class GeneratedApproach:\n"
     "    def __init__(self, action_space, observation_space, primitives):\n"

--- a/tests/environments/test_kinder_geom3d_env.py
+++ b/tests/environments/test_kinder_geom3d_env.py
@@ -81,7 +81,11 @@ _WRAPPER_MODULES = [
 
 def _mujoco_gl_after_import(module: str, preset: str | None) -> str:
     """Import *module* in a fresh process and return the resulting MUJOCO_GL."""
-    env = {k: v for k, v in os.environ.items() if k != "MUJOCO_GL"}
+    env = {
+        k: v
+        for k, v in os.environ.items()
+        if k not in ("MUJOCO_GL", "PYOPENGL_PLATFORM")
+    }
     if preset is not None:
         env["MUJOCO_GL"] = preset
         env["PYOPENGL_PLATFORM"] = preset

--- a/tests/environments/test_kinder_geom3d_env.py
+++ b/tests/environments/test_kinder_geom3d_env.py
@@ -1,5 +1,9 @@
 """Tests for kinder_geom3d_env.py."""
 
+import os
+import subprocess
+import sys
+
 import numpy as np
 import pytest
 
@@ -62,3 +66,45 @@ def test_kinder_geom3d_sample_next_state(env_id: str) -> None:
     assert env.observation_space.contains(next_state)
 
     env.close()
+
+
+# Both kinder wrappers pin MUJOCO_GL at import time. The sandbox runs headless
+# with no GPU, so it sets MUJOCO_GL=osmesa; the wrappers must NOT clobber that
+# back to egl (egl device displays need a GPU and crash the Dynamic3D mujoco
+# renderer). A fresh subprocess is required because the pin happens once on
+# first import. See the geom2d/geom3d env wrappers.
+_WRAPPER_MODULES = [
+    "robocode.environments.kinder_geom3d_env",
+    "robocode.environments.kinder_geom2d_env",
+]
+
+
+def _mujoco_gl_after_import(module: str, preset: str | None) -> str:
+    """Import *module* in a fresh process and return the resulting MUJOCO_GL."""
+    env = {k: v for k, v in os.environ.items() if k != "MUJOCO_GL"}
+    if preset is not None:
+        env["MUJOCO_GL"] = preset
+        env["PYOPENGL_PLATFORM"] = preset
+    code = f"import os; import {module}; print('RESULT=' + os.environ['MUJOCO_GL'])"
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    line = next(ln for ln in proc.stdout.splitlines() if ln.startswith("RESULT="))
+    return line.split("=", 1)[1]
+
+
+@pytest.mark.parametrize("module", _WRAPPER_MODULES)
+def test_wrapper_honors_preset_mujoco_gl(module: str) -> None:
+    """A caller-set MUJOCO_GL (the sandbox sets osmesa) survives importing the wrapper,
+    rather than being force-overridden to egl."""
+    assert _mujoco_gl_after_import(module, "osmesa") == "osmesa"
+
+
+@pytest.mark.parametrize("module", _WRAPPER_MODULES)
+def test_wrapper_defaults_to_egl(module: str) -> None:
+    """With no MUJOCO_GL set, the wrapper defaults to egl."""
+    assert _mujoco_gl_after_import(module, None) == "egl"

--- a/tests/utils/test_apptainer_sandbox.py
+++ b/tests/utils/test_apptainer_sandbox.py
@@ -68,6 +68,10 @@ def test_build_cmd_basic_shape(tmp_path: Path) -> None:
     assert "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=70" in cmd
     # init-firewall.sh is skipped (apptainer can't grant CAP_NET_ADMIN).
     assert "ROBOCODE_SKIP_FIREWALL=1" in cmd
+    # Headless container has no GPU: mujoco's Dynamic3D renderer must use OSMesa
+    # (software), so the sandbox forces it; EGL device displays would crash.
+    assert "MUJOCO_GL=osmesa" in cmd
+    assert "PYOPENGL_PLATFORM=osmesa" in cmd
 
     # Bind mounts.
     assert "/host/sandbox:/sandbox" in cmd


### PR DESCRIPTION
Fixes that came out of running agentic eval sweeps. Two related themes; happy to split further in follow-ups.

## Headless mujoco / Dynamic3D in the sandbox
The sandbox image had no GL libraries, so `import mujoco` failed and kinder silently dropped its Dynamic3D envs (e.g. `ConstrainedCupboard3D`), aborting those runs at startup.

- Add Mesa EGL + OSMesa runtime to the sandbox image (rebuild SIF via `docker/build_sif.sh`).
- Use `MUJOCO_GL=osmesa` (software rendering, no GPU) in the sandbox, and make the kinder geom2d/3d wrappers honor a caller-set `MUJOCO_GL` instead of force-overriding to `egl`. The 2D wrapper mattered too: imported via `robocode.rendering` in the render MCP server, it was flipping osmesa back to egl before kinder captured the backend.
- Centralize the render MCP bind wait as `MCP_RENDER_BIND_TIMEOUT_S` (raised, then reverted the standalone bump now that osmesa is the real fix).
- Add `ConstrainedCupboard3D` env config and a `scene_bg` option on `KinderGeom3DEnv` (forwarded to `kinder.make` only when set; `scene_bg=mimiclabs-lab2` for `constrainedcupboard3d_easy`). Verified purely cosmetic.
- Tests for the OSMesa wiring and wrapper `MUJOCO_GL` handling.

## Agentic eval reliability
- Evaluate the committed `approach.py` whenever it exists instead of silently falling back to a random policy on error (which scored real approaches as 0%). `AgenticApproach` now fails loudly when nothing was generated; use `approach=random` for a deliberate baseline. Rate-limit errors still propagate so the retry loop reruns.
- Detect the actual `hit your session limit` message in the rate-limit retry, interpret a UTC reset hour on a non-UTC host, bound the sleep to the 5h window. Raise `max_output_tokens` to 32768 (runs were aborting on long responses).
- Robustly extract `GeneratedApproach` from model output: AST-scan fenced blocks (longest-first) and prefer the one defining `GeneratedApproach` with all required methods, instead of taking the first fenced block.

## Testing
`pytest tests/ --ignore=tests/mcp` — 312 passed. Rebased cleanly onto current `main` (includes #109).
