### PR TITLE
Bilevel planning (SeSamE) per-instance baseline

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,12 @@
 [submodule "third-party/kindergarden"]
 	path = third-party/kindergarden
-	url = https://github.com/Jaraxxus-Me/kindergarden
+	url = https://github.com/Princeton-Robot-Planning-and-Learning/kindergarden
 [submodule "third-party/cap-x"]
 	path = third-party/cap-x
 	url = https://github.com/Jaraxxus-Me/cap-x
 [submodule "third-party/LIBERO-PRO"]
 	path = third-party/LIBERO-PRO
 	url = https://github.com/uynitsuj/LIBERO-PRO
+[submodule "third-party/kinder-baselines"]
+	path = third-party/kinder-baselines
+	url = https://github.com/Princeton-Robot-Planning-and-Learning/kinder-baselines

--- a/experiments/conf/approach/backend/claude_haiku.yaml
+++ b/experiments/conf/approach/backend/claude_haiku.yaml
@@ -1,0 +1,2 @@
+backend: claude
+model: haiku

--- a/experiments/conf/approach/bilevel_planning.yaml
+++ b/experiments/conf/approach/bilevel_planning.yaml
@@ -1,0 +1,14 @@
+_target_: robocode.approaches.bilevel_planning_approach.BilevelPlanningApproach
+
+# The planner has no LLM cost (cost_usd is always 0.0), so the dollar budget is
+# never spent and every eval seed is attempted. These keys must exist and be > 0
+# because run_per_instance_eval reads them; their value does not matter.
+max_budget_usd: 1.0
+max_budget_per_instance_usd: null
+
+# SeSamE planner parameters (defaults match kinder_bilevel_planning.agent).
+max_abstract_plans: 10
+samples_per_step: 10
+max_skill_horizon: 100
+heuristic_name: hff
+planning_timeout: 30.0

--- a/experiments/conf/environment/clutteredretrieval2d_easy.yaml
+++ b/experiments/conf/environment/clutteredretrieval2d_easy.yaml
@@ -1,2 +1,5 @@
 _target_: robocode.environments.kinder_geom2d_env.KinderGeom2DEnv
 env_id: kinder/ClutteredRetrieval2D-o1-v0
+bilevel_env_name: clutteredretrieval2d
+bilevel_env_model_kwargs:
+  num_obstructions: 1

--- a/experiments/conf/environment/clutteredretrieval2d_hard.yaml
+++ b/experiments/conf/environment/clutteredretrieval2d_hard.yaml
@@ -1,2 +1,5 @@
 _target_: robocode.environments.kinder_geom2d_env.KinderGeom2DEnv
 env_id: kinder/ClutteredRetrieval2D-o25-v0
+bilevel_env_name: clutteredretrieval2d
+bilevel_env_model_kwargs:
+  num_obstructions: 25

--- a/experiments/conf/environment/clutteredretrieval2d_medium.yaml
+++ b/experiments/conf/environment/clutteredretrieval2d_medium.yaml
@@ -1,2 +1,5 @@
 _target_: robocode.environments.kinder_geom2d_env.KinderGeom2DEnv
 env_id: kinder/ClutteredRetrieval2D-o10-v0
+bilevel_env_name: clutteredretrieval2d
+bilevel_env_model_kwargs:
+  num_obstructions: 10

--- a/experiments/conf/environment/clutteredstorage2d_easy.yaml
+++ b/experiments/conf/environment/clutteredstorage2d_easy.yaml
@@ -1,2 +1,5 @@
 _target_: robocode.environments.kinder_geom2d_env.KinderGeom2DEnv
 env_id: kinder/ClutteredStorage2D-b1-v0
+bilevel_env_name: clutteredstorage2d
+bilevel_env_model_kwargs:
+  num_blocks: 1

--- a/experiments/conf/environment/clutteredstorage2d_hard.yaml
+++ b/experiments/conf/environment/clutteredstorage2d_hard.yaml
@@ -1,2 +1,5 @@
 _target_: robocode.environments.kinder_geom2d_env.KinderGeom2DEnv
 env_id: kinder/ClutteredStorage2D-b7-v0
+bilevel_env_name: clutteredstorage2d
+bilevel_env_model_kwargs:
+  num_blocks: 7

--- a/experiments/conf/environment/clutteredstorage2d_medium.yaml
+++ b/experiments/conf/environment/clutteredstorage2d_medium.yaml
@@ -1,2 +1,5 @@
 _target_: robocode.environments.kinder_geom2d_env.KinderGeom2DEnv
 env_id: kinder/ClutteredStorage2D-b3-v0
+bilevel_env_name: clutteredstorage2d
+bilevel_env_model_kwargs:
+  num_blocks: 3

--- a/experiments/conf/environment/motion2d_easy.yaml
+++ b/experiments/conf/environment/motion2d_easy.yaml
@@ -1,2 +1,5 @@
 _target_: robocode.environments.kinder_geom2d_env.KinderGeom2DEnv
 env_id: kinder/Motion2D-p0-v0
+bilevel_env_name: motion2d
+bilevel_env_model_kwargs:
+  num_passages: 0

--- a/experiments/conf/environment/motion2d_hard.yaml
+++ b/experiments/conf/environment/motion2d_hard.yaml
@@ -1,2 +1,5 @@
 _target_: robocode.environments.kinder_geom2d_env.KinderGeom2DEnv
 env_id: kinder/Motion2D-p3-v0
+bilevel_env_name: motion2d
+bilevel_env_model_kwargs:
+  num_passages: 3

--- a/experiments/conf/environment/motion2d_medium.yaml
+++ b/experiments/conf/environment/motion2d_medium.yaml
@@ -1,2 +1,5 @@
 _target_: robocode.environments.kinder_geom2d_env.KinderGeom2DEnv
 env_id: kinder/Motion2D-p1-v0
+bilevel_env_name: motion2d
+bilevel_env_model_kwargs:
+  num_passages: 1

--- a/experiments/conf/environment/obstruction2d_easy.yaml
+++ b/experiments/conf/environment/obstruction2d_easy.yaml
@@ -1,2 +1,5 @@
 _target_: robocode.environments.kinder_geom2d_env.KinderGeom2DEnv
 env_id: kinder/Obstruction2D-o0-v0
+bilevel_env_name: obstruction2d
+bilevel_env_model_kwargs:
+  num_obstructions: 0

--- a/experiments/conf/environment/obstruction2d_hard.yaml
+++ b/experiments/conf/environment/obstruction2d_hard.yaml
@@ -1,2 +1,5 @@
 _target_: robocode.environments.kinder_geom2d_env.KinderGeom2DEnv
 env_id: kinder/Obstruction2D-o4-v0
+bilevel_env_name: obstruction2d
+bilevel_env_model_kwargs:
+  num_obstructions: 4

--- a/experiments/conf/environment/obstruction2d_medium.yaml
+++ b/experiments/conf/environment/obstruction2d_medium.yaml
@@ -1,2 +1,5 @@
 _target_: robocode.environments.kinder_geom2d_env.KinderGeom2DEnv
 env_id: kinder/Obstruction2D-o2-v0
+bilevel_env_name: obstruction2d
+bilevel_env_model_kwargs:
+  num_obstructions: 2

--- a/experiments/conf/environment/stickbutton2d_easy.yaml
+++ b/experiments/conf/environment/stickbutton2d_easy.yaml
@@ -1,2 +1,5 @@
 _target_: robocode.environments.kinder_geom2d_env.KinderGeom2DEnv
 env_id: kinder/StickButton2D-b1-v0
+bilevel_env_name: stickbutton2d
+bilevel_env_model_kwargs:
+  num_buttons: 1

--- a/experiments/conf/environment/stickbutton2d_hard.yaml
+++ b/experiments/conf/environment/stickbutton2d_hard.yaml
@@ -1,2 +1,5 @@
 _target_: robocode.environments.kinder_geom2d_env.KinderGeom2DEnv
 env_id: kinder/StickButton2D-b5-v0
+bilevel_env_name: stickbutton2d
+bilevel_env_model_kwargs:
+  num_buttons: 5

--- a/experiments/conf/environment/stickbutton2d_medium.yaml
+++ b/experiments/conf/environment/stickbutton2d_medium.yaml
@@ -1,2 +1,5 @@
 _target_: robocode.environments.kinder_geom2d_env.KinderGeom2DEnv
 env_id: kinder/StickButton2D-b3-v0
+bilevel_env_name: stickbutton2d
+bilevel_env_model_kwargs:
+  num_buttons: 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,10 @@ dependencies = [
    "hydra-core",
    "hydra-joblib-launcher",
    "omegaconf",
-   "kindergarden[kinematic2d,kinematic3d,dynamic2d,dynamic3d]",
+   "kindergarden",
+   "bilevel_planning>=0.1.4",
+   "kinder_bilevel_planning",
+   "kinder_models",
    "pybullet",
    "types-shapely",
    "scipy-stubs",
@@ -82,6 +85,8 @@ exclude = ["venv/*", ".venv/*", "outputs/*", "third-party/*"]
 [tool.uv.sources]
 kindergarden = { path = "third-party/kindergarden", editable = true }
 libero = { path = "third-party/LIBERO-PRO", editable = true }
+kinder_bilevel_planning = { path = "third-party/kinder-baselines/kinder-bilevel-planning", editable = true }
+kinder_models = { path = "third-party/kinder-baselines/kinder-models", editable = true }
 
 [[tool.mypy.overrides]]
 module = [

--- a/src/robocode/approaches/base_approach.py
+++ b/src/robocode/approaches/base_approach.py
@@ -3,7 +3,7 @@
 import abc
 import copy
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Generic, SupportsFloat, TypeVar
 
@@ -22,6 +22,10 @@ class InstanceResult:
     program produced, or a scoring crash) has no episode metrics. ``cost_usd``
     is always populated so the runner can charge it against the global budget
     even when the attempt failed.
+
+    ``extras`` carries approach-specific per-instance metrics (e.g. a planner's
+    ``planning_time``). Numeric extras are averaged across scored episodes by
+    ``run_per_instance_eval`` and surfaced as ``mean_<key>`` in the results.
     """
 
     solved: bool
@@ -30,6 +34,7 @@ class InstanceResult:
     cost_usd: float
     crashed: bool = False
     frames: list[Any] | None = None
+    extras: dict[str, Any] = field(default_factory=dict)
 
 
 class BaseApproach(Generic[_StateType, _ActType], abc.ABC):

--- a/src/robocode/approaches/bilevel_planning_approach.py
+++ b/src/robocode/approaches/bilevel_planning_approach.py
@@ -18,6 +18,7 @@ import time
 from pathlib import Path
 from typing import Any
 
+import numpy as np
 from kinder_bilevel_planning.agent import AgentFailure, BilevelPlanningAgent
 from kinder_bilevel_planning.env_models import create_bilevel_planning_models
 
@@ -36,7 +37,6 @@ class BilevelPlanningApproach(BaseApproach[Any, Any]):
         seed: int,
         primitives: dict[str, Any],
         *,
-        env: Any,
         max_steps: int,
         max_abstract_plans: int = 10,
         samples_per_step: int = 10,
@@ -46,14 +46,14 @@ class BilevelPlanningApproach(BaseApproach[Any, Any]):
         **kwargs: Any,
     ) -> None:
         super().__init__(action_space, observation_space, seed, primitives, **kwargs)
-        self._env = env
         self._max_steps = max_steps
         self._max_abstract_plans = max_abstract_plans
         self._samples_per_step = samples_per_step
         self._max_skill_horizon = max_skill_horizon
         self._heuristic_name = heuristic_name
         self._planning_timeout = planning_timeout
-        # SesameModels depend only on the (fixed) env, so build once and reuse.
+        # SesameModels depend only on the (fixed) env, so build once from the env
+        # handed to solve_instance and reuse across seeds.
         self._models: Any | None = None
         self._agent: BilevelPlanningAgent | None = None
 
@@ -65,17 +65,17 @@ class BilevelPlanningApproach(BaseApproach[Any, Any]):
             "train() is not used (the runner branches on approach.per_instance)"
         )
 
-    def _get_models(self) -> Any:
+    def _get_models(self, env: Any) -> Any:
         if self._models is None:
-            assert self._env.bilevel_env_name is not None, (
+            assert env.bilevel_env_name is not None, (
                 "BilevelPlanningApproach needs bilevel_env_name on the environment; "
                 "add bilevel_env_name and bilevel_env_model_kwargs to the env config."
             )
             self._models = create_bilevel_planning_models(
-                self._env.bilevel_env_name,
-                self._env.observation_space,
-                self._env.action_space,
-                **self._env.bilevel_env_model_kwargs,
+                env.bilevel_env_name,
+                env.observation_space,
+                env.action_space,
+                **env.bilevel_env_model_kwargs,
             )
         return self._models
 
@@ -101,7 +101,7 @@ class BilevelPlanningApproach(BaseApproach[Any, Any]):
         every seed is attempted.
         """
         del budget_usd, output_subdir
-        models = self._get_models()
+        models = self._get_models(env)
         agent: BilevelPlanningAgent[Any, Any, Any] = BilevelPlanningAgent(
             models,
             seed=seed,
@@ -140,7 +140,9 @@ class BilevelPlanningApproach(BaseApproach[Any, Any]):
 
         def _capture() -> None:
             rendered = env.render()
-            if rendered is not None:
+            # render() may return a single frame, a list, or None; keep only
+            # numpy RGB frames (matches run_episode and what save_video expects).
+            if isinstance(rendered, np.ndarray):
                 frames.append(rendered)
 
         if render:

--- a/src/robocode/approaches/bilevel_planning_approach.py
+++ b/src/robocode/approaches/bilevel_planning_approach.py
@@ -1,0 +1,189 @@
+"""Per-instance bilevel planning (SeSamE) baseline.
+
+For each eval seed the SeSamE planner is run once to produce an open-loop action
+sequence, which is then executed without replanning. This is a reference baseline
+whose planning cost grows with the object count `N`: it degrades (slow, then no
+plan within the timeout) as instances get harder, in contrast to a frozen
+generalized program. It runs entirely on the host (no LLM, no sandbox), so every
+attempt is free (`cost_usd=0.0`) and per-instance time is bounded by
+`planning_timeout` (planning) and `max_steps` (execution).
+
+The bilevel planning models (predicates, operators, parameterized skills,
+samplers, and a transition simulator) come from `kinder_bilevel_planning`, built
+from the env's `bilevel_env_name` / `bilevel_env_model_kwargs` mapping (see
+`KinderGeom2DEnv`).
+"""
+
+import time
+from pathlib import Path
+from typing import Any
+
+from kinder_bilevel_planning.agent import AgentFailure, BilevelPlanningAgent
+from kinder_bilevel_planning.env_models import create_bilevel_planning_models
+
+from robocode.approaches.base_approach import BaseApproach, InstanceResult
+
+
+class BilevelPlanningApproach(BaseApproach[Any, Any]):
+    """Solve each eval seed with a fresh SeSamE plan, executed open-loop."""
+
+    per_instance = True
+
+    def __init__(
+        self,
+        action_space: Any,
+        observation_space: Any,
+        seed: int,
+        primitives: dict[str, Any],
+        *,
+        env: Any,
+        max_steps: int,
+        max_abstract_plans: int = 10,
+        samples_per_step: int = 10,
+        max_skill_horizon: int = 100,
+        heuristic_name: str = "hff",
+        planning_timeout: float = 30.0,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(action_space, observation_space, seed, primitives, **kwargs)
+        self._env = env
+        self._max_steps = max_steps
+        self._max_abstract_plans = max_abstract_plans
+        self._samples_per_step = samples_per_step
+        self._max_skill_horizon = max_skill_horizon
+        self._heuristic_name = heuristic_name
+        self._planning_timeout = planning_timeout
+        # SesameModels depend only on the (fixed) env, so build once and reuse.
+        self._models: Any | None = None
+        self._agent: BilevelPlanningAgent | None = None
+
+    def train(self) -> None:
+        # Per-instance approaches solve each seed via solve_instance; the runner
+        # branches on approach.per_instance and never calls train().
+        raise NotImplementedError(
+            "BilevelPlanningApproach solves each seed via solve_instance; "
+            "train() is not used (the runner branches on approach.per_instance)"
+        )
+
+    def _get_models(self) -> Any:
+        if self._models is None:
+            assert self._env.bilevel_env_name is not None, (
+                "BilevelPlanningApproach needs bilevel_env_name on the environment; "
+                "add bilevel_env_name and bilevel_env_model_kwargs to the env config."
+            )
+            self._models = create_bilevel_planning_models(
+                self._env.bilevel_env_name,
+                self._env.observation_space,
+                self._env.action_space,
+                **self._env.bilevel_env_model_kwargs,
+            )
+        return self._models
+
+    def _get_action(self) -> Any:
+        # solve_instance drives the planner directly; this keeps the ABC honest.
+        assert self._agent is not None, "solve_instance must run planning first"
+        return self._agent.step()
+
+    def solve_instance(
+        self,
+        *,
+        env: Any,
+        seed: int,
+        budget_usd: float,
+        output_subdir: Path,
+        render: bool = False,
+    ) -> InstanceResult:
+        """Plan once for this seed, then execute the plan open-loop.
+
+        A planning timeout or an unreachable goal surfaces as ``AgentFailure`` and
+        is scored as an unsolved (not crashed) attempt. The dollar ``budget_usd``
+        is unused: the planner has no LLM cost, so ``cost_usd`` is always 0.0 and
+        every seed is attempted.
+        """
+        del budget_usd, output_subdir
+        models = self._get_models()
+        agent: BilevelPlanningAgent[Any, Any, Any] = BilevelPlanningAgent(
+            models,
+            seed=seed,
+            max_abstract_plans=self._max_abstract_plans,
+            samples_per_step=self._samples_per_step,
+            max_skill_horizon=self._max_skill_horizon,
+            heuristic_name=self._heuristic_name,
+            planning_timeout=self._planning_timeout,
+        )
+        self._agent = agent
+
+        obs, info = env.reset(seed=seed)
+
+        plan_start = time.perf_counter()
+        try:
+            agent.reset(obs, info)
+            plan_found = True
+        except AgentFailure:
+            plan_found = False
+        planning_time = time.perf_counter() - plan_start
+
+        if not plan_found:
+            return InstanceResult(
+                solved=False,
+                total_reward=None,
+                num_steps=None,
+                cost_usd=0.0,
+                extras={
+                    "planning_time": planning_time,
+                    "plan_found": False,
+                    "plan_length": 0,
+                },
+            )
+
+        frames: list[Any] = []
+
+        def _capture() -> None:
+            rendered = env.render()
+            if rendered is not None:
+                frames.append(rendered)
+
+        if render:
+            _capture()
+
+        total_reward = 0.0
+        num_steps = 0
+        terminated = False
+        execution_time = 0.0
+        env_step_time = 0.0
+        for _ in range(self._max_steps):
+            t0 = time.perf_counter()
+            try:
+                action = agent.step()
+            except AgentFailure:
+                # Plan exhausted before the goal was reached: stop and score.
+                execution_time += time.perf_counter() - t0
+                break
+            execution_time += time.perf_counter() - t0
+            t0 = time.perf_counter()
+            obs, reward, terminated, truncated, info = env.step(action)
+            env_step_time += time.perf_counter() - t0
+            total_reward += float(reward)
+            num_steps += 1
+            t0 = time.perf_counter()
+            agent.update(obs, float(reward), terminated or truncated, info)
+            execution_time += time.perf_counter() - t0
+            if render:
+                _capture()
+            if terminated or truncated:
+                break
+
+        return InstanceResult(
+            solved=bool(terminated),
+            total_reward=total_reward,
+            num_steps=num_steps,
+            cost_usd=0.0,
+            frames=frames if render else None,
+            extras={
+                "planning_time": planning_time,
+                "execution_time": execution_time,
+                "env_step_time": env_step_time,
+                "plan_length": num_steps,
+                "plan_found": True,
+            },
+        )

--- a/src/robocode/environments/kinder_geom2d_env.py
+++ b/src/robocode/environments/kinder_geom2d_env.py
@@ -62,12 +62,28 @@ def _unwrap_to_kinder(env: gymnasium.Env) -> ConstantObjectKinDEREnv:
 class KinderGeom2DEnv(BaseEnv[NDArray[Any], NDArray[Any]]):
     """A robocode environment backed by a kinder geom2d environment."""
 
-    def __init__(self, env_id: str) -> None:
+    def __init__(
+        self,
+        env_id: str,
+        bilevel_env_name: str | None = None,
+        bilevel_env_model_kwargs: dict[str, Any] | None = None,
+    ) -> None:
         self._env_id = env_id
         self._kinder_env = _unwrap_to_kinder(kinder.make(env_id))
         self.observation_space = self._kinder_env.observation_space
         self.action_space = self._kinder_env.action_space
         self._current_obs: NDArray[Any] | None = None
+        # Optional mapping to the bilevel planning models for this env family,
+        # consumed by BilevelPlanningApproach. `bilevel_env_name` is the family
+        # (e.g. "obstruction2d") and `bilevel_env_model_kwargs` its object-count
+        # kwargs (e.g. {"num_obstructions": 2}). Stored as a plain dict since
+        # Hydra passes a DictConfig.
+        self.bilevel_env_name = bilevel_env_name
+        self.bilevel_env_model_kwargs = (
+            dict(bilevel_env_model_kwargs)
+            if bilevel_env_model_kwargs is not None
+            else {}
+        )
         super().__init__()
 
     @property

--- a/src/robocode/utils/episode.py
+++ b/src/robocode/utils/episode.py
@@ -154,6 +154,9 @@ def run_per_instance_eval(
             save_video(result.frames, video_dir / f"episode_{i}.gif")
         per_episode.append(
             {
+                # Approach-specific per-instance metrics first; the fixed keys
+                # below take precedence over any colliding extras key.
+                **result.extras,
                 "seed": seed,
                 "attempted": True,
                 "solved": result.solved,
@@ -172,7 +175,7 @@ def run_per_instance_eval(
         return float(np.mean(vals)) if vals else float("nan")
 
     num_eval = len(eval_seeds)
-    return {
+    results = {
         "mean_eval_reward": _mean("total_reward"),
         "mean_eval_steps": _mean("num_steps"),
         "solve_rate": num_solved / num_eval if num_eval else float("nan"),
@@ -184,6 +187,38 @@ def run_per_instance_eval(
         "per_episode": per_episode,
         "total_cost_usd": total_cost,
     }
+
+    # Average any numeric approach-specific extras (e.g. planning_time) over
+    # scored episodes, surfaced as mean_<key> so they flow into results.json and
+    # become analyze_results columns automatically. Extras keys may vary across
+    # episodes (a failed plan has fewer), so aggregate per key over whoever has it.
+    reserved = {
+        "seed",
+        "attempted",
+        "solved",
+        "crashed",
+        "total_reward",
+        "num_steps",
+        "cost_usd",
+    }
+
+    def _mean_extra(key: str) -> float:
+        vals = [
+            v
+            for e in scored
+            if isinstance((v := e.get(key)), (int, float)) and not isinstance(v, bool)
+        ]
+        return float(np.mean(vals)) if vals else float("nan")
+
+    extra_keys = {
+        k
+        for e in scored
+        for k, v in e.items()
+        if k not in reserved and isinstance(v, (int, float)) and not isinstance(v, bool)
+    }
+    for key in sorted(extra_keys):
+        results[f"mean_{key}"] = _mean_extra(key)
+    return results
 
 
 def save_video(frames: list[NDArray[np.uint8]], path: Path, fps: int = 10) -> None:

--- a/tests/approaches/test_bilevel_planning_approach.py
+++ b/tests/approaches/test_bilevel_planning_approach.py
@@ -1,0 +1,149 @@
+"""Tests for the bilevel planning per-instance baseline."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from robocode.approaches.bilevel_planning_approach import BilevelPlanningApproach
+from robocode.environments.kinder_geom2d_env import KinderGeom2DEnv
+
+
+def _make_env() -> KinderGeom2DEnv:
+    # obstruction2d with 0 obstructions is reliably solvable and fast to plan.
+    return KinderGeom2DEnv(
+        "kinder/Obstruction2D-o0-v0",
+        bilevel_env_name="obstruction2d",
+        bilevel_env_model_kwargs={"num_obstructions": 0},
+    )
+
+
+def _make_approach(env: KinderGeom2DEnv) -> BilevelPlanningApproach:
+    return BilevelPlanningApproach(
+        env.action_space,
+        env.observation_space,
+        seed=0,
+        primitives={},
+        env=env,
+        max_steps=1000,
+        planning_timeout=30.0,
+    )
+
+
+def test_solve_instance_solves_and_reports_metrics(tmp_path: Path) -> None:
+    """A solvable instance is solved and reports the planning/execution split."""
+    env = _make_env()
+    approach = _make_approach(env)
+    result = approach.solve_instance(
+        env=env, seed=0, budget_usd=0.0, output_subdir=tmp_path
+    )
+    assert result.solved
+    assert result.cost_usd == 0.0
+    assert result.crashed is False
+    assert result.extras["plan_found"] is True
+    assert result.extras["plan_length"] == result.num_steps
+    for key in ("planning_time", "execution_time", "env_step_time"):
+        assert result.extras[key] >= 0.0
+
+
+def test_solve_instance_captures_frames_when_rendering(tmp_path: Path) -> None:
+    """Render=True populates InstanceResult.frames so the runner can save a gif."""
+    env = _make_env()
+    approach = _make_approach(env)
+    result = approach.solve_instance(
+        env=env, seed=0, budget_usd=0.0, output_subdir=tmp_path, render=True
+    )
+    assert result.solved
+    assert result.frames is not None
+    assert result.num_steps is not None
+    # One frame captured at reset plus one per executed step.
+    assert len(result.frames) == result.num_steps + 1
+    assert isinstance(result.frames[0], np.ndarray)
+
+
+def test_solve_instance_skips_frames_without_rendering(tmp_path: Path) -> None:
+    """Without render, no frames are captured (frames is None)."""
+    env = _make_env()
+    approach = _make_approach(env)
+    result = approach.solve_instance(
+        env=env, seed=0, budget_usd=0.0, output_subdir=tmp_path
+    )
+    assert result.frames is None
+
+
+def test_models_are_built_once(tmp_path: Path) -> None:
+    """SesameModels depend only on the fixed env, so they are cached across seeds."""
+    env = _make_env()
+    approach = _make_approach(env)
+    approach.solve_instance(env=env, seed=0, budget_usd=0.0, output_subdir=tmp_path)
+    models = approach._models  # pylint: disable=protected-access
+    assert models is not None
+    approach.solve_instance(env=env, seed=1, budget_usd=0.0, output_subdir=tmp_path)
+    assert approach._models is models  # pylint: disable=protected-access
+
+
+def test_planning_failure_is_unsolved_not_crashed(tmp_path: Path) -> None:
+    """A planning timeout scores as an unsolved (not crashed) attempt.
+
+    obstruction2d with 2 obstructions plus a tiny timeout reliably yields no plan (the
+    degradation path). It must return solved=False, crashed=False, no episode metrics,
+    and still report the planning time it spent failing.
+    """
+    env = KinderGeom2DEnv(
+        "kinder/Obstruction2D-o2-v0",
+        bilevel_env_name="obstruction2d",
+        bilevel_env_model_kwargs={"num_obstructions": 2},
+    )
+    approach = BilevelPlanningApproach(
+        env.action_space,
+        env.observation_space,
+        seed=0,
+        primitives={},
+        env=env,
+        max_steps=1000,
+        planning_timeout=0.001,
+    )
+    result = approach.solve_instance(
+        env=env, seed=0, budget_usd=0.0, output_subdir=tmp_path
+    )
+    assert result.solved is False
+    assert result.crashed is False
+    assert result.cost_usd == 0.0
+    assert result.total_reward is None
+    assert result.num_steps is None
+    assert result.extras["plan_found"] is False
+    assert result.extras["plan_length"] == 0
+    assert result.extras["planning_time"] >= 0.0
+
+
+def test_planning_is_deterministic(tmp_path: Path) -> None:
+    """Same seed, same models -> same plan (the planner is seeded)."""
+    env = _make_env()
+    approach = _make_approach(env)
+    r1 = approach.solve_instance(
+        env=env, seed=3, budget_usd=0.0, output_subdir=tmp_path
+    )
+    r2 = approach.solve_instance(
+        env=env, seed=3, budget_usd=0.0, output_subdir=tmp_path
+    )
+    assert r1.solved == r2.solved
+    assert r1.num_steps == r2.num_steps
+    assert r1.total_reward == r2.total_reward
+
+
+def test_missing_mapping_fails_loudly(tmp_path: Path) -> None:
+    """An env without the bilevel mapping raises rather than planning silently."""
+    env = KinderGeom2DEnv("kinder/Obstruction2D-o0-v0")  # no bilevel_env_name
+    approach = _make_approach(env)
+    with pytest.raises(AssertionError, match="bilevel_env_name"):
+        approach.solve_instance(env=env, seed=0, budget_usd=0.0, output_subdir=tmp_path)
+
+
+def test_train_is_not_supported() -> None:
+    """The per-instance baseline does not train a generalized policy."""
+    env = _make_env()
+    approach = _make_approach(env)
+    with pytest.raises(NotImplementedError):
+        approach.train()

--- a/tests/utils/test_episode.py
+++ b/tests/utils/test_episode.py
@@ -122,8 +122,53 @@ def test_per_instance_eval_charges_crashed_attempts(tmp_path: Path) -> None:
     assert out["per_episode"][1]["crashed"] is True
 
 
+def test_per_instance_eval_aggregates_extras(tmp_path: Path) -> None:
+    """Per-instance extras are merged into per_episode and averaged as mean_<key>.
+
+    Extras keys may differ across instances (a failed attempt reports fewer): the
+    aggregation averages each numeric key over whichever scored episodes have it,
+    ignores bools (e.g. a flag), and never lets extras clobber the fixed keys.
+    """
+    results = [
+        InstanceResult(
+            solved=True,
+            total_reward=1.0,
+            num_steps=5,
+            cost_usd=0.0,
+            extras={
+                "planning_time": 2.0,
+                "execution_time": 4.0,
+                "plan_found": True,
+                "seed": 999,  # collides with a fixed key; must be ignored
+            },
+        ),
+        InstanceResult(
+            solved=False,
+            total_reward=None,
+            num_steps=None,
+            cost_usd=0.0,
+            # A failed plan reports planning_time but no execution_time.
+            extras={"planning_time": 6.0, "plan_found": False},
+        ),
+    ]
+    approach = _ScriptedPerInstanceApproach(results)
+    out = run_per_instance_eval(
+        None, approach, [3, 4], max_budget_usd=1.0, output_dir=tmp_path
+    )
+    # planning_time is present on both scored episodes -> mean of 2.0 and 6.0.
+    assert out["mean_planning_time"] == pytest.approx(4.0)
+    # execution_time only on the first -> mean over the one that has it.
+    assert out["mean_execution_time"] == pytest.approx(4.0)
+    # bool extras are not averaged.
+    assert "mean_plan_found" not in out
+    # extras are exposed per-episode; the fixed "seed" key is not overwritten.
+    assert out["per_episode"][0]["planning_time"] == pytest.approx(2.0)
+    assert out["per_episode"][0]["seed"] == 3
+    assert out["per_episode"][0]["plan_found"] is True
+
+
 def test_per_instance_eval_threads_render_and_saves_video(tmp_path: Path) -> None:
-    """render is passed to solve_instance and returned frames are saved as a gif."""
+    """Render is passed to solve_instance and returned frames are saved as a gif."""
     rng = np.random.default_rng(0)
     frames = [rng.integers(0, 255, (8, 8, 3), dtype=np.uint8) for _ in range(3)]
     results = [


### PR DESCRIPTION
## Summary

Adds the PRPL SeSamE planner as a **per-instance baseline** (`approach=bilevel_planning`) plus the supporting infrastructure. The planner plans once per eval seed and executes the plan open-loop; it runs entirely on the host (no LLM, no sandbox), so `cost_usd=0` and every seed is attempted.

This is "Role A" of the bilevel-planning integration: the reference baseline whose planning time grows and solve-rate collapses with object count N. A synthesized generalized program (future work, "Role B") is meant to beat it at scale.

## What's included

- **Deps + kindergarden upgrade** (`6c890fc`): repoint the `kindergarden` submodule from the stale `Jaraxxus-Me` fork (zero custom commits) to upstream `Princeton-Robot-Planning-and-Learning` v0.1.3, drop the now-removed `[kinematic2d,...]` extras (already no-ops), and add `bilevel_planning` (PyPI) + editable `kinder_bilevel_planning`/`kinder_models` from a new `third-party/kinder-baselines` submodule.
- **Generic per-instance metrics** (`0e06487`): `InstanceResult.extras` + `mean_<key>` aggregation in `run_per_instance_eval`, so any per-instance approach can report metrics (e.g. `planning_time`) that flow into `results.json` and `analyze_results` automatically.
- **Bilevel baseline** (`adb8ebc`): `BilevelPlanningApproach` + `bilevel_planning.yaml` + env→models mapping (`bilevel_env_name` / `bilevel_env_model_kwargs`) on the 2D env configs, reporting the planning / execution / env-step time split via `extras`.
- **Haiku backend** (`1054da9`): a small `claude_haiku` backend config.

## Degradation curve (the point of the baseline)

Reproduced end-to-end (multirun → `results.json` → `analyze_results`):

| environment | N | solve_rate | mean_planning_time |
|---|---|---|---|
| obstruction2d_easy | o0 | 1.00 | 0.23s |
| obstruction2d_medium | o2 | 0.33 | 8.5s |
| obstruction2d_hard | o4 | 0.00 | 12.4s |

## Testing

- New unit tests: solve + metrics, no-plan/timeout path, determinism, render on/off, and the extras aggregation.
- All 5 mapped 2D families (obstruction, stickbutton, motion, clutteredstorage, clutteredretrieval) solve at `easy` end-to-end.
- `approach=bilevel_planning environment=stickbutton2d_easy render_videos=true` produces metrics + per-episode gifs.
- Repo-wide mypy clean (138 files); 2D fast + 2D oracle suites pass on kindergarden 0.1.3.

## Notes

- The kindergarden bump repoints a submodule; after pulling, run `git submodule sync && git submodule update --init`.
- The sandbox Docker/Apptainer image should be rebuilt (kindergarden bump) so existing **agentic** approaches pick up 0.1.3 — follow-up; the bilevel baseline is host-only and unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
