### PR TITLE
Consolidate agent prompts into a single prompts.py module

### DIFF
--- a/src/robocode/approaches/agentic_approach.py
+++ b/src/robocode/approaches/agentic_approach.py
@@ -10,22 +10,14 @@ from typing import Any, TypeVar
 from gymnasium.spaces import Space
 from omegaconf import DictConfig
 
+from robocode import prompts
 from robocode.approaches.base_approach import BaseApproach
-from robocode.mcp import (
-    MCP_TOOLS_SYSTEM_PROMPT_SUFFIX,
-    MCP_TOOLS_SYSTEM_PROMPT_SUFFIX_BLACKBOX,
-    mcp_tool_descriptions,
-)
 from robocode.primitives import (
     blackbox_primitive_manifest,
     format_primitives_description,
 )
 from robocode.utils.apptainer_sandbox import ApptainerSandboxConfig
-from robocode.utils.backends import (
-    CLAUDE_PROMPT_SUFFIX,
-    OPENCODE_PROMPT_SUFFIX,
-    create_backend,
-)
+from robocode.utils.backends import create_backend
 from robocode.utils.docker_sandbox import (
     DOCKER_PYTHON,
     DockerSandboxConfig,
@@ -45,265 +37,6 @@ logger = logging.getLogger(__name__)
 
 _ObsType = TypeVar("_ObsType")
 _ActType = TypeVar("_ActType")
-
-_SYSTEM_PROMPT = (
-    "You are an expert at writing policies for gymnasium environments. "
-    "You will read environment source code, understand the dynamics, "
-    "and write an optimal approach class. "
-    "IMPORTANT: You MUST write ALL files (approach.py, test scripts, etc.) "
-    "to the current working directory using RELATIVE paths only. "
-    "Never use absolute paths when writing files. "
-    "IMPORTANT: Write code often to approach.py as you iterate. You may be "
-    "interrupted at any time, so you should make sure that approach.py is "
-    "your best current attempt at all times. "
-    "VERSION CONTROL: This directory is a git repo. After each meaningful "
-    "change to approach.py or supporting modules, run "
-    "`git add -A && git commit -m '<describe what you changed and why>'`. "
-    "Commit often, do not batch everything into one final commit. "
-    "You should commit the approach every time before you test it in the environment. "
-    "Use subagents to explore source code in parallel, e.g. spawn "
-    "subagents to read environment dynamics, reward functions, and object "
-    "types simultaneously rather than sequentially."
-)
-
-_SYSTEM_PROMPT_BLACKBOX = (
-    "You are an expert at writing policies for gymnasium environments. "
-    "The environment is a black box: its source code is not available, so "
-    "you will discover the dynamics, reward structure, and termination "
-    "conditions empirically by interacting with a live environment "
-    "instance, and write an optimal approach class. "
-    "IMPORTANT: You MUST write ALL files (approach.py, test scripts, etc.) "
-    "to the current working directory using RELATIVE paths only. "
-    "Never use absolute paths when writing files. "
-    "IMPORTANT: Write code often to approach.py as you iterate. You may be "
-    "interrupted at any time, so you should make sure that approach.py is "
-    "your best current attempt at all times. "
-    "VERSION CONTROL: This directory is a git repo. After each meaningful "
-    "change to approach.py or supporting modules, run "
-    "`git add -A && git commit -m '<describe what you changed and why>'`. "
-    "Commit often, do not batch everything into one final commit. "
-    "You should commit the approach every time before you test it in the environment. "
-    "Use subagents to run exploration experiments in parallel, e.g. spawn "
-    "subagents to probe action effects, reward structure, and termination "
-    "conditions simultaneously rather than sequentially; each test script "
-    "gets its own fresh environment instance."
-)
-
-_INTERFACE_SPEC = """\
-Write `approach.py` containing a class `GeneratedApproach` with the following \
-interface:
-
-```python
-class GeneratedApproach:
-    def __init__(self, action_space, observation_space, primitives):
-        \"\"\"Initialize with the environment's gym spaces.\"\"\"
-        ...
-
-    def reset(self, state, info):
-        \"\"\"Called at the start of each episode with the initial state.\"\"\"
-        ...
-
-    def get_action(self, state):
-        \"\"\"Return a valid action for the given state.\"\"\"
-        ...
-```
-
-The class can maintain internal state between calls (e.g., a computed plan). \
-The `reset` method is called at the start of each episode. The `get_action` \
-method is called each step and must return a valid action.
-
-{primitives_description}
-
-Write the best approach you can \u2014 ideally one that solves the environment \
-optimally. Your `approach.py` should only use packages available in the \
-current environment. Write test scripts that use the real environment to \
-verify your approach works.
-
-IMPORTANT: Use `{python_executable}` to run your test scripts, since that \
-interpreter has all required packages installed. For example:
-```bash
-{python_executable} test_approach.py
-```\
-"""
-
-_INSPECT_SOURCE_SUFFIX = """
-
-You can also inspect the source code of any imported module to understand \
-the environment's dynamics in detail (reward function, transition logic, \
-termination conditions, etc.). To locate a module's source file:
-```bash
-{python_executable} -c "import some_module; print(some_module.__file__)"
-```
-Then read the source to inform your approach.\
-"""
-
-_BLACKBOX_INTERACTION_SPEC = """\
-The environment is a BLACK BOX. You CANNOT read its source code; it is not \
-available anywhere on this machine. A live environment server is running. \
-Interact with it through `env_client.py` in your working directory:
-
-```python
-from env_client import make_env
-
-env = make_env()  # fresh environment instance per call
-obs, info = env.reset(seed=0)
-obs, reward, terminated, truncated, info = env.step(action)
-state = env.get_state()  # numpy snapshot of the full environment state
-env.set_state(state)  # restore a snapshot
-env.close()
-```
-
-`env.observation_space` and `env.action_space` expose `shape`, `low`, \
-`high`, `dtype`, and `sample()`; the same metadata is in `env_spaces.json`. \
-`env.max_steps` is the episode step limit used at evaluation time.
-
-`env.make_primitives()` returns the SAME `primitives` dict the evaluation \
-harness passes to `GeneratedApproach.__init__`. Use it in test scripts so \
-they exercise the real primitives (env-dependent ones run on the host):
-
-```python
-from env_client import make_env
-
-env = make_env()
-primitives = env.make_primitives()
-```
-
-You can also call `env.observation_space.devectorize(obs)` to get an \
-object-centric view of an observation. It returns an `ObjectCentricState` \
-with `get_object_names()`, `get_object_from_name(name)`, `get_objects(type)`, \
-and `get(obj, feature)`; iterate objects via `get_objects(...)`, NOT \
-`for obj in ocs`. Call `env.observation_space.vectorize(ocs)` to go back to a \
-flat array. The evaluation harness passes the SAME `observation_space` to \
-`GeneratedApproach`, so `observation_space.devectorize(obs)` works identically \
-there, and `approach.py` can use it directly.
-
-Parallel test scripts are fine: every `make_env()` call creates an \
-independent environment instance.
-
-Start by exploring systematically: reset with several seeds, apply \
-controlled actions, and study how the observation vector changes to \
-identify what each dimension means and how actions affect the state.
-
-CRITICAL: `approach.py` itself must NOT import `env_client`. It will be \
-evaluated against the real environment by a separate harness that calls \
-`reset(state, info)` and `get_action(state)` directly. Use `env_client` \
-ONLY in test and exploration scripts.\
-"""
-
-_GEOMETRY_PROMPT = """\
-
-BEFORE writing any code, you MUST first reason in detail about the geometry of this environment. \
-Think carefully and qualitatively about spatial relationships, shapes, motions, and constraints.
-
-CRITICAL: Your geometric reasoning must be PURELY QUALITATIVE. Do NOT use any numbers AT ALL — \
-not in your reasoning, not in your thinking, not anywhere in your geometric analysis. This means \
-NO coordinates, NO distances, NO angles, NO dimensions, NO sizes, NO counts of objects, NO \
-thresholds, NO numeric constants, NO array indices, NO velocities, NO ratios, NO percentages. \
-Not even "2D" or "3D" — say "two-dimensional" or "three-dimensional" instead. If you catch \
-yourself about to write a number, stop and rephrase using purely relational, qualitative language. \
-Instead of saying "the object is at position (x, y)" say "the object is near the boundary". \
-Instead of "move 0.1 units" say "move a small step". Instead of "the angle is 90 degrees" say \
-"the surfaces are perpendicular".
-
-Your geometric reasoning should cover topics like:
-- What kinds of geometric shapes are involved (e.g. rectangles, circles, polygons, cuboids, \
-spheres, cylinders, capsules)? How do their shapes affect interactions — for instance, \
-rectangles tile differently than circles, spheres roll while cuboids don't, narrow corridors \
-between rectangular obstacles require precise alignment.
-- What are the key spatial relationships between objects? Reason about relative orientations \
-(parallel, perpendicular, oblique, aligned, tangent, skewed, transverse), relative positions \
-(adjacent, opposite, coplanar, collinear, concentric, coaxial, symmetric), and topological \
-relations (inside, outside, overlapping, enclosing, intersecting, touching, disjoint). Which \
-of these relationships matter for solving the task?
-- What geometric constraints exist? Are there boundaries, obstacles, containment relationships, \
-or clearance requirements? How do the shapes of obstacles create narrow passages, dead ends, \
-or open regions? Are surfaces flush or offset? Are relevant surfaces convex or concave?
-- What kind of motions or transformations are involved? Are objects translating, rotating, or \
-both? Are motions continuous or discrete? Does an object's shape affect how it can move \
-(e.g. a rectangle rotating requires more swept area than a circle of similar size)?
-- What makes a configuration "good" or "bad" geometrically? Think about reachability, \
-collision-freeness, coverage, proximity to goals.
-- What is the overall geometric strategy? For example:
-  - "The agent needs to navigate around obstacles to reach a goal region, so it must find a \
-path that threads between blocked areas while staying within bounds. When two rectangular \
-obstacles have parallel edges with a gap between them, the agent can pass through \
-perpendicular to those edges."
-  - "Objects must be packed tightly without overlapping, so the approach needs to find \
-placements where each new object fits into remaining gaps while respecting clearance from \
-existing objects. Rectangular objects can be aligned with parallel edges flush against each \
-other for dense packing, while circular objects leave unavoidable gaps."
-  - "The robot arm must move its end effector to a grasp pose, which means planning a \
-sequence of joint motions that avoids self-collision and keeps the kinematic chain valid. \
-The shape of the target object determines viable grasp orientations — a sphere can be \
-grasped from any direction, while a flat rectangular object requires approaching \
-perpendicular to one of its faces."
-  - "The agent must push an object toward a target, which requires approaching from the \
-opposite side so that the push direction is aligned with the line from object to goal. \
-A cylindrical object may roll unpredictably under pushes that are oblique to its axis."
-
-This qualitative geometric analysis should directly inform your code. Write your reasoning \
-out before you start coding. Do NOT skip this step. Remember: your geometric reasoning must \
-contain ZERO numbers. If any number appears in your geometric analysis, you have failed the task.
-"""
-
-_MODULAR_CODE_PROMPT = """\
-
-IMPORTANT: Write MODULAR code, like a skilled software engineer:
-- Break your solution into small, self-contained modules in separate .py files.
-- Each module should be minimal and focused on a single responsibility, small enough to \
-reason about, test, and reuse independently.
-- Write and run a test script for each module BEFORE composing them together. Verify each \
-piece works in isolation. The tests should play out the modules in the actual environment \
-if possible, verifying the conditions before and after execution and ensuring these match \
-the expectations, under multiple conditions and edge cases, and should not just rely \
-on mock objects or simplified assumptions.
-- Your final `approach.py` should import from these modules and compose them into the \
-complete solution. Keep `approach.py` itself as thin as possible, it should primarily \
-orchestrate your tested modules.
-- Prefer many small files over one large file. If a function could be useful in multiple \
-contexts, it belongs in its own module.
-IMPORTANT: be careful about repeated behavior! If an action or strategy in your \
-approach fails, you should design your code to avoid repeating that failure.
-"""
-
-_PROMPT_WITH_DESCRIPTION = """\
-You are writing an approach for the environment described below.
-
-Your approach should be general enough to solve any instance of this environment (env.reset()), \
-but it does NOT need to be adaptable to different other environments.
-
-{env_description}
-{geometry_prompt}
-{interface_spec}
-{modular_code_prompt}\
-"""
-
-_PROMPT_WITH_SOURCE = """\
-Read the environment source files in this directory to understand the state \
-type, action space, and dynamics.
-{interface_spec}
-{modular_code_prompt}\
-"""
-
-_PROMPT_BLACKBOX = """\
-You are writing an approach for an environment that you can only access as \
-a black box.
-
-Your approach should be general enough to solve any instance of this \
-environment (each reset gives a new instance), but it does NOT need to be \
-adaptable to different other environments.
-{env_description_section}
-{blackbox_interaction_spec}
-{geometry_prompt}
-{interface_spec}
-{modular_code_prompt}\
-"""
-
-_BLACKBOX_DESCRIPTION_PREFIX = """\
-
-The environment is described below.
-
-"""
 
 
 class AgenticApproach(BaseApproach[_ObsType, _ActType]):
@@ -391,78 +124,51 @@ class AgenticApproach(BaseApproach[_ObsType, _ActType]):
             list(self._primitives), blackbox=self._blackbox
         )
 
-        if self._mcp_tools:
-            backend_name = self._backend_cfg["backend"]
-            tool_descs = mcp_tool_descriptions(backend_name, blackbox=self._blackbox)
-            mcp_lines = [
-                "\n\nYou also have MCP tools for visual debugging (they do NOT "
-                "affect your test scripts):\n",
-            ]
-            for name in self._mcp_tools:
-                if name in tool_descs:
-                    mcp_lines.append(f"- {tool_descs[name]}")
-            primitives_desc += "\n".join(mcp_lines)
+        primitives_desc += prompts.build_mcp_tool_lines(
+            mcp_tools=self._mcp_tools,
+            backend_name=self._backend_cfg["backend"],
+            blackbox=self._blackbox,
+        )
 
         python_exe = (
             DOCKER_PYTHON if self._container_backend != "local" else sys.executable
         )
-        interface_spec = _INTERFACE_SPEC.format(
+        interface_spec = prompts.build_interface_spec(
+            template=prompts.AGENTIC_INTERFACE_SPEC,
             python_executable=python_exe,
             primitives_description=primitives_desc,
+            blackbox=self._blackbox,
         )
-        if not self._blackbox:
-            interface_spec += _INSPECT_SOURCE_SUFFIX.format(
-                python_executable=python_exe
-            )
 
-        modular = _MODULAR_CODE_PROMPT if self._modular_code_prompt else ""
-
-        if self._blackbox:
-            env_description_section = ""
-            if self._env_description_path is not None:
-                env_desc = Path(self._env_description_path).read_text(encoding="utf-8")
-                env_description_section = _BLACKBOX_DESCRIPTION_PREFIX + env_desc + "\n"
-            geometry = _GEOMETRY_PROMPT if self._geometry_prompt else ""
-            prompt = _PROMPT_BLACKBOX.format(
-                env_description_section=env_description_section,
-                blackbox_interaction_spec=_BLACKBOX_INTERACTION_SPEC,
-                geometry_prompt=geometry,
-                interface_spec=interface_spec,
-                modular_code_prompt=modular,
+        env_description: str | None = None
+        if self._env_description_path is not None:
+            env_description = Path(self._env_description_path).read_text(
+                encoding="utf-8"
             )
-        elif self._env_description_path is not None:
-            env_desc = Path(self._env_description_path).read_text(encoding="utf-8")
-            geometry = _GEOMETRY_PROMPT if self._geometry_prompt else ""
-            prompt = _PROMPT_WITH_DESCRIPTION.format(
-                env_description=env_desc,
-                geometry_prompt=geometry,
-                modular_code_prompt=modular,
-                interface_spec=interface_spec,
-            )
-        else:
-            prompt = _PROMPT_WITH_SOURCE.format(
-                modular_code_prompt=modular,
-                interface_spec=interface_spec,
-            )
+        prompt = prompts.build_agentic_prompt(
+            blackbox=self._blackbox,
+            interface_spec=interface_spec,
+            geometry=self._geometry_prompt,
+            modular_code=self._modular_code_prompt,
+            env_description=env_description,
+        )
 
         docker_config: DockerSandboxConfig | None = None
         apptainer_config: ApptainerSandboxConfig | None = None
         config: SandboxConfig | None = None
-        system_prompt = _SYSTEM_PROMPT_BLACKBOX if self._blackbox else _SYSTEM_PROMPT
+        system_prompt = prompts.build_system_prompt(
+            intro=(
+                prompts.AGENTIC_INTRO_BLACKBOX
+                if self._blackbox
+                else prompts.AGENTIC_INTRO
+            ),
+            blackbox=self._blackbox,
+            backend_name=self._backend_cfg["backend"],
+            mcp_tools=self._mcp_tools,
+        )
         init_files: dict[str, Path] = {}
         if self._blackbox:
             init_files["env_client.py"] = ENV_CLIENT_SRC
-        backend_name = self._backend_cfg["backend"]
-        if backend_name == "opencode":
-            system_prompt += OPENCODE_PROMPT_SUFFIX
-        else:
-            system_prompt += CLAUDE_PROMPT_SUFFIX
-        if self._mcp_tools:
-            system_prompt += (
-                MCP_TOOLS_SYSTEM_PROMPT_SUFFIX_BLACKBOX
-                if self._blackbox
-                else MCP_TOOLS_SYSTEM_PROMPT_SUFFIX
-            )
 
         if self._container_backend == "docker":
             docker_config = DockerSandboxConfig(

--- a/src/robocode/approaches/agentic_approach.py
+++ b/src/robocode/approaches/agentic_approach.py
@@ -134,7 +134,8 @@ class AgenticApproach(BaseApproach[_ObsType, _ActType]):
             DOCKER_PYTHON if self._container_backend != "local" else sys.executable
         )
         interface_spec = prompts.build_interface_spec(
-            template=prompts.AGENTIC_INTERFACE_SPEC,
+            class_interface=prompts.AGENTIC_CLASS_INTERFACE,
+            run_commands=prompts.AGENTIC_RUN_COMMANDS,
             python_executable=python_exe,
             primitives_description=primitives_desc,
             blackbox=self._blackbox,

--- a/src/robocode/approaches/agentic_cdl_approach.py
+++ b/src/robocode/approaches/agentic_cdl_approach.py
@@ -172,7 +172,8 @@ class AgenticCDLApproach(BaseApproach[_ObsType, _ActType]):
             DOCKER_PYTHON if self._container_backend != "local" else sys.executable
         )
         interface_spec = prompts.build_interface_spec(
-            template=prompts.CDL_INTERFACE_SPEC,
+            class_interface=prompts.CDL_CLASS_INTERFACE,
+            run_commands=prompts.CDL_RUN_COMMANDS,
             python_executable=python_exe,
             primitives_description=primitives_desc,
             blackbox=self._blackbox,

--- a/src/robocode/approaches/agentic_cdl_approach.py
+++ b/src/robocode/approaches/agentic_cdl_approach.py
@@ -196,7 +196,6 @@ class AgenticCDLApproach(BaseApproach[_ObsType, _ActType]):
             blackbox=self._blackbox,
             backend_name=self._backend_cfg["backend"],
             mcp_tools=self._mcp_tools,
-            extra_tail=prompts.CDL_SYSTEM_TOKEN_BUDGET,
         )
 
         docker_config: DockerSandboxConfig | None = None

--- a/src/robocode/approaches/agentic_cdl_approach.py
+++ b/src/robocode/approaches/agentic_cdl_approach.py
@@ -21,22 +21,14 @@ from typing import Any, TypeVar
 from gymnasium.spaces import Space
 from omegaconf import DictConfig
 
+from robocode import prompts
 from robocode.approaches.base_approach import BaseApproach
-from robocode.mcp import (
-    MCP_TOOLS_SYSTEM_PROMPT_SUFFIX,
-    MCP_TOOLS_SYSTEM_PROMPT_SUFFIX_BLACKBOX,
-    mcp_tool_descriptions,
-)
 from robocode.primitives import (
     blackbox_primitive_manifest,
     format_primitives_description,
 )
 from robocode.utils.apptainer_sandbox import ApptainerSandboxConfig
-from robocode.utils.backends import (
-    CLAUDE_PROMPT_SUFFIX,
-    OPENCODE_PROMPT_SUFFIX,
-    create_backend,
-)
+from robocode.utils.backends import create_backend
 from robocode.utils.docker_sandbox import (
     DOCKER_PYTHON,
     DockerSandboxConfig,
@@ -56,377 +48,6 @@ logger = logging.getLogger(__name__)
 
 _ObsType = TypeVar("_ObsType")
 _ActType = TypeVar("_ActType")
-
-# ---------------------------------------------------------------------------
-# Prompts
-# ---------------------------------------------------------------------------
-
-_SYSTEM_PROMPT = (
-    "You are an expert at writing purely imperative, feedforward policies for "
-    "gymnasium environments. You decompose tasks into a fixed sequence of "
-    "BEHAVIORS, where each behavior is a small, self-contained module with an "
-    "explicit precondition, subgoal, and a deterministic policy body. "
-    "IMPORTANT: You MUST write ALL files (approach.py, test scripts, etc.) "
-    "to the current working directory using RELATIVE paths only. "
-    "Never use absolute paths when writing files. "
-    "IMPORTANT: Write code often to approach.py as you iterate. You may be "
-    "interrupted at any time, so you should make sure that approach.py is "
-    "your best current attempt at all times. "
-    "VERSION CONTROL: This directory is a git repo. After each meaningful "
-    "change to approach.py or supporting modules, run "
-    "`git add -A && git commit -m '<describe what you changed and why>'`. "
-    "Commit often, do not batch everything into one final commit. "
-    "You should commit the approach every time before you test it in the environment. "
-    "Use subagents to explore source code in parallel, e.g. spawn "
-    "subagents to read environment dynamics, reward functions, and object "
-    "types simultaneously rather than sequentially. "
-    "TOKEN BUDGET: You have a limited output-token budget per turn. Be concise. "
-    "Do NOT write lengthy prose reasoning about geometry or arithmetic — put "
-    "all numerical calculations in code (Python scripts or inline print "
-    "statements) and read the results. Your text should be SHORT: state what "
-    "you will do, then immediately write code. Never narrate step-by-step "
-    "arithmetic in text."
-)
-
-_SYSTEM_PROMPT_BLACKBOX = (
-    "You are an expert at writing purely imperative, feedforward policies for "
-    "gymnasium environments. You decompose tasks into a fixed sequence of "
-    "BEHAVIORS, where each behavior is a small, self-contained module with an "
-    "explicit precondition, subgoal, and a deterministic policy body. "
-    "The environment is a black box: its source code is not available, so "
-    "you will discover the dynamics, reward structure, and termination "
-    "conditions empirically by interacting with a live environment instance. "
-    "IMPORTANT: You MUST write ALL files (approach.py, test scripts, etc.) "
-    "to the current working directory using RELATIVE paths only. "
-    "Never use absolute paths when writing files. "
-    "IMPORTANT: Write code often to approach.py as you iterate. You may be "
-    "interrupted at any time, so you should make sure that approach.py is "
-    "your best current attempt at all times. "
-    "VERSION CONTROL: This directory is a git repo. After each meaningful "
-    "change to approach.py or supporting modules, run "
-    "`git add -A && git commit -m '<describe what you changed and why>'`. "
-    "Commit often, do not batch everything into one final commit. "
-    "You should commit the approach every time before you test it in the environment. "
-    "Use subagents to run exploration experiments in parallel, e.g. spawn "
-    "subagents to probe action effects, reward structure, and termination "
-    "conditions simultaneously rather than sequentially; each test script "
-    "gets its own fresh environment instance. "
-    "TOKEN BUDGET: You have a limited output-token budget per turn. Be concise. "
-    "Do NOT write lengthy prose reasoning about geometry or arithmetic — put "
-    "all numerical calculations in code (Python scripts or inline print "
-    "statements) and read the results. Your text should be SHORT: state what "
-    "you will do, then immediately write code. Never narrate step-by-step "
-    "arithmetic in text."
-)
-
-_CDL_DECOMPOSITION_PROMPT = """\
-
-BEFORE writing any low-level code, you MUST first reason about the HIGH-LEVEL \
-BEHAVIOR DECOMPOSITION of this task. Think of the task as a fixed sequence of \
-phases/behaviors that, when executed in order, solve the environment.
-
-For each behavior, explicitly define:
-1. **Name**: A descriptive name.
-2. **Precondition** (``initializable(state) -> bool``): Under what state conditions can \
-this behavior start? This is a boolean predicate on the observation. This should always \
-be true after the previous behavior's subgoal is achieved. For the initial behavior, \
-it should be satisfied by the initial state of the environment (env.reset()). \
-3. **Subgoal** (``terminated(state) -> bool``): What condition must be true for this \
-behavior to be considered complete? Another boolean predicate.
-4. **Policy body**: A high-level description of the strategy (e.g., "move above the \
-object, lower the arm, activate vacuum, retract arm").
-5. **Why this ordering**: Explain why the previous behavior's subgoal satisfies this \
-behavior's precondition.
-
-The approach should determine which behavior to start from by checking preconditions \
-BACKWARDS from the last behavior. If the last behavior's precondition is already \
-satisfied, skip all earlier behaviors.
-
-Write out your full decomposition BEFORE writing any code. This decomposition is the \
-most important part of your solution.
-"""
-
-_BEHAVIOR_IMPLEMENTATION_PROMPT = """\
-
-IMPORTANT: You MUST follow this EXACT file structure. Do NOT put everything in \
-one file. Do NOT put helper functions inside approach.py or behavior files.
-
-Required files:
-- ``obs_helpers.py`` — ALL functions that parse/interpret the observation vector. \
-This includes extracting object positions, computing geometric predicates, \
-and any named constants for observation indices. \
-Every "magic number" related to observation parsing MUST be a named constant here. \
-{obs_inspection_note}\
-{obs_helpers_note}
-- ``act_helpers.py`` — ALL functions that help generate actions. This includes \
-waypoint interpolation, action clipping, proportional controllers, etc. \
-Every "magic number" related to action generation (step limits, arm extension \
-rate, etc.) MUST be a named constant here. \
-{act_helpers_note}
-- ``behaviors.py`` — ALL behavior classes. Each behavior inherits from the \
-``Behavior`` base class (provided in ``behavior.py``). Behaviors import from \
-``obs_helpers`` and ``act_helpers`` but contain NO magic numbers themselves.
-- ``approach.py`` — ONLY the ``GeneratedApproach`` class. It imports behaviors \
-from ``behaviors.py`` and does NOTHING except: (1) in ``reset``, determine \
-the behavior sequence by checking ``initializable`` backwards, (2) in \
-``get_action``, delegate to the current behavior's ``step()`` and advance \
-when ``terminated()`` returns True. NO control logic, NO observation parsing, \
-NO action generation in this file.
-
-CRITICAL RULES:
-- NO magic numbers anywhere except as named constants in obs_helpers.py or \
-act_helpers.py. Every numeric literal (tolerances, offsets, indices, limits) \
-must have a descriptive name. ``0.05`` is WRONG; ``DX_LIMIT = 0.05`` is RIGHT.
-- Behaviors must use obs_helpers for ALL observation access. Never index into \
-the observation array directly inside a behavior — use named extraction \
-functions like ``extract_robot(obs)``, ``extract_rect(obs, "target_block")``.
-- approach.py must be THIN. Its reset() only builds a behavior deque using \
-backward precondition checking. Its get_action() only delegates to the \
-current behavior and advances on termination. Nothing else.
-
-A ``Behavior`` base class is provided in your working directory as ``behavior.py``:
-
-```python
-from behavior import Behavior
-
-class MyBehavior(Behavior):
-    def reset(self, x):
-        \"\"\"Initialize internal state for a new execution.\"\"\"
-        ...
-    def initializable(self, x) -> bool:
-        \"\"\"Return True if the precondition is met.\"\"\"
-        ...
-    def terminated(self, x) -> bool:
-        \"\"\"Return True if the subgoal has been achieved.\"\"\"
-        ...
-    def step(self, x):
-        \"\"\"Return the next action.\"\"\"
-        ...
-```
-
-Testing protocol — for EACH behavior, write and run a test script that:
-1. Resets the environment (try multiple seeds: 0, 1, 2, 3, 42).
-2. If needed, manually sets up the state so the behavior's precondition is met \
-(e.g., move obstructions away for a "pick" behavior).
-3. Calls ``behavior.reset(state)``, then loops ``behavior.step(state)`` until \
-``behavior.terminated(state)`` returns True.
-4. **Asserts** that the subgoal is actually achieved and the behavior completes \
-within a reasonable number of steps.
-5. Only after ALL behaviors pass their individual tests, compose them into the \
-final ``approach.py``.
-
-IMPORTANT: If a behavior's action plan is exhausted but the subgoal is not \
-reached, re-generate the plan from the current observation instead of \
-repeating the same failed plan.
-"""
-
-_OBS_INSPECTION_NOTE = """\
-BEFORE writing this file, you MUST run: \
-``feats = env.unwrapped.observation_space.devectorize(obs)`` \
-to inspect the observation structure. This returns a dictionary mapping \
-feature names to their values, so you can see exactly what each part of \
-the observation vector represents. Use this to determine the correct \
-indices, feature names, and semantics — do NOT guess the observation layout. \
-"""
-
-_OBS_INSPECTION_NOTE_BLACKBOX = """\
-BEFORE writing this file, you MUST map the observation layout empirically \
-with env_client: reset with several seeds, perturb the state with \
-``set_state``, and observe which observation entries change as you act. \
-Do NOT guess the observation layout. \
-"""
-
-_INTERFACE_SPEC = """\
-Write `approach.py` containing a class `GeneratedApproach` with the following \
-interface:
-
-```python
-from collections import deque
-from behaviors import BehaviorA, BehaviorB  # your behavior classes
-
-class GeneratedApproach:
-    def __init__(self, action_space, observation_space, primitives):
-        self._behaviors = deque()
-        self._current = None
-
-    def reset(self, state, info):
-        # Determine behavior sequence by checking preconditions BACKWARDS.
-        # This is the ONLY logic allowed here.
-        b_last = BehaviorB()
-        b_first = BehaviorA()
-        if b_last.initializable(state):
-            self._behaviors = deque([b_last])
-        else:
-            self._behaviors = deque([b_first, b_last])
-        self._current = self._behaviors.popleft()
-        self._current.reset(state)
-
-    def get_action(self, state):
-        # Advance to next behavior when subgoal reached.
-        if self._current.terminated(state) and self._behaviors:
-            self._current = self._behaviors.popleft()
-            self._current.reset(state)
-        return self._current.step(state)
-```
-
-The ``reset`` method MUST ONLY build a behavior deque using backward \
-precondition checking. The ``get_action`` method MUST ONLY delegate to the \
-current behavior and advance on termination. No other logic is allowed in \
-approach.py — all intelligence lives in the behaviors and helpers.
-
-{primitives_description}
-
-Write the best approach you can — ideally one that solves the environment \
-optimally. Your `approach.py` should only use packages available in the \
-current environment.
-
-IMPORTANT: Use `{python_executable}` to run your test scripts, since that \
-interpreter has all required packages installed. For example:
-```bash
-{python_executable} test_behavior_[behavior_name].py
-{python_executable} test_approach.py
-```\
-"""
-
-_INSPECT_SOURCE_SUFFIX = """
-
-You can also inspect the source code of any imported module to understand \
-the environment's dynamics in detail (reward function, transition logic, \
-termination conditions, etc.). To locate a module's source file:
-```bash
-{python_executable} -c "import some_module; print(some_module.__file__)"
-```
-Then read the source to inform your approach.\
-"""
-
-_BLACKBOX_INTERACTION_SPEC = """\
-The environment is a BLACK BOX. You CANNOT read its source code; it is not \
-available anywhere on this machine. A live environment server is running. \
-Interact with it through `env_client.py` in your working directory:
-
-```python
-from env_client import make_env
-
-env = make_env()  # fresh environment instance per call
-obs, info = env.reset(seed=0)
-obs, reward, terminated, truncated, info = env.step(action)
-state = env.get_state()  # numpy snapshot of the full environment state
-env.set_state(state)  # restore a snapshot
-env.close()
-```
-
-`env.observation_space` and `env.action_space` expose `shape`, `low`, \
-`high`, `dtype`, and `sample()`; the same metadata is in `env_spaces.json`. \
-`env.max_steps` is the episode step limit used at evaluation time.
-
-`env.make_primitives()` returns the SAME `primitives` dict the evaluation \
-harness passes to `GeneratedApproach.__init__` (env-dependent primitives run \
-on the host); use it in test scripts so behaviors exercise the real \
-primitives.
-
-You can also call `env.observation_space.devectorize(obs)` to get an \
-object-centric view of an observation. It returns an `ObjectCentricState` \
-with `get_object_names()`, `get_object_from_name(name)`, `get_objects(type)`, \
-and `get(obj, feature)`; iterate objects via `get_objects(...)`, NOT \
-`for obj in ocs`. Call `env.observation_space.vectorize(ocs)` to go back to a \
-flat array. The evaluation harness passes the SAME `observation_space` to \
-`GeneratedApproach`, so `observation_space.devectorize(obs)` works identically \
-there, and `approach.py` can use it directly.
-
-Parallel test scripts are fine: every `make_env()` call creates an \
-independent environment instance. Use `set_state` to put the environment \
-into the state a behavior's precondition requires when testing it in \
-isolation.
-
-Start by exploring systematically: reset with several seeds, apply \
-controlled actions, and study how the observation vector changes to \
-identify what each dimension means and how actions affect the state.
-
-CRITICAL: `approach.py` itself must NOT import `env_client`. It will be \
-evaluated against the real environment by a separate harness that calls \
-`reset(state, info)` and `get_action(state)` directly. Use `env_client` \
-ONLY in test and exploration scripts.\
-"""
-
-_GEOMETRY_PROMPT = """\
-
-BEFORE writing any code, briefly describe (in 5-10 bullet points) the key \
-geometric relationships in this environment:
-- What shapes are involved and how they interact spatially.
-- What motions/transformations are needed (translate, rotate, extend arm).
-- What collision constraints exist (clearances, boundaries).
-
-Keep this analysis SHORT and QUALITATIVE — no numbers, no arithmetic. \
-If you need to compute specific positions or offsets, write a Python \
-script to do it and print the results. NEVER do arithmetic in text.
-"""
-
-_INITIAL_HELPERS_PROMPT = """\
-
-IMPORTANT: You have been provided with initial versions of ``obs_helpers.py`` \
-and ``act_helpers.py`` in your working directory. These files contain CORRECT \
-observation parsing (feature indices, object layout, extraction functions) and \
-action generation helpers (waypoint interpolation, action limits) for this \
-environment. You MUST use them as your starting point:
-
-- **DO NOT** rewrite observation parsing from scratch — the provided \
-``obs_helpers.py`` already has the correct feature layout and extraction \
-functions.
-- **DO NOT** rewrite action helpers from scratch — the provided \
-``act_helpers.py`` already has correct action limits and waypoint utilities.
-- You MAY and SHOULD add new helper functions, constants, or geometric \
-predicates to these files as needed for your behaviors.
-- You MAY modify existing functions if you need to extend them, but do not \
-change the core observation layout or action format — they are correct.
-
-Start by reading these files to understand the observation structure and \
-available utilities before writing any behaviors.
-"""
-
-_PROMPT_WITH_DESCRIPTION = """\
-You are writing a behavior-based approach for the environment described below.
-
-Your approach should be general enough to solve any instance of this environment \
-(env.reset()), but it does NOT need to be adaptable to different other environments.
-
-{env_description}
-{initial_helpers_prompt}
-{geometry_prompt}
-{cdl_decomposition_prompt}
-{interface_spec}
-{behavior_implementation_prompt}\
-"""
-
-_PROMPT_WITH_SOURCE = """\
-Read the environment source files in this directory to understand the state \
-type, action space, and dynamics.
-{initial_helpers_prompt}
-{cdl_decomposition_prompt}
-{interface_spec}
-{behavior_implementation_prompt}\
-"""
-
-_PROMPT_BLACKBOX = """\
-You are writing a behavior-based approach for an environment that you can \
-only access as a black box.
-
-Your approach should be general enough to solve any instance of this \
-environment (each reset gives a new instance), but it does NOT need to be \
-adaptable to different other environments.
-{env_description_section}
-{blackbox_interaction_spec}
-{initial_helpers_prompt}
-{geometry_prompt}
-{cdl_decomposition_prompt}
-{interface_spec}
-{behavior_implementation_prompt}\
-"""
-
-_BLACKBOX_DESCRIPTION_PREFIX = """\
-
-The environment is described below.
-
-"""
 
 
 class AgenticCDLApproach(BaseApproach[_ObsType, _ActType]):
@@ -541,99 +162,42 @@ class AgenticCDLApproach(BaseApproach[_ObsType, _ActType]):
             list(self._primitives), blackbox=self._blackbox
         )
 
-        if self._mcp_tools:
-            backend_name = self._backend_cfg["backend"]
-            tool_descs = mcp_tool_descriptions(backend_name, blackbox=self._blackbox)
-            mcp_lines = [
-                "\n\nYou also have MCP tools for visual debugging (they do NOT "
-                "affect your test scripts):\n",
-            ]
-            for name in self._mcp_tools:
-                if name in tool_descs:
-                    mcp_lines.append(f"- {tool_descs[name]}")
-            primitives_desc += "\n".join(mcp_lines)
+        primitives_desc += prompts.build_mcp_tool_lines(
+            mcp_tools=self._mcp_tools,
+            backend_name=self._backend_cfg["backend"],
+            blackbox=self._blackbox,
+        )
 
         python_exe = (
             DOCKER_PYTHON if self._container_backend != "local" else sys.executable
         )
-        interface_spec = _INTERFACE_SPEC.format(
+        interface_spec = prompts.build_interface_spec(
+            template=prompts.CDL_INTERFACE_SPEC,
             python_executable=python_exe,
             primitives_description=primitives_desc,
-        )
-        if not self._blackbox:
-            interface_spec += _INSPECT_SOURCE_SUFFIX.format(
-                python_executable=python_exe
-            )
-
-        geometry = _GEOMETRY_PROMPT if self._geometry_prompt else ""
-        initial_helpers = _INITIAL_HELPERS_PROMPT if has_initial_helpers else ""
-
-        if has_initial_helpers:
-            provided_note = (
-                "This file is ALREADY PROVIDED in your working directory with "
-                "correct parsing logic. Read it first, then extend it with any "
-                "additional helpers you need. Do NOT rewrite it from scratch."
-            )
-            obs_helpers_note = provided_note
-            act_helpers_note = provided_note
-        else:
-            obs_helpers_note = ""
-            act_helpers_note = ""
-
-        behavior_impl_prompt = _BEHAVIOR_IMPLEMENTATION_PROMPT.format(
-            obs_inspection_note=(
-                _OBS_INSPECTION_NOTE_BLACKBOX
-                if self._blackbox
-                else _OBS_INSPECTION_NOTE
-            ),
-            obs_helpers_note=obs_helpers_note,
-            act_helpers_note=act_helpers_note,
+            blackbox=self._blackbox,
         )
 
-        if self._blackbox:
-            env_description_section = ""
-            if self._env_description_path is not None:
-                env_desc = Path(self._env_description_path).read_text(encoding="utf-8")
-                env_description_section = _BLACKBOX_DESCRIPTION_PREFIX + env_desc + "\n"
-            prompt = _PROMPT_BLACKBOX.format(
-                env_description_section=env_description_section,
-                blackbox_interaction_spec=_BLACKBOX_INTERACTION_SPEC,
-                initial_helpers_prompt=initial_helpers,
-                geometry_prompt=geometry,
-                cdl_decomposition_prompt=_CDL_DECOMPOSITION_PROMPT,
-                interface_spec=interface_spec,
-                behavior_implementation_prompt=behavior_impl_prompt,
+        env_description: str | None = None
+        if self._env_description_path is not None:
+            env_description = Path(self._env_description_path).read_text(
+                encoding="utf-8"
             )
-        elif self._env_description_path is not None:
-            env_desc = Path(self._env_description_path).read_text(encoding="utf-8")
-            prompt = _PROMPT_WITH_DESCRIPTION.format(
-                env_description=env_desc,
-                geometry_prompt=geometry,
-                cdl_decomposition_prompt=_CDL_DECOMPOSITION_PROMPT,
-                interface_spec=interface_spec,
-                behavior_implementation_prompt=behavior_impl_prompt,
-                initial_helpers_prompt=initial_helpers,
-            )
-        else:
-            prompt = _PROMPT_WITH_SOURCE.format(
-                initial_helpers_prompt=initial_helpers,
-                cdl_decomposition_prompt=_CDL_DECOMPOSITION_PROMPT,
-                interface_spec=interface_spec,
-                behavior_implementation_prompt=behavior_impl_prompt,
-            )
+        prompt = prompts.build_cdl_prompt(
+            blackbox=self._blackbox,
+            interface_spec=interface_spec,
+            geometry=self._geometry_prompt,
+            env_description=env_description,
+            has_initial_helpers=has_initial_helpers,
+        )
 
-        system_prompt = _SYSTEM_PROMPT_BLACKBOX if self._blackbox else _SYSTEM_PROMPT
-        backend_name = self._backend_cfg["backend"]
-        if backend_name == "opencode":
-            system_prompt += OPENCODE_PROMPT_SUFFIX
-        else:
-            system_prompt += CLAUDE_PROMPT_SUFFIX
-        if self._mcp_tools:
-            system_prompt += (
-                MCP_TOOLS_SYSTEM_PROMPT_SUFFIX_BLACKBOX
-                if self._blackbox
-                else MCP_TOOLS_SYSTEM_PROMPT_SUFFIX
-            )
+        system_prompt = prompts.build_system_prompt(
+            intro=(prompts.CDL_INTRO_BLACKBOX if self._blackbox else prompts.CDL_INTRO),
+            blackbox=self._blackbox,
+            backend_name=self._backend_cfg["backend"],
+            mcp_tools=self._mcp_tools,
+            extra_tail=prompts.CDL_SYSTEM_TOKEN_BUDGET,
+        )
 
         docker_config: DockerSandboxConfig | None = None
         apptainer_config: ApptainerSandboxConfig | None = None

--- a/src/robocode/approaches/llm_genplan_approach.py
+++ b/src/robocode/approaches/llm_genplan_approach.py
@@ -22,6 +22,7 @@ import gymnasium
 from gymnasium.spaces import Space
 from omegaconf import DictConfig, OmegaConf
 
+from robocode import prompts
 from robocode.approaches.base_approach import BaseApproach
 from robocode.primitives import format_primitives_description
 from robocode.utils.apptainer_sandbox import _DEFAULT_SIF, run_genplan_in_apptainer
@@ -36,37 +37,6 @@ logger = logging.getLogger(__name__)
 
 _ObsType = TypeVar("_ObsType")
 _ActType = TypeVar("_ActType")
-
-_INTERFACE_SPEC = """\
-Implement the strategy as a Python class named `GeneratedApproach` in a single \
-code block:
-
-```python
-class GeneratedApproach:
-    def __init__(self, action_space, observation_space, primitives):
-        \"\"\"action_space and observation_space are the gym spaces above.\"\"\"
-        ...
-
-    def reset(self, state, info):
-        \"\"\"Called at the start of each episode with the initial observation.\"\"\"
-        ...
-
-    def get_action(self, state):
-        \"\"\"Return a valid action (matching action_space) for this state.\"\"\"
-        ...
-```
-
-`state` is a numpy observation matching the observation space. `get_action` is \
-called every step and must return an action inside the action space. The class \
-may keep internal state between calls (e.g. a precomputed plan). Return ONLY \
-the code block; do not write tests or explanations."""
-
-_SUMMARY_PROMPT = "Write a short summary of this environment in words."
-
-_STRATEGY_PROMPT = (
-    "There is a simple strategy for solving all instances of this environment "
-    "without using search. What is that strategy?"
-)
 
 
 class LLMGenPlanApproach(BaseApproach[_ObsType, _ActType]):
@@ -179,14 +149,19 @@ class LLMGenPlanApproach(BaseApproach[_ObsType, _ActType]):
                     "content": (
                         f"{context}\n\nThere is a simple strategy for solving "
                         "all instances of this environment without using "
-                        f"search. {_INTERFACE_SPEC}"
+                        f"search. {prompts.GENPLAN_INTERFACE_SPEC}"
                     ),
                 }
             )
         else:
-            self._exchange(messages, f"{context}\n\n{_SUMMARY_PROMPT}", sandbox_dir, 0)
-            self._exchange(messages, _STRATEGY_PROMPT, sandbox_dir, 1)
-            messages.append({"role": "user", "content": _INTERFACE_SPEC})
+            self._exchange(
+                messages,
+                f"{context}\n\n{prompts.GENPLAN_SUMMARY_PROMPT}",
+                sandbox_dir,
+                0,
+            )
+            self._exchange(messages, prompts.GENPLAN_STRATEGY_PROMPT, sandbox_dir, 1)
+            messages.append({"role": "user", "content": prompts.GENPLAN_INTERFACE_SPEC})
         return messages
 
     def _driver_config(self, completion: dict[str, Any]) -> dict[str, Any]:
@@ -419,10 +394,10 @@ _FENCE = r"```[ \t]*[a-zA-Z0-9]*[ \t]*\r?\n"
 def _parse_python_code(response: str) -> str:
     """Extract the GeneratedApproach implementation from a model response.
 
-    Models sometimes emit an illustrative snippet before the real implementation,
-    so prefer the last fenced block that defines GeneratedApproach, then the last
-    fenced block. If the response was truncated at the token limit (an opening
-    fence with no close), recover the code after the last opening fence.
+    Models sometimes emit an illustrative snippet before the real implementation, so
+    prefer the last fenced block that defines GeneratedApproach, then the last fenced
+    block. If the response was truncated at the token limit (an opening fence with no
+    close), recover the code after the last opening fence.
     """
     blocks = [b.strip() for b in re.findall(_FENCE + r"(.*?)```", response, re.DOTALL)]
     blocks = [b for b in blocks if b]

--- a/src/robocode/prompts.py
+++ b/src/robocode/prompts.py
@@ -300,6 +300,7 @@ _AGENTIC_WITH_DESCRIPTION = """\
 
 _AGENTIC_WITH_SOURCE = """\
 {source_opener}
+{geometry_prompt}
 {interface_spec}
 {modular_code_prompt}\
 """
@@ -519,6 +520,7 @@ _CDL_WITH_DESCRIPTION = """\
 _CDL_WITH_SOURCE = """\
 {source_opener}
 {initial_helpers_prompt}
+{geometry_prompt}
 {cdl_decomposition_prompt}
 {interface_spec}
 {behavior_implementation_prompt}\
@@ -699,6 +701,7 @@ def build_agentic_prompt(
         )
     return _AGENTIC_WITH_SOURCE.format(
         source_opener=_SOURCE_OPENER,
+        geometry_prompt=geometry_prompt,
         modular_code_prompt=modular,
         interface_spec=interface_spec,
     )
@@ -749,6 +752,7 @@ def build_cdl_prompt(
     return _CDL_WITH_SOURCE.format(
         source_opener=_SOURCE_OPENER,
         initial_helpers_prompt=initial_helpers,
+        geometry_prompt=geometry_prompt,
         cdl_decomposition_prompt=CDL_DECOMPOSITION_PROMPT,
         interface_spec=interface_spec,
         behavior_implementation_prompt=behavior_impl_prompt,

--- a/src/robocode/prompts.py
+++ b/src/robocode/prompts.py
@@ -506,36 +506,33 @@ CDL_HELPERS_PROVIDED_NOTE = (
     "additional helpers you need. Do NOT rewrite it from scratch."
 )
 
-_CDL_WITH_DESCRIPTION = """\
-{scaffold_intro}
+_CDL_WITH_DESCRIPTION = (
+    "{scaffold_intro}\n\n"
+    "{env_description}\n"
+    "{initial_helpers_prompt}{geometry_prompt}{cdl_decomposition_prompt}\n"
+    "{interface_spec}\n"
+    "{behavior_implementation_prompt}"
+)
 
-{env_description}
-{initial_helpers_prompt}
-{geometry_prompt}
-{cdl_decomposition_prompt}
-{interface_spec}
-{behavior_implementation_prompt}\
-"""
+# The optional initial-helpers and geometry fragments each begin with their own
+# newline, so they are concatenated directly rather than each occupying its own
+# template line; that keeps a single blank line between sections instead of
+# accumulating blank lines when a fragment is empty.
+_CDL_WITH_SOURCE = (
+    "{source_opener}\n"
+    "{initial_helpers_prompt}{geometry_prompt}{cdl_decomposition_prompt}\n"
+    "{interface_spec}\n"
+    "{behavior_implementation_prompt}"
+)
 
-_CDL_WITH_SOURCE = """\
-{source_opener}
-{initial_helpers_prompt}
-{geometry_prompt}
-{cdl_decomposition_prompt}
-{interface_spec}
-{behavior_implementation_prompt}\
-"""
-
-_CDL_BLACKBOX = """\
-{scaffold_intro}
-{env_description_section}
-{blackbox_interaction_spec}
-{initial_helpers_prompt}
-{geometry_prompt}
-{cdl_decomposition_prompt}
-{interface_spec}
-{behavior_implementation_prompt}\
-"""
+_CDL_BLACKBOX = (
+    "{scaffold_intro}\n"
+    "{env_description_section}\n"
+    "{blackbox_interaction_spec}\n"
+    "{initial_helpers_prompt}{geometry_prompt}{cdl_decomposition_prompt}\n"
+    "{interface_spec}\n"
+    "{behavior_implementation_prompt}"
+)
 
 # ---------------------------------------------------------------------------
 # LLMGenPlanApproach (non-agentic baseline) fragments
@@ -617,9 +614,9 @@ def build_interface_spec(
     primitives_description: str,
     blackbox: bool,
 ) -> str:
-    """Fill the shared interface-spec template with an approach's class contract and
-    run commands; append the inspect-source suffix when the agent can read env source
-    (non-blackbox)."""
+    """Fill the shared interface-spec template with an approach's class contract and run
+    commands; append the inspect-source suffix when the agent can read env source (non-
+    blackbox)."""
     interface_spec = INTERFACE_SPEC_TEMPLATE.format(
         class_interface=class_interface,
         primitives_description=primitives_description,

--- a/src/robocode/prompts.py
+++ b/src/robocode/prompts.py
@@ -86,9 +86,9 @@ SYSTEM_SUBAGENTS_BLACKBOX = (
     "gets its own fresh environment instance."
 )
 
-# CDL-only system-prompt tail (passed as extra_tail). Leading space joins it to
-# the subagent sentence above.
-CDL_SYSTEM_TOKEN_BUDGET = (
+# Token-budget guidance appended to every system prompt. Leading space joins it
+# to the subagent sentence above.
+SYSTEM_TOKEN_BUDGET = (
     " TOKEN BUDGET: You have a limited output-token budget per turn. Be concise. "
     "Do NOT write lengthy prose reasoning about geometry or arithmetic — put "
     "all numerical calculations in code (Python scripts or inline print "
@@ -231,60 +231,18 @@ interpreter has all required packages installed. For example:
 ```\
 """
 
-AGENTIC_GEOMETRY_PROMPT = """\
+# Geometric-reasoning prompt, shared by both approaches.
+GEOMETRY_PROMPT = """\
 
-BEFORE writing any code, you MUST first reason in detail about the geometry of this environment. \
-Think carefully and qualitatively about spatial relationships, shapes, motions, and constraints.
+BEFORE writing any code, briefly describe (in 5-10 bullet points) the key \
+geometric relationships in this environment:
+- What shapes are involved and how they interact spatially.
+- What motions/transformations are needed (translate, rotate, extend arm).
+- What collision constraints exist (clearances, boundaries).
 
-CRITICAL: Your geometric reasoning must be PURELY QUALITATIVE. Do NOT use any numbers AT ALL — \
-not in your reasoning, not in your thinking, not anywhere in your geometric analysis. This means \
-NO coordinates, NO distances, NO angles, NO dimensions, NO sizes, NO counts of objects, NO \
-thresholds, NO numeric constants, NO array indices, NO velocities, NO ratios, NO percentages. \
-Not even "2D" or "3D" — say "two-dimensional" or "three-dimensional" instead. If you catch \
-yourself about to write a number, stop and rephrase using purely relational, qualitative language. \
-Instead of saying "the object is at position (x, y)" say "the object is near the boundary". \
-Instead of "move 0.1 units" say "move a small step". Instead of "the angle is 90 degrees" say \
-"the surfaces are perpendicular".
-
-Your geometric reasoning should cover topics like:
-- What kinds of geometric shapes are involved (e.g. rectangles, circles, polygons, cuboids, \
-spheres, cylinders, capsules)? How do their shapes affect interactions — for instance, \
-rectangles tile differently than circles, spheres roll while cuboids don't, narrow corridors \
-between rectangular obstacles require precise alignment.
-- What are the key spatial relationships between objects? Reason about relative orientations \
-(parallel, perpendicular, oblique, aligned, tangent, skewed, transverse), relative positions \
-(adjacent, opposite, coplanar, collinear, concentric, coaxial, symmetric), and topological \
-relations (inside, outside, overlapping, enclosing, intersecting, touching, disjoint). Which \
-of these relationships matter for solving the task?
-- What geometric constraints exist? Are there boundaries, obstacles, containment relationships, \
-or clearance requirements? How do the shapes of obstacles create narrow passages, dead ends, \
-or open regions? Are surfaces flush or offset? Are relevant surfaces convex or concave?
-- What kind of motions or transformations are involved? Are objects translating, rotating, or \
-both? Are motions continuous or discrete? Does an object's shape affect how it can move \
-(e.g. a rectangle rotating requires more swept area than a circle of similar size)?
-- What makes a configuration "good" or "bad" geometrically? Think about reachability, \
-collision-freeness, coverage, proximity to goals.
-- What is the overall geometric strategy? For example:
-  - "The agent needs to navigate around obstacles to reach a goal region, so it must find a \
-path that threads between blocked areas while staying within bounds. When two rectangular \
-obstacles have parallel edges with a gap between them, the agent can pass through \
-perpendicular to those edges."
-  - "Objects must be packed tightly without overlapping, so the approach needs to find \
-placements where each new object fits into remaining gaps while respecting clearance from \
-existing objects. Rectangular objects can be aligned with parallel edges flush against each \
-other for dense packing, while circular objects leave unavoidable gaps."
-  - "The robot arm must move its end effector to a grasp pose, which means planning a \
-sequence of joint motions that avoids self-collision and keeps the kinematic chain valid. \
-The shape of the target object determines viable grasp orientations — a sphere can be \
-grasped from any direction, while a flat rectangular object requires approaching \
-perpendicular to one of its faces."
-  - "The agent must push an object toward a target, which requires approaching from the \
-opposite side so that the push direction is aligned with the line from object to goal. \
-A cylindrical object may roll unpredictably under pushes that are oblique to its axis."
-
-This qualitative geometric analysis should directly inform your code. Write your reasoning \
-out before you start coding. Do NOT skip this step. Remember: your geometric reasoning must \
-contain ZERO numbers. If any number appears in your geometric analysis, you have failed the task.
+Keep this analysis SHORT and QUALITATIVE — no numbers, no arithmetic. \
+If you need to compute specific positions or offsets, write a Python \
+script to do it and print the results. NEVER do arithmetic in text.
 """
 
 MODULAR_CODE_PROMPT = """\
@@ -513,19 +471,6 @@ interpreter has all required packages installed. For example:
 ```\
 """
 
-CDL_GEOMETRY_PROMPT = """\
-
-BEFORE writing any code, briefly describe (in 5-10 bullet points) the key \
-geometric relationships in this environment:
-- What shapes are involved and how they interact spatially.
-- What motions/transformations are needed (translate, rotate, extend arm).
-- What collision constraints exist (clearances, boundaries).
-
-Keep this analysis SHORT and QUALITATIVE — no numbers, no arithmetic. \
-If you need to compute specific positions or offsets, write a Python \
-script to do it and print the results. NEVER do arithmetic in text.
-"""
-
 CDL_INITIAL_HELPERS_PROMPT = """\
 
 IMPORTANT: You have been provided with initial versions of ``obs_helpers.py`` \
@@ -644,17 +589,16 @@ def build_system_prompt(
     blackbox: bool,
     backend_name: str,
     mcp_tools: tuple[str, ...] = (),
-    extra_tail: str = "",
 ) -> str:
     """Compose a coding-agent system prompt from shared fragments.
 
     ``intro`` is one of the composed intro constants (AGENTIC_INTRO[_BLACKBOX],
     CDL_INTRO[_BLACKBOX]). The shared file-discipline block, blackbox-aware
-    subagent guidance, optional ``extra_tail`` (CDL token budget), the
-    backend-specific suffix, and the optional MCP-tools suffix follow.
+    subagent guidance, token-budget guidance, the backend-specific suffix, and
+    the optional MCP-tools suffix follow.
     """
     subagents = SYSTEM_SUBAGENTS_BLACKBOX if blackbox else SYSTEM_SUBAGENTS
-    system_prompt = intro + SYSTEM_FILE_DISCIPLINE + subagents + extra_tail
+    system_prompt = intro + SYSTEM_FILE_DISCIPLINE + subagents + SYSTEM_TOKEN_BUDGET
     if backend_name == "opencode":
         system_prompt += OPENCODE_PROMPT_SUFFIX
     else:
@@ -724,7 +668,7 @@ def build_agentic_prompt(
     env_description: str | None,
 ) -> str:
     """Compose the monolithic-approach task prompt."""
-    geometry_prompt = AGENTIC_GEOMETRY_PROMPT if geometry else ""
+    geometry_prompt = GEOMETRY_PROMPT if geometry else ""
     modular = MODULAR_CODE_PROMPT if modular_code else ""
     if blackbox:
         return _AGENTIC_BLACKBOX.format(
@@ -758,7 +702,7 @@ def build_cdl_prompt(
     has_initial_helpers: bool,
 ) -> str:
     """Compose the behavior-decomposed-approach task prompt."""
-    geometry_prompt = CDL_GEOMETRY_PROMPT if geometry else ""
+    geometry_prompt = GEOMETRY_PROMPT if geometry else ""
     initial_helpers = CDL_INITIAL_HELPERS_PROMPT if has_initial_helpers else ""
     helpers_note = CDL_HELPERS_PROVIDED_NOTE if has_initial_helpers else ""
     behavior_impl_prompt = CDL_BEHAVIOR_IMPLEMENTATION_PROMPT.format(

--- a/src/robocode/prompts.py
+++ b/src/robocode/prompts.py
@@ -190,14 +190,49 @@ The environment is described below.
 
 """
 
+# Shared task-prompt scaffold. The opener sentences and the interface-spec
+# wrapper are common to both approaches; only small slotted pieces (approach
+# kind, class-interface code, run commands, section ordering) differ.
+_SCAFFOLD_INTRO = (
+    "You are writing {approach_kind} for {target}.\n\n"
+    "Your approach should be general enough to solve any instance of this "
+    "environment (env.reset()), but it does NOT need to be adaptable to "
+    "different other environments."
+)
+_SOURCE_OPENER = (
+    "Read the environment source files in this directory to understand the "
+    "state type, action space, and dynamics."
+)
+
+# Shared interface-spec wrapper. {class_interface} is the approach-specific
+# GeneratedApproach contract (code block + rules); {run_commands} the
+# approach-specific example test invocations.
+INTERFACE_SPEC_TEMPLATE = """\
+Write `approach.py` containing a class `GeneratedApproach` with the following \
+interface:
+
+{class_interface}
+
+{primitives_description}
+
+Write the best approach you can — ideally one that solves the environment \
+optimally. Your `approach.py` should only use packages available in the \
+current environment. Write test scripts that use the real environment to \
+verify your approach works.
+
+IMPORTANT: Use `{python_executable}` to run your test scripts, since that \
+interpreter has all required packages installed. For example:
+```bash
+{run_commands}
+```\
+"""
+
 # ---------------------------------------------------------------------------
 # AgenticApproach (monolithic policy) fragments
 # ---------------------------------------------------------------------------
 
-AGENTIC_INTERFACE_SPEC = """\
-Write `approach.py` containing a class `GeneratedApproach` with the following \
-interface:
-
+# Approach-specific GeneratedApproach contract, filled into INTERFACE_SPEC_TEMPLATE.
+AGENTIC_CLASS_INTERFACE = """\
 ```python
 class GeneratedApproach:
     def __init__(self, action_space, observation_space, primitives):
@@ -215,21 +250,10 @@ class GeneratedApproach:
 
 The class can maintain internal state between calls (e.g., a computed plan). \
 The `reset` method is called at the start of each episode. The `get_action` \
-method is called each step and must return a valid action.
-
-{primitives_description}
-
-Write the best approach you can — ideally one that solves the environment \
-optimally. Your `approach.py` should only use packages available in the \
-current environment. Write test scripts that use the real environment to \
-verify your approach works.
-
-IMPORTANT: Use `{python_executable}` to run your test scripts, since that \
-interpreter has all required packages installed. For example:
-```bash
-{python_executable} test_approach.py
-```\
+method is called each step and must return a valid action.\
 """
+
+AGENTIC_RUN_COMMANDS = "{python_executable} test_approach.py"
 
 # Geometric-reasoning prompt, shared by both approaches.
 GEOMETRY_PROMPT = """\
@@ -266,10 +290,7 @@ approach fails, you should design your code to avoid repeating that failure.
 """
 
 _AGENTIC_WITH_DESCRIPTION = """\
-You are writing an approach for the environment described below.
-
-Your approach should be general enough to solve any instance of this environment (env.reset()), \
-but it does NOT need to be adaptable to different other environments.
+{scaffold_intro}
 
 {env_description}
 {geometry_prompt}
@@ -278,19 +299,13 @@ but it does NOT need to be adaptable to different other environments.
 """
 
 _AGENTIC_WITH_SOURCE = """\
-Read the environment source files in this directory to understand the state \
-type, action space, and dynamics.
+{source_opener}
 {interface_spec}
 {modular_code_prompt}\
 """
 
 _AGENTIC_BLACKBOX = """\
-You are writing an approach for an environment that you can only access as \
-a black box.
-
-Your approach should be general enough to solve any instance of this \
-environment (each reset gives a new instance), but it does NOT need to be \
-adaptable to different other environments.
+{scaffold_intro}
 {env_description_section}
 {blackbox_interaction_spec}
 {geometry_prompt}
@@ -419,10 +434,7 @@ with env_client: reset with several seeds, perturb the state with \
 Do NOT guess the observation layout. \
 """
 
-CDL_INTERFACE_SPEC = """\
-Write `approach.py` containing a class `GeneratedApproach` with the following \
-interface:
-
+CDL_CLASS_INTERFACE = """\
 ```python
 from collections import deque
 from behaviors import BehaviorA, BehaviorB  # your behavior classes
@@ -455,21 +467,13 @@ class GeneratedApproach:
 The ``reset`` method MUST ONLY build a behavior deque using backward \
 precondition checking. The ``get_action`` method MUST ONLY delegate to the \
 current behavior and advance on termination. No other logic is allowed in \
-approach.py — all intelligence lives in the behaviors and helpers.
-
-{primitives_description}
-
-Write the best approach you can — ideally one that solves the environment \
-optimally. Your `approach.py` should only use packages available in the \
-current environment.
-
-IMPORTANT: Use `{python_executable}` to run your test scripts, since that \
-interpreter has all required packages installed. For example:
-```bash
-{python_executable} test_behavior_[behavior_name].py
-{python_executable} test_approach.py
-```\
+approach.py — all intelligence lives in the behaviors and helpers.\
 """
+
+CDL_RUN_COMMANDS = (
+    "{python_executable} test_behavior_[behavior_name].py\n"
+    "{python_executable} test_approach.py"
+)
 
 CDL_INITIAL_HELPERS_PROMPT = """\
 
@@ -502,10 +506,7 @@ CDL_HELPERS_PROVIDED_NOTE = (
 )
 
 _CDL_WITH_DESCRIPTION = """\
-You are writing a behavior-based approach for the environment described below.
-
-Your approach should be general enough to solve any instance of this environment \
-(env.reset()), but it does NOT need to be adaptable to different other environments.
+{scaffold_intro}
 
 {env_description}
 {initial_helpers_prompt}
@@ -516,8 +517,7 @@ Your approach should be general enough to solve any instance of this environment
 """
 
 _CDL_WITH_SOURCE = """\
-Read the environment source files in this directory to understand the state \
-type, action space, and dynamics.
+{source_opener}
 {initial_helpers_prompt}
 {cdl_decomposition_prompt}
 {interface_spec}
@@ -525,12 +525,7 @@ type, action space, and dynamics.
 """
 
 _CDL_BLACKBOX = """\
-You are writing a behavior-based approach for an environment that you can \
-only access as a black box.
-
-Your approach should be general enough to solve any instance of this \
-environment (each reset gives a new instance), but it does NOT need to be \
-adaptable to different other environments.
+{scaffold_intro}
 {env_description_section}
 {blackbox_interaction_spec}
 {initial_helpers_prompt}
@@ -614,16 +609,20 @@ def build_system_prompt(
 
 def build_interface_spec(
     *,
-    template: str,
+    class_interface: str,
+    run_commands: str,
     python_executable: str,
     primitives_description: str,
     blackbox: bool,
 ) -> str:
-    """Fill an interface-spec template; append the inspect-source suffix when the agent
-    can read env source (non-blackbox)."""
-    interface_spec = template.format(
-        python_executable=python_executable,
+    """Fill the shared interface-spec template with an approach's class contract and
+    run commands; append the inspect-source suffix when the agent can read env source
+    (non-blackbox)."""
+    interface_spec = INTERFACE_SPEC_TEMPLATE.format(
+        class_interface=class_interface,
         primitives_description=primitives_description,
+        python_executable=python_executable,
+        run_commands=run_commands.format(python_executable=python_executable),
     )
     if not blackbox:
         interface_spec += INSPECT_SOURCE_SUFFIX.format(
@@ -659,6 +658,15 @@ def _env_description_section(blackbox_description: str | None) -> str:
     return BLACKBOX_DESCRIPTION_PREFIX + blackbox_description + "\n"
 
 
+def _scaffold_intro(approach_kind: str, blackbox: bool) -> str:
+    target = (
+        "an environment that you can only access as a black box"
+        if blackbox
+        else "the environment described below"
+    )
+    return _SCAFFOLD_INTRO.format(approach_kind=approach_kind, target=target)
+
+
 def build_agentic_prompt(
     *,
     blackbox: bool,
@@ -672,6 +680,7 @@ def build_agentic_prompt(
     modular = MODULAR_CODE_PROMPT if modular_code else ""
     if blackbox:
         return _AGENTIC_BLACKBOX.format(
+            scaffold_intro=_scaffold_intro("an approach", blackbox=True),
             env_description_section=_env_description_section(env_description),
             blackbox_interaction_spec=BLACKBOX_INTERACTION_SPEC.format(
                 set_state_note=""
@@ -682,12 +691,14 @@ def build_agentic_prompt(
         )
     if env_description is not None:
         return _AGENTIC_WITH_DESCRIPTION.format(
+            scaffold_intro=_scaffold_intro("an approach", blackbox=False),
             env_description=env_description,
             geometry_prompt=geometry_prompt,
             modular_code_prompt=modular,
             interface_spec=interface_spec,
         )
     return _AGENTIC_WITH_SOURCE.format(
+        source_opener=_SOURCE_OPENER,
         modular_code_prompt=modular,
         interface_spec=interface_spec,
     )
@@ -714,6 +725,7 @@ def build_cdl_prompt(
     )
     if blackbox:
         return _CDL_BLACKBOX.format(
+            scaffold_intro=_scaffold_intro("a behavior-based approach", blackbox=True),
             env_description_section=_env_description_section(env_description),
             blackbox_interaction_spec=BLACKBOX_INTERACTION_SPEC.format(
                 set_state_note=BLACKBOX_SET_STATE_NOTE
@@ -726,6 +738,7 @@ def build_cdl_prompt(
         )
     if env_description is not None:
         return _CDL_WITH_DESCRIPTION.format(
+            scaffold_intro=_scaffold_intro("a behavior-based approach", blackbox=False),
             env_description=env_description,
             geometry_prompt=geometry_prompt,
             cdl_decomposition_prompt=CDL_DECOMPOSITION_PROMPT,
@@ -734,6 +747,7 @@ def build_cdl_prompt(
             initial_helpers_prompt=initial_helpers,
         )
     return _CDL_WITH_SOURCE.format(
+        source_opener=_SOURCE_OPENER,
         initial_helpers_prompt=initial_helpers,
         cdl_decomposition_prompt=CDL_DECOMPOSITION_PROMPT,
         interface_spec=interface_spec,

--- a/src/robocode/prompts.py
+++ b/src/robocode/prompts.py
@@ -1,0 +1,797 @@
+"""Centralized prompt text and composition for the LLM-agent approaches.
+
+Single source of truth for the instructions fed to the coding-agent backends
+(``AgenticApproach``, ``AgenticCDLApproach``) and the non-agentic
+``LLMGenPlanApproach``. Source-free, like ``primitive_specs``: it imports only
+stdlib plus the already-centralized backend and MCP suffix constants, never the
+env or primitives packages, so it stays safe to import on the host during
+``train()``. Dynamic strings (the primitives description, env-description text,
+the python-executable path) are passed in as arguments.
+
+Two axes of variation are kept orthogonal and are NEVER expressed as near-copies:
+- approach (agentic / CDL / genplan): legitimately different structural content,
+  kept as separate fragments.
+- blackbox vs non-blackbox: a small named delta selected by a ``blackbox`` bool.
+
+Shared text lives in exactly one fragment; only the genuine difference gets its
+own piece. The four agentic/CDL system prompts, for instance, share their
+file-discipline and subagent boilerplate verbatim and differ only in a short
+identity sentence and a blackbox-discovery clause, so they are composed from
+fragments here rather than stored as four full strings.
+"""
+
+from robocode.mcp import (
+    MCP_TOOLS_SYSTEM_PROMPT_SUFFIX,
+    MCP_TOOLS_SYSTEM_PROMPT_SUFFIX_BLACKBOX,
+    mcp_tool_descriptions,
+)
+from robocode.utils.backends import CLAUDE_PROMPT_SUFFIX, OPENCODE_PROMPT_SUFFIX
+
+# ---------------------------------------------------------------------------
+# System prompt fragments (shared by AgenticApproach and AgenticCDLApproach)
+# ---------------------------------------------------------------------------
+
+# Identity sentence: the one part of the intro that genuinely differs by approach.
+_AGENTIC_IDENTITY = "You are an expert at writing policies for gymnasium environments. "
+_CDL_IDENTITY = (
+    "You are an expert at writing purely imperative, feedforward policies for "
+    "gymnasium environments. You decompose tasks into a fixed sequence of "
+    "BEHAVIORS, where each behavior is a small, self-contained module with an "
+    "explicit precondition, subgoal, and a deterministic policy body. "
+)
+
+# Blackbox-discovery clause, shared by both approaches' blackbox intros. No
+# trailing punctuation: the per-approach tail supplies it.
+_BLACKBOX_DISCOVERY = (
+    "The environment is a black box: its source code is not available, so "
+    "you will discover the dynamics, reward structure, and termination "
+    "conditions empirically by interacting with a live environment instance"
+)
+
+# How the agent learns the dynamics and what it produces. Shared by both
+# approaches; only the blackbox vs non-blackbox wording differs.
+_LEARN_SOURCE = (
+    "You will read environment source code, understand the dynamics, "
+    "and write an optimal approach class. "
+)
+_LEARN_BLACKBOX = _BLACKBOX_DISCOVERY + ", and write an optimal approach class. "
+
+# File-writing + version-control discipline. Byte-identical across all four
+# agentic/CDL system prompts.
+SYSTEM_FILE_DISCIPLINE = (
+    "IMPORTANT: You MUST write ALL files (approach.py, test scripts, etc.) "
+    "to the current working directory using RELATIVE paths only. "
+    "Never use absolute paths when writing files. "
+    "IMPORTANT: Write code often to approach.py as you iterate. You may be "
+    "interrupted at any time, so you should make sure that approach.py is "
+    "your best current attempt at all times. "
+    "VERSION CONTROL: This directory is a git repo. After each meaningful "
+    "change to approach.py or supporting modules, run "
+    "`git add -A && git commit -m '<describe what you changed and why>'`. "
+    "Commit often, do not batch everything into one final commit. "
+    "You should commit the approach every time before you test it in the environment. "
+)
+
+# Subagent guidance tails (identical across agentic and CDL). No trailing space:
+# the optional extra tail (CDL token budget) or backend suffix begins with one.
+SYSTEM_SUBAGENTS = (
+    "Use subagents to explore source code in parallel, e.g. spawn "
+    "subagents to read environment dynamics, reward functions, and object "
+    "types simultaneously rather than sequentially."
+)
+SYSTEM_SUBAGENTS_BLACKBOX = (
+    "Use subagents to run exploration experiments in parallel, e.g. spawn "
+    "subagents to probe action effects, reward structure, and termination "
+    "conditions simultaneously rather than sequentially; each test script "
+    "gets its own fresh environment instance."
+)
+
+# CDL-only system-prompt tail (passed as extra_tail). Leading space joins it to
+# the subagent sentence above.
+CDL_SYSTEM_TOKEN_BUDGET = (
+    " TOKEN BUDGET: You have a limited output-token budget per turn. Be concise. "
+    "Do NOT write lengthy prose reasoning about geometry or arithmetic — put "
+    "all numerical calculations in code (Python scripts or inline print "
+    "statements) and read the results. Your text should be SHORT: state what "
+    "you will do, then immediately write code. Never narrate step-by-step "
+    "arithmetic in text."
+)
+
+# Composed intros (single source of truth): per-approach identity + the shared
+# learning clause; blackbox swaps only the learning clause.
+AGENTIC_INTRO = _AGENTIC_IDENTITY + _LEARN_SOURCE
+AGENTIC_INTRO_BLACKBOX = _AGENTIC_IDENTITY + _LEARN_BLACKBOX
+CDL_INTRO = _CDL_IDENTITY + _LEARN_SOURCE
+CDL_INTRO_BLACKBOX = _CDL_IDENTITY + _LEARN_BLACKBOX
+
+# ---------------------------------------------------------------------------
+# Shared body fragments (used by both agentic approaches)
+# ---------------------------------------------------------------------------
+
+# Appended to the interface spec in non-blackbox mode. Takes {python_executable}.
+INSPECT_SOURCE_SUFFIX = """
+
+You can also inspect the source code of any imported module to understand \
+the environment's dynamics in detail (reward function, transition logic, \
+termination conditions, etc.). To locate a module's source file:
+```bash
+{python_executable} -c "import some_module; print(some_module.__file__)"
+```
+Then read the source to inform your approach.\
+"""
+
+# How to interact with the live env server in blackbox mode. Takes
+# {set_state_note}: empty for the monolithic approach, the behavior-precondition
+# note for CDL (the only difference between the two blackbox interaction specs).
+BLACKBOX_INTERACTION_SPEC = """\
+The environment is a BLACK BOX. You CANNOT read its source code; it is not \
+available anywhere on this machine. A live environment server is running. \
+Interact with it through `env_client.py` in your working directory:
+
+```python
+from env_client import make_env
+
+env = make_env()  # fresh environment instance per call
+obs, info = env.reset(seed=0)
+obs, reward, terminated, truncated, info = env.step(action)
+state = env.get_state()  # numpy snapshot of the full environment state
+env.set_state(state)  # restore a snapshot
+env.close()
+```
+
+`env.observation_space` and `env.action_space` expose `shape`, `low`, \
+`high`, `dtype`, and `sample()`; the same metadata is in `env_spaces.json`. \
+`env.max_steps` is the episode step limit used at evaluation time.
+
+`env.make_primitives()` returns the SAME `primitives` dict the evaluation \
+harness passes to `GeneratedApproach.__init__`. Use it in test scripts so \
+they exercise the real primitives (env-dependent ones run on the host):
+
+```python
+from env_client import make_env
+
+env = make_env()
+primitives = env.make_primitives()
+```
+
+You can also call `env.observation_space.devectorize(obs)` to get an \
+object-centric view of an observation. It returns an `ObjectCentricState` \
+with `get_object_names()`, `get_object_from_name(name)`, `get_objects(type)`, \
+and `get(obj, feature)`; iterate objects via `get_objects(...)`, NOT \
+`for obj in ocs`. Call `env.observation_space.vectorize(ocs)` to go back to a \
+flat array. The evaluation harness passes the SAME `observation_space` to \
+`GeneratedApproach`, so `observation_space.devectorize(obs)` works identically \
+there, and `approach.py` can use it directly.
+
+Parallel test scripts are fine: every `make_env()` call creates an \
+independent environment instance.{set_state_note}
+
+Start by exploring systematically: reset with several seeds, apply \
+controlled actions, and study how the observation vector changes to \
+identify what each dimension means and how actions affect the state.
+
+CRITICAL: `approach.py` itself must NOT import `env_client`. It will be \
+evaluated against the real environment by a separate harness that calls \
+`reset(state, info)` and `get_action(state)` directly. Use `env_client` \
+ONLY in test and exploration scripts.\
+"""
+
+# CDL-only {set_state_note} value for BLACKBOX_INTERACTION_SPEC.
+BLACKBOX_SET_STATE_NOTE = (
+    " Use `set_state` to put the environment "
+    "into the state a behavior's precondition requires when testing it in "
+    "isolation."
+)
+
+# Prefix for an optional env description in blackbox mode.
+BLACKBOX_DESCRIPTION_PREFIX = """\
+
+The environment is described below.
+
+"""
+
+# ---------------------------------------------------------------------------
+# AgenticApproach (monolithic policy) fragments
+# ---------------------------------------------------------------------------
+
+AGENTIC_INTERFACE_SPEC = """\
+Write `approach.py` containing a class `GeneratedApproach` with the following \
+interface:
+
+```python
+class GeneratedApproach:
+    def __init__(self, action_space, observation_space, primitives):
+        \"\"\"Initialize with the environment's gym spaces.\"\"\"
+        ...
+
+    def reset(self, state, info):
+        \"\"\"Called at the start of each episode with the initial state.\"\"\"
+        ...
+
+    def get_action(self, state):
+        \"\"\"Return a valid action for the given state.\"\"\"
+        ...
+```
+
+The class can maintain internal state between calls (e.g., a computed plan). \
+The `reset` method is called at the start of each episode. The `get_action` \
+method is called each step and must return a valid action.
+
+{primitives_description}
+
+Write the best approach you can — ideally one that solves the environment \
+optimally. Your `approach.py` should only use packages available in the \
+current environment. Write test scripts that use the real environment to \
+verify your approach works.
+
+IMPORTANT: Use `{python_executable}` to run your test scripts, since that \
+interpreter has all required packages installed. For example:
+```bash
+{python_executable} test_approach.py
+```\
+"""
+
+AGENTIC_GEOMETRY_PROMPT = """\
+
+BEFORE writing any code, you MUST first reason in detail about the geometry of this environment. \
+Think carefully and qualitatively about spatial relationships, shapes, motions, and constraints.
+
+CRITICAL: Your geometric reasoning must be PURELY QUALITATIVE. Do NOT use any numbers AT ALL — \
+not in your reasoning, not in your thinking, not anywhere in your geometric analysis. This means \
+NO coordinates, NO distances, NO angles, NO dimensions, NO sizes, NO counts of objects, NO \
+thresholds, NO numeric constants, NO array indices, NO velocities, NO ratios, NO percentages. \
+Not even "2D" or "3D" — say "two-dimensional" or "three-dimensional" instead. If you catch \
+yourself about to write a number, stop and rephrase using purely relational, qualitative language. \
+Instead of saying "the object is at position (x, y)" say "the object is near the boundary". \
+Instead of "move 0.1 units" say "move a small step". Instead of "the angle is 90 degrees" say \
+"the surfaces are perpendicular".
+
+Your geometric reasoning should cover topics like:
+- What kinds of geometric shapes are involved (e.g. rectangles, circles, polygons, cuboids, \
+spheres, cylinders, capsules)? How do their shapes affect interactions — for instance, \
+rectangles tile differently than circles, spheres roll while cuboids don't, narrow corridors \
+between rectangular obstacles require precise alignment.
+- What are the key spatial relationships between objects? Reason about relative orientations \
+(parallel, perpendicular, oblique, aligned, tangent, skewed, transverse), relative positions \
+(adjacent, opposite, coplanar, collinear, concentric, coaxial, symmetric), and topological \
+relations (inside, outside, overlapping, enclosing, intersecting, touching, disjoint). Which \
+of these relationships matter for solving the task?
+- What geometric constraints exist? Are there boundaries, obstacles, containment relationships, \
+or clearance requirements? How do the shapes of obstacles create narrow passages, dead ends, \
+or open regions? Are surfaces flush or offset? Are relevant surfaces convex or concave?
+- What kind of motions or transformations are involved? Are objects translating, rotating, or \
+both? Are motions continuous or discrete? Does an object's shape affect how it can move \
+(e.g. a rectangle rotating requires more swept area than a circle of similar size)?
+- What makes a configuration "good" or "bad" geometrically? Think about reachability, \
+collision-freeness, coverage, proximity to goals.
+- What is the overall geometric strategy? For example:
+  - "The agent needs to navigate around obstacles to reach a goal region, so it must find a \
+path that threads between blocked areas while staying within bounds. When two rectangular \
+obstacles have parallel edges with a gap between them, the agent can pass through \
+perpendicular to those edges."
+  - "Objects must be packed tightly without overlapping, so the approach needs to find \
+placements where each new object fits into remaining gaps while respecting clearance from \
+existing objects. Rectangular objects can be aligned with parallel edges flush against each \
+other for dense packing, while circular objects leave unavoidable gaps."
+  - "The robot arm must move its end effector to a grasp pose, which means planning a \
+sequence of joint motions that avoids self-collision and keeps the kinematic chain valid. \
+The shape of the target object determines viable grasp orientations — a sphere can be \
+grasped from any direction, while a flat rectangular object requires approaching \
+perpendicular to one of its faces."
+  - "The agent must push an object toward a target, which requires approaching from the \
+opposite side so that the push direction is aligned with the line from object to goal. \
+A cylindrical object may roll unpredictably under pushes that are oblique to its axis."
+
+This qualitative geometric analysis should directly inform your code. Write your reasoning \
+out before you start coding. Do NOT skip this step. Remember: your geometric reasoning must \
+contain ZERO numbers. If any number appears in your geometric analysis, you have failed the task.
+"""
+
+MODULAR_CODE_PROMPT = """\
+
+IMPORTANT: Write MODULAR code, like a skilled software engineer:
+- Break your solution into small, self-contained modules in separate .py files.
+- Each module should be minimal and focused on a single responsibility, small enough to \
+reason about, test, and reuse independently.
+- Write and run a test script for each module BEFORE composing them together. Verify each \
+piece works in isolation. The tests should play out the modules in the actual environment \
+if possible, verifying the conditions before and after execution and ensuring these match \
+the expectations, under multiple conditions and edge cases, and should not just rely \
+on mock objects or simplified assumptions.
+- Your final `approach.py` should import from these modules and compose them into the \
+complete solution. Keep `approach.py` itself as thin as possible, it should primarily \
+orchestrate your tested modules.
+- Prefer many small files over one large file. If a function could be useful in multiple \
+contexts, it belongs in its own module.
+IMPORTANT: be careful about repeated behavior! If an action or strategy in your \
+approach fails, you should design your code to avoid repeating that failure.
+"""
+
+_AGENTIC_WITH_DESCRIPTION = """\
+You are writing an approach for the environment described below.
+
+Your approach should be general enough to solve any instance of this environment (env.reset()), \
+but it does NOT need to be adaptable to different other environments.
+
+{env_description}
+{geometry_prompt}
+{interface_spec}
+{modular_code_prompt}\
+"""
+
+_AGENTIC_WITH_SOURCE = """\
+Read the environment source files in this directory to understand the state \
+type, action space, and dynamics.
+{interface_spec}
+{modular_code_prompt}\
+"""
+
+_AGENTIC_BLACKBOX = """\
+You are writing an approach for an environment that you can only access as \
+a black box.
+
+Your approach should be general enough to solve any instance of this \
+environment (each reset gives a new instance), but it does NOT need to be \
+adaptable to different other environments.
+{env_description_section}
+{blackbox_interaction_spec}
+{geometry_prompt}
+{interface_spec}
+{modular_code_prompt}\
+"""
+
+# ---------------------------------------------------------------------------
+# AgenticCDLApproach (behavior-decomposed policy) fragments
+# ---------------------------------------------------------------------------
+
+CDL_DECOMPOSITION_PROMPT = """\
+
+BEFORE writing any low-level code, you MUST first reason about the HIGH-LEVEL \
+BEHAVIOR DECOMPOSITION of this task. Think of the task as a fixed sequence of \
+phases/behaviors that, when executed in order, solve the environment.
+
+For each behavior, explicitly define:
+1. **Name**: A descriptive name.
+2. **Precondition** (``initializable(state) -> bool``): Under what state conditions can \
+this behavior start? This is a boolean predicate on the observation. This should always \
+be true after the previous behavior's subgoal is achieved. For the initial behavior, \
+it should be satisfied by the initial state of the environment (env.reset()). \
+3. **Subgoal** (``terminated(state) -> bool``): What condition must be true for this \
+behavior to be considered complete? Another boolean predicate.
+4. **Policy body**: A high-level description of the strategy (e.g., "move above the \
+object, lower the arm, activate vacuum, retract arm").
+5. **Why this ordering**: Explain why the previous behavior's subgoal satisfies this \
+behavior's precondition.
+
+The approach should determine which behavior to start from by checking preconditions \
+BACKWARDS from the last behavior. If the last behavior's precondition is already \
+satisfied, skip all earlier behaviors.
+
+Write out your full decomposition BEFORE writing any code. This decomposition is the \
+most important part of your solution.
+"""
+
+CDL_BEHAVIOR_IMPLEMENTATION_PROMPT = """\
+
+IMPORTANT: You MUST follow this EXACT file structure. Do NOT put everything in \
+one file. Do NOT put helper functions inside approach.py or behavior files.
+
+Required files:
+- ``obs_helpers.py`` — ALL functions that parse/interpret the observation vector. \
+This includes extracting object positions, computing geometric predicates, \
+and any named constants for observation indices. \
+Every "magic number" related to observation parsing MUST be a named constant here. \
+{obs_inspection_note}\
+{obs_helpers_note}
+- ``act_helpers.py`` — ALL functions that help generate actions. This includes \
+waypoint interpolation, action clipping, proportional controllers, etc. \
+Every "magic number" related to action generation (step limits, arm extension \
+rate, etc.) MUST be a named constant here. \
+{act_helpers_note}
+- ``behaviors.py`` — ALL behavior classes. Each behavior inherits from the \
+``Behavior`` base class (provided in ``behavior.py``). Behaviors import from \
+``obs_helpers`` and ``act_helpers`` but contain NO magic numbers themselves.
+- ``approach.py`` — ONLY the ``GeneratedApproach`` class. It imports behaviors \
+from ``behaviors.py`` and does NOTHING except: (1) in ``reset``, determine \
+the behavior sequence by checking ``initializable`` backwards, (2) in \
+``get_action``, delegate to the current behavior's ``step()`` and advance \
+when ``terminated()`` returns True. NO control logic, NO observation parsing, \
+NO action generation in this file.
+
+CRITICAL RULES:
+- NO magic numbers anywhere except as named constants in obs_helpers.py or \
+act_helpers.py. Every numeric literal (tolerances, offsets, indices, limits) \
+must have a descriptive name. ``0.05`` is WRONG; ``DX_LIMIT = 0.05`` is RIGHT.
+- Behaviors must use obs_helpers for ALL observation access. Never index into \
+the observation array directly inside a behavior — use named extraction \
+functions like ``extract_robot(obs)``, ``extract_rect(obs, "target_block")``.
+- approach.py must be THIN. Its reset() only builds a behavior deque using \
+backward precondition checking. Its get_action() only delegates to the \
+current behavior and advances on termination. Nothing else.
+
+A ``Behavior`` base class is provided in your working directory as ``behavior.py``:
+
+```python
+from behavior import Behavior
+
+class MyBehavior(Behavior):
+    def reset(self, x):
+        \"\"\"Initialize internal state for a new execution.\"\"\"
+        ...
+    def initializable(self, x) -> bool:
+        \"\"\"Return True if the precondition is met.\"\"\"
+        ...
+    def terminated(self, x) -> bool:
+        \"\"\"Return True if the subgoal has been achieved.\"\"\"
+        ...
+    def step(self, x):
+        \"\"\"Return the next action.\"\"\"
+        ...
+```
+
+Testing protocol — for EACH behavior, write and run a test script that:
+1. Resets the environment (try multiple seeds: 0, 1, 2, 3, 42).
+2. If needed, manually sets up the state so the behavior's precondition is met \
+(e.g., move obstructions away for a "pick" behavior).
+3. Calls ``behavior.reset(state)``, then loops ``behavior.step(state)`` until \
+``behavior.terminated(state)`` returns True.
+4. **Asserts** that the subgoal is actually achieved and the behavior completes \
+within a reasonable number of steps.
+5. Only after ALL behaviors pass their individual tests, compose them into the \
+final ``approach.py``.
+
+IMPORTANT: If a behavior's action plan is exhausted but the subgoal is not \
+reached, re-generate the plan from the current observation instead of \
+repeating the same failed plan.
+"""
+
+CDL_OBS_INSPECTION_NOTE = """\
+BEFORE writing this file, you MUST run: \
+``feats = env.unwrapped.observation_space.devectorize(obs)`` \
+to inspect the observation structure. This returns a dictionary mapping \
+feature names to their values, so you can see exactly what each part of \
+the observation vector represents. Use this to determine the correct \
+indices, feature names, and semantics — do NOT guess the observation layout. \
+"""
+
+CDL_OBS_INSPECTION_NOTE_BLACKBOX = """\
+BEFORE writing this file, you MUST map the observation layout empirically \
+with env_client: reset with several seeds, perturb the state with \
+``set_state``, and observe which observation entries change as you act. \
+Do NOT guess the observation layout. \
+"""
+
+CDL_INTERFACE_SPEC = """\
+Write `approach.py` containing a class `GeneratedApproach` with the following \
+interface:
+
+```python
+from collections import deque
+from behaviors import BehaviorA, BehaviorB  # your behavior classes
+
+class GeneratedApproach:
+    def __init__(self, action_space, observation_space, primitives):
+        self._behaviors = deque()
+        self._current = None
+
+    def reset(self, state, info):
+        # Determine behavior sequence by checking preconditions BACKWARDS.
+        # This is the ONLY logic allowed here.
+        b_last = BehaviorB()
+        b_first = BehaviorA()
+        if b_last.initializable(state):
+            self._behaviors = deque([b_last])
+        else:
+            self._behaviors = deque([b_first, b_last])
+        self._current = self._behaviors.popleft()
+        self._current.reset(state)
+
+    def get_action(self, state):
+        # Advance to next behavior when subgoal reached.
+        if self._current.terminated(state) and self._behaviors:
+            self._current = self._behaviors.popleft()
+            self._current.reset(state)
+        return self._current.step(state)
+```
+
+The ``reset`` method MUST ONLY build a behavior deque using backward \
+precondition checking. The ``get_action`` method MUST ONLY delegate to the \
+current behavior and advance on termination. No other logic is allowed in \
+approach.py — all intelligence lives in the behaviors and helpers.
+
+{primitives_description}
+
+Write the best approach you can — ideally one that solves the environment \
+optimally. Your `approach.py` should only use packages available in the \
+current environment.
+
+IMPORTANT: Use `{python_executable}` to run your test scripts, since that \
+interpreter has all required packages installed. For example:
+```bash
+{python_executable} test_behavior_[behavior_name].py
+{python_executable} test_approach.py
+```\
+"""
+
+CDL_GEOMETRY_PROMPT = """\
+
+BEFORE writing any code, briefly describe (in 5-10 bullet points) the key \
+geometric relationships in this environment:
+- What shapes are involved and how they interact spatially.
+- What motions/transformations are needed (translate, rotate, extend arm).
+- What collision constraints exist (clearances, boundaries).
+
+Keep this analysis SHORT and QUALITATIVE — no numbers, no arithmetic. \
+If you need to compute specific positions or offsets, write a Python \
+script to do it and print the results. NEVER do arithmetic in text.
+"""
+
+CDL_INITIAL_HELPERS_PROMPT = """\
+
+IMPORTANT: You have been provided with initial versions of ``obs_helpers.py`` \
+and ``act_helpers.py`` in your working directory. These files contain CORRECT \
+observation parsing (feature indices, object layout, extraction functions) and \
+action generation helpers (waypoint interpolation, action limits) for this \
+environment. You MUST use them as your starting point:
+
+- **DO NOT** rewrite observation parsing from scratch — the provided \
+``obs_helpers.py`` already has the correct feature layout and extraction \
+functions.
+- **DO NOT** rewrite action helpers from scratch — the provided \
+``act_helpers.py`` already has correct action limits and waypoint utilities.
+- You MAY and SHOULD add new helper functions, constants, or geometric \
+predicates to these files as needed for your behaviors.
+- You MAY modify existing functions if you need to extend them, but do not \
+change the core observation layout or action format — they are correct.
+
+Start by reading these files to understand the observation structure and \
+available utilities before writing any behaviors.
+"""
+
+# Filled into the behavior-impl prompt's {obs_helpers_note}/{act_helpers_note}
+# slots when env-specific helper files are provided.
+CDL_HELPERS_PROVIDED_NOTE = (
+    "This file is ALREADY PROVIDED in your working directory with "
+    "correct parsing logic. Read it first, then extend it with any "
+    "additional helpers you need. Do NOT rewrite it from scratch."
+)
+
+_CDL_WITH_DESCRIPTION = """\
+You are writing a behavior-based approach for the environment described below.
+
+Your approach should be general enough to solve any instance of this environment \
+(env.reset()), but it does NOT need to be adaptable to different other environments.
+
+{env_description}
+{initial_helpers_prompt}
+{geometry_prompt}
+{cdl_decomposition_prompt}
+{interface_spec}
+{behavior_implementation_prompt}\
+"""
+
+_CDL_WITH_SOURCE = """\
+Read the environment source files in this directory to understand the state \
+type, action space, and dynamics.
+{initial_helpers_prompt}
+{cdl_decomposition_prompt}
+{interface_spec}
+{behavior_implementation_prompt}\
+"""
+
+_CDL_BLACKBOX = """\
+You are writing a behavior-based approach for an environment that you can \
+only access as a black box.
+
+Your approach should be general enough to solve any instance of this \
+environment (each reset gives a new instance), but it does NOT need to be \
+adaptable to different other environments.
+{env_description_section}
+{blackbox_interaction_spec}
+{initial_helpers_prompt}
+{geometry_prompt}
+{cdl_decomposition_prompt}
+{interface_spec}
+{behavior_implementation_prompt}\
+"""
+
+# ---------------------------------------------------------------------------
+# LLMGenPlanApproach (non-agentic baseline) fragments
+# ---------------------------------------------------------------------------
+# Kept faithful to the upstream llm-genplan method; textually independent from
+# the agentic prompts above (single code block, no test scripts).
+
+GENPLAN_INTERFACE_SPEC = """\
+Implement the strategy as a Python class named `GeneratedApproach` in a single \
+code block:
+
+```python
+class GeneratedApproach:
+    def __init__(self, action_space, observation_space, primitives):
+        \"\"\"action_space and observation_space are the gym spaces above.\"\"\"
+        ...
+
+    def reset(self, state, info):
+        \"\"\"Called at the start of each episode with the initial observation.\"\"\"
+        ...
+
+    def get_action(self, state):
+        \"\"\"Return a valid action (matching action_space) for this state.\"\"\"
+        ...
+```
+
+`state` is a numpy observation matching the observation space. `get_action` is \
+called every step and must return an action inside the action space. The class \
+may keep internal state between calls (e.g. a precomputed plan). Return ONLY \
+the code block; do not write tests or explanations."""
+
+GENPLAN_SUMMARY_PROMPT = "Write a short summary of this environment in words."
+
+GENPLAN_STRATEGY_PROMPT = (
+    "There is a simple strategy for solving all instances of this environment "
+    "without using search. What is that strategy?"
+)
+
+
+# ---------------------------------------------------------------------------
+# Composition helpers (pure: strings/bools in, string out)
+# ---------------------------------------------------------------------------
+
+
+def build_system_prompt(
+    *,
+    intro: str,
+    blackbox: bool,
+    backend_name: str,
+    mcp_tools: tuple[str, ...] = (),
+    extra_tail: str = "",
+) -> str:
+    """Compose a coding-agent system prompt from shared fragments.
+
+    ``intro`` is one of the composed intro constants (AGENTIC_INTRO[_BLACKBOX],
+    CDL_INTRO[_BLACKBOX]). The shared file-discipline block, blackbox-aware
+    subagent guidance, optional ``extra_tail`` (CDL token budget), the
+    backend-specific suffix, and the optional MCP-tools suffix follow.
+    """
+    subagents = SYSTEM_SUBAGENTS_BLACKBOX if blackbox else SYSTEM_SUBAGENTS
+    system_prompt = intro + SYSTEM_FILE_DISCIPLINE + subagents + extra_tail
+    if backend_name == "opencode":
+        system_prompt += OPENCODE_PROMPT_SUFFIX
+    else:
+        system_prompt += CLAUDE_PROMPT_SUFFIX
+    if mcp_tools:
+        system_prompt += (
+            MCP_TOOLS_SYSTEM_PROMPT_SUFFIX_BLACKBOX
+            if blackbox
+            else MCP_TOOLS_SYSTEM_PROMPT_SUFFIX
+        )
+    return system_prompt
+
+
+def build_interface_spec(
+    *,
+    template: str,
+    python_executable: str,
+    primitives_description: str,
+    blackbox: bool,
+) -> str:
+    """Fill an interface-spec template; append the inspect-source suffix when the agent
+    can read env source (non-blackbox)."""
+    interface_spec = template.format(
+        python_executable=python_executable,
+        primitives_description=primitives_description,
+    )
+    if not blackbox:
+        interface_spec += INSPECT_SOURCE_SUFFIX.format(
+            python_executable=python_executable
+        )
+    return interface_spec
+
+
+def build_mcp_tool_lines(
+    *,
+    mcp_tools: tuple[str, ...],
+    backend_name: str,
+    blackbox: bool,
+) -> str:
+    """Return the MCP-tools section appended to the primitives description, or "" when
+    no MCP tools are configured."""
+    if not mcp_tools:
+        return ""
+    tool_descs = mcp_tool_descriptions(backend_name, blackbox=blackbox)
+    lines = [
+        "\n\nYou also have MCP tools for visual debugging (they do NOT "
+        "affect your test scripts):\n",
+    ]
+    for name in mcp_tools:
+        if name in tool_descs:
+            lines.append(f"- {tool_descs[name]}")
+    return "\n".join(lines)
+
+
+def _env_description_section(blackbox_description: str | None) -> str:
+    if blackbox_description is None:
+        return ""
+    return BLACKBOX_DESCRIPTION_PREFIX + blackbox_description + "\n"
+
+
+def build_agentic_prompt(
+    *,
+    blackbox: bool,
+    interface_spec: str,
+    geometry: bool,
+    modular_code: bool,
+    env_description: str | None,
+) -> str:
+    """Compose the monolithic-approach task prompt."""
+    geometry_prompt = AGENTIC_GEOMETRY_PROMPT if geometry else ""
+    modular = MODULAR_CODE_PROMPT if modular_code else ""
+    if blackbox:
+        return _AGENTIC_BLACKBOX.format(
+            env_description_section=_env_description_section(env_description),
+            blackbox_interaction_spec=BLACKBOX_INTERACTION_SPEC.format(
+                set_state_note=""
+            ),
+            geometry_prompt=geometry_prompt,
+            interface_spec=interface_spec,
+            modular_code_prompt=modular,
+        )
+    if env_description is not None:
+        return _AGENTIC_WITH_DESCRIPTION.format(
+            env_description=env_description,
+            geometry_prompt=geometry_prompt,
+            modular_code_prompt=modular,
+            interface_spec=interface_spec,
+        )
+    return _AGENTIC_WITH_SOURCE.format(
+        modular_code_prompt=modular,
+        interface_spec=interface_spec,
+    )
+
+
+def build_cdl_prompt(
+    *,
+    blackbox: bool,
+    interface_spec: str,
+    geometry: bool,
+    env_description: str | None,
+    has_initial_helpers: bool,
+) -> str:
+    """Compose the behavior-decomposed-approach task prompt."""
+    geometry_prompt = CDL_GEOMETRY_PROMPT if geometry else ""
+    initial_helpers = CDL_INITIAL_HELPERS_PROMPT if has_initial_helpers else ""
+    helpers_note = CDL_HELPERS_PROVIDED_NOTE if has_initial_helpers else ""
+    behavior_impl_prompt = CDL_BEHAVIOR_IMPLEMENTATION_PROMPT.format(
+        obs_inspection_note=(
+            CDL_OBS_INSPECTION_NOTE_BLACKBOX if blackbox else CDL_OBS_INSPECTION_NOTE
+        ),
+        obs_helpers_note=helpers_note,
+        act_helpers_note=helpers_note,
+    )
+    if blackbox:
+        return _CDL_BLACKBOX.format(
+            env_description_section=_env_description_section(env_description),
+            blackbox_interaction_spec=BLACKBOX_INTERACTION_SPEC.format(
+                set_state_note=BLACKBOX_SET_STATE_NOTE
+            ),
+            initial_helpers_prompt=initial_helpers,
+            geometry_prompt=geometry_prompt,
+            cdl_decomposition_prompt=CDL_DECOMPOSITION_PROMPT,
+            interface_spec=interface_spec,
+            behavior_implementation_prompt=behavior_impl_prompt,
+        )
+    if env_description is not None:
+        return _CDL_WITH_DESCRIPTION.format(
+            env_description=env_description,
+            geometry_prompt=geometry_prompt,
+            cdl_decomposition_prompt=CDL_DECOMPOSITION_PROMPT,
+            interface_spec=interface_spec,
+            behavior_implementation_prompt=behavior_impl_prompt,
+            initial_helpers_prompt=initial_helpers,
+        )
+    return _CDL_WITH_SOURCE.format(
+        initial_helpers_prompt=initial_helpers,
+        cdl_decomposition_prompt=CDL_DECOMPOSITION_PROMPT,
+        interface_spec=interface_spec,
+        behavior_implementation_prompt=behavior_impl_prompt,
+    )

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,290 @@
+"""Tests for robocode.prompts composition helpers and blackbox deltas."""
+
+from robocode import prompts
+from robocode.mcp import (
+    MCP_TOOLS_SYSTEM_PROMPT_SUFFIX,
+    MCP_TOOLS_SYSTEM_PROMPT_SUFFIX_BLACKBOX,
+)
+from robocode.utils.backends import CLAUDE_PROMPT_SUFFIX, OPENCODE_PROMPT_SUFFIX
+
+# ---------------------------------------------------------------------------
+# Composed intros: the shared blackbox-discovery clause is one fragment, not a
+# per-approach copy.
+# ---------------------------------------------------------------------------
+
+
+def test_blackbox_discovery_clause_shared_between_intros():
+    """The blackbox-discovery clause is shared; identities genuinely differ."""
+    assert "discover the dynamics" in prompts.AGENTIC_INTRO_BLACKBOX
+    assert "discover the dynamics" in prompts.CDL_INTRO_BLACKBOX
+    assert "black box" not in prompts.AGENTIC_INTRO
+    assert "black box" not in prompts.CDL_INTRO
+    assert "purely imperative, feedforward" in prompts.CDL_INTRO
+    assert "purely imperative, feedforward" not in prompts.AGENTIC_INTRO
+
+
+def test_learning_clause_shared_across_approaches():
+    """Both approaches get the same learning clause; only blackbox wording differs."""
+    # The non-blackbox learning clause is identical for agentic and CDL.
+    assert "read environment source code" in prompts.AGENTIC_INTRO
+    assert "read environment source code" in prompts.CDL_INTRO
+    # All four intros state the agent writes an approach class.
+    for intro in (
+        prompts.AGENTIC_INTRO,
+        prompts.AGENTIC_INTRO_BLACKBOX,
+        prompts.CDL_INTRO,
+        prompts.CDL_INTRO_BLACKBOX,
+    ):
+        assert "write an optimal approach class" in intro
+
+
+# ---------------------------------------------------------------------------
+# build_system_prompt
+# ---------------------------------------------------------------------------
+
+
+def test_system_prompt_agentic_non_blackbox():
+    """Non-blackbox agentic system prompt reads source and ends with the suffix."""
+    sp = prompts.build_system_prompt(
+        intro=prompts.AGENTIC_INTRO, blackbox=False, backend_name="claude"
+    )
+    assert "expert at writing policies" in sp
+    assert "VERSION CONTROL" in sp
+    assert "explore source code in parallel" in sp
+    assert "black box" not in sp
+    assert sp.endswith(CLAUDE_PROMPT_SUFFIX)
+    assert MCP_TOOLS_SYSTEM_PROMPT_SUFFIX not in sp
+
+
+def test_system_prompt_blackbox_swaps_subagents():
+    """Blackbox selects the empirical-exploration subagent guidance."""
+    sp = prompts.build_system_prompt(
+        intro=prompts.AGENTIC_INTRO_BLACKBOX, blackbox=True, backend_name="claude"
+    )
+    assert "black box" in sp
+    assert "run exploration experiments" in sp
+    assert "explore source code in parallel" not in sp
+
+
+def test_system_prompt_opencode_backend_suffix():
+    """The opencode backend swaps in its own prompt suffix."""
+    sp = prompts.build_system_prompt(
+        intro=prompts.AGENTIC_INTRO, blackbox=False, backend_name="opencode"
+    )
+    assert sp.endswith(OPENCODE_PROMPT_SUFFIX)
+    assert CLAUDE_PROMPT_SUFFIX not in sp
+
+
+def test_system_prompt_mcp_suffix_blackbox_variant():
+    """Blackbox + mcp tools appends the blackbox MCP suffix, not the normal one."""
+    sp = prompts.build_system_prompt(
+        intro=prompts.AGENTIC_INTRO_BLACKBOX,
+        blackbox=True,
+        backend_name="claude",
+        mcp_tools=("render_state",),
+    )
+    assert MCP_TOOLS_SYSTEM_PROMPT_SUFFIX_BLACKBOX in sp
+    assert MCP_TOOLS_SYSTEM_PROMPT_SUFFIX not in sp
+
+
+def test_system_prompt_mcp_suffix_non_blackbox_variant():
+    """Non-blackbox + mcp tools appends the standard MCP suffix."""
+    sp = prompts.build_system_prompt(
+        intro=prompts.AGENTIC_INTRO,
+        blackbox=False,
+        backend_name="claude",
+        mcp_tools=("render_state",),
+    )
+    assert MCP_TOOLS_SYSTEM_PROMPT_SUFFIX in sp
+
+
+def test_system_prompt_cdl_token_budget_tail():
+    """The CDL extra tail injects the token-budget guidance."""
+    sp = prompts.build_system_prompt(
+        intro=prompts.CDL_INTRO,
+        blackbox=False,
+        backend_name="claude",
+        extra_tail=prompts.CDL_SYSTEM_TOKEN_BUDGET,
+    )
+    assert "purely imperative, feedforward" in sp
+    assert "TOKEN BUDGET" in sp
+
+
+# ---------------------------------------------------------------------------
+# build_interface_spec
+# ---------------------------------------------------------------------------
+
+
+def test_interface_spec_non_blackbox_appends_inspect():
+    """Non-blackbox interface spec appends the inspect-source suffix."""
+    spec = prompts.build_interface_spec(
+        template=prompts.AGENTIC_INTERFACE_SPEC,
+        python_executable="/usr/bin/python3",
+        primitives_description="PRIMS_DESC",
+        blackbox=False,
+    )
+    assert "inspect the source code" in spec
+    assert "/usr/bin/python3" in spec
+    assert "PRIMS_DESC" in spec
+
+
+def test_interface_spec_blackbox_omits_inspect():
+    """Blackbox interface spec omits the inspect-source suffix."""
+    spec = prompts.build_interface_spec(
+        template=prompts.AGENTIC_INTERFACE_SPEC,
+        python_executable="/usr/bin/python3",
+        primitives_description="PRIMS_DESC",
+        blackbox=True,
+    )
+    assert "inspect the source code" not in spec
+    assert "PRIMS_DESC" in spec
+
+
+# ---------------------------------------------------------------------------
+# build_agentic_prompt
+# ---------------------------------------------------------------------------
+
+
+def test_agentic_prompt_blackbox():
+    """Blackbox agentic prompt warns about env_client and includes geometry."""
+    p = prompts.build_agentic_prompt(
+        blackbox=True,
+        interface_spec="IFACE",
+        geometry=True,
+        modular_code=False,
+        env_description=None,
+    )
+    assert "BLACK BOX" in p
+    assert "must NOT import `env_client`" in p
+    assert "Read the environment source files" not in p
+    assert "ZERO numbers" in p
+    assert "IFACE" in p
+
+
+def test_agentic_prompt_blackbox_with_description_and_no_geometry():
+    """Blackbox prompt wraps the description and omits geometry when disabled."""
+    p = prompts.build_agentic_prompt(
+        blackbox=True,
+        interface_spec="IFACE",
+        geometry=False,
+        modular_code=False,
+        env_description="ENVDESC",
+    )
+    assert "The environment is described below." in p
+    assert "ENVDESC" in p
+    assert "ZERO numbers" not in p
+
+
+def test_agentic_prompt_with_description_non_blackbox():
+    """Non-blackbox prompt with a description never asks to read source."""
+    p = prompts.build_agentic_prompt(
+        blackbox=False,
+        interface_spec="IFACE",
+        geometry=True,
+        modular_code=True,
+        env_description="ENVDESC",
+    )
+    assert "ENVDESC" in p
+    assert "BLACK BOX" not in p
+    assert "Read the environment source files" not in p
+    assert "Write MODULAR code" in p
+
+
+def test_agentic_prompt_source_non_blackbox():
+    """Non-blackbox prompt without a description asks to read source."""
+    p = prompts.build_agentic_prompt(
+        blackbox=False,
+        interface_spec="IFACE",
+        geometry=True,
+        modular_code=False,
+        env_description=None,
+    )
+    assert "Read the environment source files" in p
+    assert "Write MODULAR code" not in p
+
+
+# ---------------------------------------------------------------------------
+# build_cdl_prompt
+# ---------------------------------------------------------------------------
+
+
+def test_cdl_prompt_blackbox():
+    """Blackbox CDL prompt uses the empirical obs note and the canonical D1 spec."""
+    p = prompts.build_cdl_prompt(
+        blackbox=True,
+        interface_spec="IFACE",
+        geometry=True,
+        env_description=None,
+        has_initial_helpers=False,
+    )
+    assert "BLACK BOX" in p
+    assert "must NOT import `env_client`" in p
+    assert "map the observation layout empirically" in p
+    assert "devectorize" in p
+    assert "Read the environment source files" not in p
+    # D1: the behavior-precondition set_state note and the code-block
+    # make_primitives form (canonical, shared with the monolithic approach).
+    assert "precondition requires when testing it in" in p
+    assert "primitives = env.make_primitives()" in p
+    assert "ALREADY PROVIDED" not in p
+
+
+def test_cdl_prompt_initial_helpers_non_blackbox():
+    """Non-blackbox CDL prompt with helpers uses the devectorize obs note."""
+    p = prompts.build_cdl_prompt(
+        blackbox=False,
+        interface_spec="IFACE",
+        geometry=True,
+        env_description="ENVDESC",
+        has_initial_helpers=True,
+    )
+    assert "ENVDESC" in p
+    assert "ALREADY PROVIDED" in p
+    assert "devectorize" in p
+    assert "map the observation layout empirically" not in p
+    assert "BLACK BOX" not in p
+
+
+# ---------------------------------------------------------------------------
+# build_mcp_tool_lines
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_tool_lines_empty():
+    """No MCP tools yields an empty string."""
+    assert (
+        prompts.build_mcp_tool_lines(
+            mcp_tools=(), backend_name="claude", blackbox=False
+        )
+        == ""
+    )
+
+
+def test_mcp_tool_lines_claude_naming():
+    """Claude backend uses the mcp__server__tool naming."""
+    lines = prompts.build_mcp_tool_lines(
+        mcp_tools=("render_state",), backend_name="claude", blackbox=False
+    )
+    assert "MCP tools for visual debugging" in lines
+    assert "mcp__robocode-tools__render_state" in lines
+
+
+def test_mcp_tool_lines_opencode_naming():
+    """OpenCode backend uses the server_tool naming."""
+    lines = prompts.build_mcp_tool_lines(
+        mcp_tools=("render_state",), backend_name="opencode", blackbox=False
+    )
+    assert "robocode-tools_render_state" in lines
+
+
+# ---------------------------------------------------------------------------
+# genplan constants (kept faithful to upstream llm-genplan)
+# ---------------------------------------------------------------------------
+
+
+def test_genplan_constants():
+    """Genplan prompt constants carry their distinctive single-code-block text."""
+    assert "GeneratedApproach" in prompts.GENPLAN_INTERFACE_SPEC
+    assert "Return ONLY" in prompts.GENPLAN_INTERFACE_SPEC
+    assert prompts.GENPLAN_SUMMARY_PROMPT
+    assert "simple strategy" in prompts.GENPLAN_STRATEGY_PROMPT

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -98,16 +98,16 @@ def test_system_prompt_mcp_suffix_non_blackbox_variant():
     assert MCP_TOOLS_SYSTEM_PROMPT_SUFFIX in sp
 
 
-def test_system_prompt_cdl_token_budget_tail():
-    """The CDL extra tail injects the token-budget guidance."""
-    sp = prompts.build_system_prompt(
-        intro=prompts.CDL_INTRO,
-        blackbox=False,
-        backend_name="claude",
-        extra_tail=prompts.CDL_SYSTEM_TOKEN_BUDGET,
+def test_system_prompt_token_budget_on_both_approaches():
+    """Token-budget guidance is appended to every system prompt (both approaches)."""
+    agentic = prompts.build_system_prompt(
+        intro=prompts.AGENTIC_INTRO, blackbox=False, backend_name="claude"
     )
-    assert "purely imperative, feedforward" in sp
-    assert "TOKEN BUDGET" in sp
+    cdl = prompts.build_system_prompt(
+        intro=prompts.CDL_INTRO, blackbox=False, backend_name="claude"
+    )
+    assert "TOKEN BUDGET" in agentic
+    assert "TOKEN BUDGET" in cdl
 
 
 # ---------------------------------------------------------------------------
@@ -157,7 +157,7 @@ def test_agentic_prompt_blackbox():
     assert "BLACK BOX" in p
     assert "must NOT import `env_client`" in p
     assert "Read the environment source files" not in p
-    assert "ZERO numbers" in p
+    assert "5-10 bullet points" in p
     assert "IFACE" in p
 
 
@@ -172,7 +172,7 @@ def test_agentic_prompt_blackbox_with_description_and_no_geometry():
     )
     assert "The environment is described below." in p
     assert "ENVDESC" in p
-    assert "ZERO numbers" not in p
+    assert "5-10 bullet points" not in p
 
 
 def test_agentic_prompt_with_description_non_blackbox():
@@ -227,6 +227,28 @@ def test_cdl_prompt_blackbox():
     assert "precondition requires when testing it in" in p
     assert "primitives = env.make_primitives()" in p
     assert "ALREADY PROVIDED" not in p
+
+
+def test_geometry_prompt_unified_across_approaches():
+    """Both approaches use the same (terse) geometry-reasoning prompt."""
+    agentic = prompts.build_agentic_prompt(
+        blackbox=False,
+        interface_spec="IFACE",
+        geometry=True,
+        modular_code=False,
+        env_description="E",
+    )
+    cdl = prompts.build_cdl_prompt(
+        blackbox=False,
+        interface_spec="IFACE",
+        geometry=True,
+        env_description="E",
+        has_initial_helpers=False,
+    )
+    assert prompts.GEOMETRY_PROMPT in agentic
+    assert prompts.GEOMETRY_PROMPT in cdl
+    assert "5-10 bullet points" in agentic
+    assert "5-10 bullet points" in cdl
 
 
 def test_cdl_prompt_initial_helpers_non_blackbox():

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -118,26 +118,53 @@ def test_system_prompt_token_budget_on_both_approaches():
 def test_interface_spec_non_blackbox_appends_inspect():
     """Non-blackbox interface spec appends the inspect-source suffix."""
     spec = prompts.build_interface_spec(
-        template=prompts.AGENTIC_INTERFACE_SPEC,
+        class_interface=prompts.AGENTIC_CLASS_INTERFACE,
+        run_commands=prompts.AGENTIC_RUN_COMMANDS,
         python_executable="/usr/bin/python3",
         primitives_description="PRIMS_DESC",
         blackbox=False,
     )
     assert "inspect the source code" in spec
-    assert "/usr/bin/python3" in spec
+    assert "/usr/bin/python3 test_approach.py" in spec
     assert "PRIMS_DESC" in spec
 
 
 def test_interface_spec_blackbox_omits_inspect():
     """Blackbox interface spec omits the inspect-source suffix."""
     spec = prompts.build_interface_spec(
-        template=prompts.AGENTIC_INTERFACE_SPEC,
+        class_interface=prompts.AGENTIC_CLASS_INTERFACE,
+        run_commands=prompts.AGENTIC_RUN_COMMANDS,
         python_executable="/usr/bin/python3",
         primitives_description="PRIMS_DESC",
         blackbox=True,
     )
     assert "inspect the source code" not in spec
     assert "PRIMS_DESC" in spec
+
+
+def test_interface_spec_shared_wrapper_across_approaches():
+    """Both approaches share the interface-spec wrapper, including the test note."""
+    common = {
+        "python_executable": "/py",
+        "primitives_description": "PRIMS",
+        "blackbox": False,
+    }
+    agentic = prompts.build_interface_spec(
+        class_interface=prompts.AGENTIC_CLASS_INTERFACE,
+        run_commands=prompts.AGENTIC_RUN_COMMANDS,
+        **common,
+    )
+    cdl = prompts.build_interface_spec(
+        class_interface=prompts.CDL_CLASS_INTERFACE,
+        run_commands=prompts.CDL_RUN_COMMANDS,
+        **common,
+    )
+    for spec in (agentic, cdl):
+        assert "Write the best approach you can" in spec
+        assert "Write test scripts that use the real environment" in spec
+    # Structural slots still differ.
+    assert "test_behavior_[behavior_name].py" in cdl
+    assert "test_behavior_[behavior_name].py" not in agentic
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -218,7 +218,7 @@ def test_agentic_prompt_with_description_non_blackbox():
 
 
 def test_agentic_prompt_source_non_blackbox():
-    """Non-blackbox prompt without a description asks to read source."""
+    """Non-blackbox prompt without a description asks to read source, with geometry."""
     p = prompts.build_agentic_prompt(
         blackbox=False,
         interface_spec="IFACE",
@@ -227,6 +227,7 @@ def test_agentic_prompt_source_non_blackbox():
         env_description=None,
     )
     assert "Read the environment source files" in p
+    assert "5-10 bullet points" in p  # geometry applies in every branch
     assert "Write MODULAR code" not in p
 
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,5 +1,7 @@
 """Tests for robocode.prompts composition helpers and blackbox deltas."""
 
+import itertools
+
 from robocode import prompts
 from robocode.mcp import (
     MCP_TOOLS_SYSTEM_PROMPT_SUFFIX,
@@ -338,3 +340,241 @@ def test_genplan_constants():
     assert "Return ONLY" in prompts.GENPLAN_INTERFACE_SPEC
     assert prompts.GENPLAN_SUMMARY_PROMPT
     assert "simple strategy" in prompts.GENPLAN_STRATEGY_PROMPT
+
+
+# ---------------------------------------------------------------------------
+# Golden composition tests: pin the exact assembled output so a future fragment
+# reorder, dropped section, or stray separator (e.g. a reintroduced blank line)
+# is caught. Expected values are built from the public fragments in canonical
+# order, so an intentional edit to a fragment's text updates in exactly one
+# place while still locking ordering and the single-blank-line spacing.
+# ---------------------------------------------------------------------------
+
+_IFACE = "<<IFACE>>"
+_SOURCE_OPENER = (
+    "Read the environment source files in this directory to understand the "
+    "state type, action space, and dynamics."
+)
+_SCAFFOLD_CDL_DESCRIPTION = (
+    "You are writing a behavior-based approach for the environment described "
+    "below.\n\nYour approach should be general enough to solve any instance of "
+    "this environment (env.reset()), but it does NOT need to be adaptable to "
+    "different other environments."
+)
+_SCAFFOLD_CDL_BLACKBOX = (
+    "You are writing a behavior-based approach for an environment that you can "
+    "only access as a black box.\n\nYour approach should be general enough to "
+    "solve any instance of this environment (env.reset()), but it does NOT need "
+    "to be adaptable to different other environments."
+)
+
+
+def _cdl_behavior_impl(blackbox, helpers_note):
+    return prompts.CDL_BEHAVIOR_IMPLEMENTATION_PROMPT.format(
+        obs_inspection_note=(
+            prompts.CDL_OBS_INSPECTION_NOTE_BLACKBOX
+            if blackbox
+            else prompts.CDL_OBS_INSPECTION_NOTE
+        ),
+        obs_helpers_note=helpers_note,
+        act_helpers_note=helpers_note,
+    )
+
+
+def test_golden_system_prompt_agentic_nonblackbox_claude():
+    """Exact agentic (non-blackbox) system prompt: intro + shared tails + suffix."""
+    expected = (
+        prompts.AGENTIC_INTRO
+        + prompts.SYSTEM_FILE_DISCIPLINE
+        + prompts.SYSTEM_SUBAGENTS
+        + prompts.SYSTEM_TOKEN_BUDGET
+        + CLAUDE_PROMPT_SUFFIX
+    )
+    assert (
+        prompts.build_system_prompt(
+            intro=prompts.AGENTIC_INTRO, blackbox=False, backend_name="claude"
+        )
+        == expected
+    )
+
+
+def test_golden_system_prompt_cdl_blackbox_claude_with_mcp():
+    """Exact CDL blackbox system prompt: blackbox subagents + blackbox MCP suffix."""
+    expected = (
+        prompts.CDL_INTRO_BLACKBOX
+        + prompts.SYSTEM_FILE_DISCIPLINE
+        + prompts.SYSTEM_SUBAGENTS_BLACKBOX
+        + prompts.SYSTEM_TOKEN_BUDGET
+        + CLAUDE_PROMPT_SUFFIX
+        + MCP_TOOLS_SYSTEM_PROMPT_SUFFIX_BLACKBOX
+    )
+    assert (
+        prompts.build_system_prompt(
+            intro=prompts.CDL_INTRO_BLACKBOX,
+            blackbox=True,
+            backend_name="claude",
+            mcp_tools=("render_state",),
+        )
+        == expected
+    )
+
+
+def test_golden_system_prompt_opencode_suffix():
+    """Exact agentic system prompt under the opencode backend suffix."""
+    expected = (
+        prompts.AGENTIC_INTRO
+        + prompts.SYSTEM_FILE_DISCIPLINE
+        + prompts.SYSTEM_SUBAGENTS
+        + prompts.SYSTEM_TOKEN_BUDGET
+        + OPENCODE_PROMPT_SUFFIX
+    )
+    assert (
+        prompts.build_system_prompt(
+            intro=prompts.AGENTIC_INTRO, blackbox=False, backend_name="opencode"
+        )
+        == expected
+    )
+
+
+def test_golden_interface_spec_agentic_nonblackbox():
+    """Exact agentic interface spec: filled template plus the inspect-source suffix."""
+    expected = prompts.INTERFACE_SPEC_TEMPLATE.format(
+        class_interface=prompts.AGENTIC_CLASS_INTERFACE,
+        primitives_description="PRIMS",
+        python_executable="/py",
+        run_commands="/py test_approach.py",
+    ) + prompts.INSPECT_SOURCE_SUFFIX.format(python_executable="/py")
+    assert (
+        prompts.build_interface_spec(
+            class_interface=prompts.AGENTIC_CLASS_INTERFACE,
+            run_commands=prompts.AGENTIC_RUN_COMMANDS,
+            python_executable="/py",
+            primitives_description="PRIMS",
+            blackbox=False,
+        )
+        == expected
+    )
+
+
+def test_golden_agentic_task_prompt_source_with_geometry():
+    """Exact agentic source-branch prompt: opener, geometry, interface (one blank
+    line between sections)."""
+    expected = _SOURCE_OPENER + "\n" + prompts.GEOMETRY_PROMPT + "\n" + _IFACE + "\n"
+    prompt = prompts.build_agentic_prompt(
+        blackbox=False,
+        interface_spec=_IFACE,
+        geometry=True,
+        modular_code=False,
+        env_description=None,
+    )
+    assert prompt == expected
+    assert "\n\n\n" not in prompt
+
+
+def test_golden_cdl_task_prompt_source_with_geometry():
+    """Exact CDL source-branch prompt: optional fragments self-separate, so no
+    doubled blank line accumulates ahead of the decomposition section."""
+    expected = (
+        _SOURCE_OPENER
+        + "\n"
+        + prompts.GEOMETRY_PROMPT
+        + prompts.CDL_DECOMPOSITION_PROMPT
+        + "\n"
+        + _IFACE
+        + "\n"
+        + _cdl_behavior_impl(blackbox=False, helpers_note="")
+    )
+    prompt = prompts.build_cdl_prompt(
+        blackbox=False,
+        interface_spec=_IFACE,
+        geometry=True,
+        env_description=None,
+        has_initial_helpers=False,
+    )
+    assert prompt == expected
+    assert "\n\n\n" not in prompt
+
+
+def test_golden_cdl_task_prompt_blackbox_with_helpers():
+    """Exact CDL blackbox prompt: scaffold, interaction spec, helpers + geometry +
+    decomposition, interface, behavior impl, with single-blank-line spacing."""
+    expected = (
+        _SCAFFOLD_CDL_BLACKBOX
+        + "\n\n"
+        + prompts.BLACKBOX_INTERACTION_SPEC.format(
+            set_state_note=prompts.BLACKBOX_SET_STATE_NOTE
+        )
+        + "\n"
+        + prompts.CDL_INITIAL_HELPERS_PROMPT
+        + prompts.GEOMETRY_PROMPT
+        + prompts.CDL_DECOMPOSITION_PROMPT
+        + "\n"
+        + _IFACE
+        + "\n"
+        + _cdl_behavior_impl(
+            blackbox=True, helpers_note=prompts.CDL_HELPERS_PROVIDED_NOTE
+        )
+    )
+    prompt = prompts.build_cdl_prompt(
+        blackbox=True,
+        interface_spec=_IFACE,
+        geometry=True,
+        env_description=None,
+        has_initial_helpers=True,
+    )
+    assert prompt == expected
+    assert "\n\n\n" not in prompt
+
+
+def test_golden_cdl_task_prompt_description_with_helpers():
+    """Exact CDL description-branch prompt with provided helpers and geometry."""
+    expected = (
+        _SCAFFOLD_CDL_DESCRIPTION
+        + "\n\n"
+        + "ENVDESC"
+        + "\n"
+        + prompts.CDL_INITIAL_HELPERS_PROMPT
+        + prompts.GEOMETRY_PROMPT
+        + prompts.CDL_DECOMPOSITION_PROMPT
+        + "\n"
+        + _IFACE
+        + "\n"
+        + _cdl_behavior_impl(
+            blackbox=False, helpers_note=prompts.CDL_HELPERS_PROVIDED_NOTE
+        )
+    )
+    prompt = prompts.build_cdl_prompt(
+        blackbox=False,
+        interface_spec=_IFACE,
+        geometry=True,
+        env_description="ENVDESC",
+        has_initial_helpers=True,
+    )
+    assert prompt == expected
+    assert "\n\n\n" not in prompt
+
+
+def test_no_doubled_blank_lines_in_any_task_prompt():
+    """No composed task prompt contains a doubled blank line, in any config."""
+    for blackbox, geometry, modular, env in itertools.product(
+        (False, True), (False, True), (False, True), (None, "ENVDESC")
+    ):
+        prompt = prompts.build_agentic_prompt(
+            blackbox=blackbox,
+            interface_spec=_IFACE,
+            geometry=geometry,
+            modular_code=modular,
+            env_description=env,
+        )
+        assert "\n\n\n" not in prompt, ("agentic", blackbox, geometry, modular, env)
+    for blackbox, geometry, env, helpers in itertools.product(
+        (False, True), (False, True), (None, "ENVDESC"), (False, True)
+    ):
+        prompt = prompts.build_cdl_prompt(
+            blackbox=blackbox,
+            interface_spec=_IFACE,
+            geometry=geometry,
+            env_description=env,
+            has_initial_helpers=helpers,
+        )
+        assert "\n\n\n" not in prompt, ("cdl", blackbox, geometry, env, helpers)


### PR DESCRIPTION
## Summary

Consolidates all coding-agent prompt text into a single `src/robocode/prompts.py`
module: one source of truth for the instructions fed to `AgenticApproach`,
`AgenticCDLApproach`, and the non-agentic `LLMGenPlanApproach`. The two axes of
variation (approach kind, and blackbox vs reading source) are factored into
shared fragments plus small named deltas, so shared text lives in exactly one
place. The module is source-free (it imports no env or primitives packages), so
it stays safe to import on the host during `train()`.

## Heads-up: some prompts are now unified even where we used to differ

Before this, the agentic and CDL prompts diverged in several ways that were not
well motivated. Rather than preserve those differences, I chose to unify
everything onto one canonical form, **even where that changes the exact text we
had before**. The intentional behavior changes, at a glance:

- **Geometry prompt → terse version.** The monolithic agentic approach used to
  get a long (~40-line) detailed geometric-reasoning prompt; CDL got a short
  ~10-line one. Both now use the short version.
- **Geometry prompt now also in the read-source branch.** Previously neither
  approach included the geometry prompt when reading env source directly; both
  do now.
- **Token-budget guidance on both system prompts.** CDL already had the
  "be concise, put arithmetic in code" token-budget block; the agentic system
  prompt now gets it too.
- **CDL system prompt gains the learning clause.** "You will read environment
  source code ... and write an optimal approach class" (and the
  ", and write an optimal approach class" tail in blackbox mode) was on the
  agentic prompt only; CDL now shares it.
- **Interface spec: "Write test scripts ..." sentence.** Was on the agentic
  interface spec only; the CDL interface spec now includes it.
- **Task-prompt scaffold unified.** The blackbox task prompt now says "solve any
  instance of this environment (env.reset())" instead of "(each reset gives a
  new instance)".
- **CDL blackbox interaction spec.** CDL now uses the same canonical
  `make_primitives()` code-block form as the agentic approach instead of its
  prior prose form.
- **CDL prompt spacing normalized.** Optional fragments no longer accumulate
  doubled blank lines between sections.

The `LLMGenPlanApproach` prompts are byte-identical to before.

## Tests

- New `tests/test_prompts.py`: covers the composition helpers and the blackbox
  deltas, plus golden assertions pinning the exact composed system / interface /
  task prompts (built from the public fragments in canonical order), and a sweep
  asserting no doubled blank lines in any config.
- mypy clean, pylint 10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
