### PR TITLE
Added consistent timeout to eval

### DIFF
--- a/experiments/conf/approach/best_of_k.yaml
+++ b/experiments/conf/approach/best_of_k.yaml
@@ -15,7 +15,7 @@ max_budget_usd: 5.0  # dollar cap; only bounds cost-reporting backends (null -> 
 # false: a single prompt -> code, sampled per candidate (simplest baseline).
 # true: each candidate repeats GenPlan's summary -> strategy -> code flow, no debug loop.
 chain_of_thought: false
-episode_timeout_s: 30.0
+# The per-episode validation timeout is the shared top-level eval_timeout.
 # Run the whole loop inside one sandbox container (like the agentic approach),
 # so generated code never executes on the host. local runs in-process.
 container_backend: docker  # docker | apptainer | local

--- a/experiments/conf/approach/bilevel_planning.yaml
+++ b/experiments/conf/approach/bilevel_planning.yaml
@@ -7,8 +7,8 @@ max_budget_usd: 1.0
 max_budget_per_instance_usd: null
 
 # SeSamE planner parameters (defaults match kinder_bilevel_planning.agent).
+# The planning-time budget is the shared top-level eval_timeout.
 max_abstract_plans: 10
 samples_per_step: 10
 max_skill_horizon: 100
 heuristic_name: hff
-planning_timeout: 30.0

--- a/experiments/conf/approach/llm_genplan.yaml
+++ b/experiments/conf/approach/llm_genplan.yaml
@@ -12,7 +12,7 @@ num_prompt_tasks: 2
 max_debug_attempts: 4  # step cap: 1 initial attempt + this many debug attempts
 max_budget_usd: 5.0  # dollar cap; only bounds cost-reporting backends (null -> step cap only)
 chain_of_thought: true  # summary -> strategy -> code; false: single prompt -> code
-episode_timeout_s: 30.0
+# The per-episode validation timeout is the shared top-level eval_timeout.
 # Run the whole genplan loop inside one sandbox container (like the agentic
 # approach), so generated code never executes on the host. local runs in-process.
 container_backend: docker  # docker | apptainer | local

--- a/experiments/conf/config.yaml
+++ b/experiments/conf/config.yaml
@@ -6,7 +6,7 @@ defaults:
 seed: 42
 max_steps: 1000
 num_eval_tasks: 100
-# Per-instance eval wall-clock budget (seconds), shared by every approach. null disables it.
+# Per-instance eval wall-clock budget (seconds), shared by every approach.
 eval_timeout: 30
 render_videos: false
 record_approach_history: false

--- a/experiments/conf/config.yaml
+++ b/experiments/conf/config.yaml
@@ -6,6 +6,8 @@ defaults:
 seed: 42
 max_steps: 1000
 num_eval_tasks: 100
+# Per-instance eval wall-clock budget (seconds), shared by every approach. null disables it.
+eval_timeout: 30
 render_videos: false
 record_approach_history: false
 primitives:

--- a/experiments/run_experiment.py
+++ b/experiments/run_experiment.py
@@ -51,6 +51,12 @@ def _main(cfg: DictConfig) -> float:
     output_dir = Path(HydraConfig.get().runtime.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
+    if cfg.eval_timeout is None:
+        raise ValueError(
+            "eval_timeout must be set to a number of seconds; it bounds every "
+            "evaluation rollout. Use a large value for an effectively unlimited budget."
+        )
+
     env = hydra.utils.instantiate(cfg.environment)
 
     # If the environment provides a description (e.g. kinder envs), write it

--- a/experiments/run_experiment.py
+++ b/experiments/run_experiment.py
@@ -36,7 +36,7 @@ from robocode.environments.variable_object_count_env import VariableObjectCountE
 from robocode.primitives import build_primitives
 from robocode.utils.approach_history import get_snapshots, record_episodes
 from robocode.utils.episode import (
-    run_episode,
+    run_episode_with_timeout,
     run_per_instance_eval,
     save_video,
     summarize_by_count,
@@ -96,6 +96,7 @@ def _main(cfg: DictConfig) -> float:
         # instantiate it; the llm_genplan docker driver rebuilds the env from it.
         env_cfg=json.dumps(OmegaConf.to_container(cfg.environment, resolve=True)),
         max_steps=cfg.max_steps,
+        eval_timeout=cfg.eval_timeout,
         _partial_=True,
     )
     approach = approach_ctor(primitives=primitives)
@@ -171,8 +172,14 @@ def _main(cfg: DictConfig) -> float:
                 else cfg.max_steps
             )
             try:
-                episode_result, frames, _ = run_episode(
-                    env, approach, s, episode_max_steps, render=render, count=count
+                episode_result, frames, _ = run_episode_with_timeout(
+                    env,
+                    approach,
+                    s,
+                    episode_max_steps,
+                    timeout=cfg.eval_timeout,
+                    render=render,
+                    count=count,
                 )
             except Exception as exc:  # pylint: disable=broad-exception-caught
                 # A loaded policy can raise on an unseen eval seed. We cannot fairly

--- a/src/robocode/approaches/agentic_base.py
+++ b/src/robocode/approaches/agentic_base.py
@@ -74,6 +74,7 @@ class GeneratedProgramApproach(BaseApproach[_ObsType, _ActType]):
         blackbox: bool = False,
         env_cfg: str | None = None,
         max_steps: int | None = None,
+        eval_timeout: float = 30.0,
         **kwargs: Any,
     ) -> None:
         super().__init__(
@@ -104,6 +105,7 @@ class GeneratedProgramApproach(BaseApproach[_ObsType, _ActType]):
         self._object_centric = isinstance(observation_space, ObjectCentricStateSpace)
         self._env_cfg = env_cfg
         self._max_steps = max_steps
+        self._eval_timeout = eval_timeout
         if blackbox:
             if env_cfg is None:
                 raise ValueError("blackbox mode requires env_cfg")
@@ -129,8 +131,9 @@ class GeneratedProgramApproach(BaseApproach[_ObsType, _ActType]):
 
         Shared by the generalized ``train()`` (``per_instance_seed=None``) and
         per-instance ``solve_instance()`` (a concrete seed); the seed -- and, for a
-        variable-count env, ``per_instance_count`` -- are threaded into the task prompt
-        so the agent develops against the same instance it is scored on. If we have an
+        variable-count env, ``per_instance_count`` -- name the target instance in the
+        system prompt's goal so the agent develops against the same instance it is
+        scored on, and add a budget-stewardship note to the task prompt. If we have an
         env description it is inlined; otherwise the agent is asked to read source files.
         """
         primitives_desc = format_primitives_description(
@@ -169,7 +172,6 @@ class GeneratedProgramApproach(BaseApproach[_ObsType, _ActType]):
             modular_code=self._modular_code_prompt,
             env_description=env_description,
             per_instance_seed=per_instance_seed,
-            per_instance_count=per_instance_count,
             object_centric=self._object_centric,
         )
 
@@ -181,8 +183,11 @@ class GeneratedProgramApproach(BaseApproach[_ObsType, _ActType]):
             ),
             blackbox=self._blackbox,
             backend_name=self._backend_cfg["backend"],
+            timeout=self._eval_timeout,
             mcp_tools=self._mcp_tools,
             object_centric=self._object_centric,
+            per_instance_seed=per_instance_seed,
+            per_instance_count=per_instance_count,
         )
         init_files: dict[str, Path] = {}
         if self._blackbox:

--- a/src/robocode/approaches/agentic_cdl_approach.py
+++ b/src/robocode/approaches/agentic_cdl_approach.py
@@ -74,6 +74,7 @@ class AgenticCDLApproach(BaseApproach[_ObsType, _ActType]):
         blackbox: bool = False,
         env_cfg: str | None = None,
         max_steps: int | None = None,
+        eval_timeout: float = 30.0,
         **kwargs: Any,
     ) -> None:
         super().__init__(
@@ -102,6 +103,7 @@ class AgenticCDLApproach(BaseApproach[_ObsType, _ActType]):
         self._blackbox = blackbox
         self._env_cfg = env_cfg
         self._max_steps = max_steps
+        self._eval_timeout = eval_timeout
         if blackbox:
             if env_cfg is None:
                 raise ValueError("blackbox mode requires env_cfg")
@@ -203,6 +205,7 @@ class AgenticCDLApproach(BaseApproach[_ObsType, _ActType]):
             intro=(prompts.CDL_INTRO_BLACKBOX if self._blackbox else prompts.CDL_INTRO),
             blackbox=self._blackbox,
             backend_name=self._backend_cfg["backend"],
+            timeout=self._eval_timeout,
             mcp_tools=self._mcp_tools,
             object_centric=self._object_centric,
         )

--- a/src/robocode/approaches/agentic_per_instance_approach.py
+++ b/src/robocode/approaches/agentic_per_instance_approach.py
@@ -15,7 +15,7 @@ from typing import Any
 from robocode.approaches.agentic_base import GeneratedProgramApproach
 from robocode.approaches.base_approach import InstanceResult
 from robocode.environments.variable_object_count_env import VariableObjectCountEnv
-from robocode.utils.episode import run_episode
+from robocode.utils.episode import run_episode_with_timeout
 
 logger = logging.getLogger(__name__)
 
@@ -108,8 +108,14 @@ class AgenticPerInstanceApproach(GeneratedProgramApproach):
         )
         try:
             self._load_generated(result.output_file)
-            metrics, frames, _ = run_episode(
-                env, self, seed, episode_max_steps, render=render, count=count
+            metrics, frames, _ = run_episode_with_timeout(
+                env,
+                self,
+                seed,
+                episode_max_steps,
+                timeout=self._eval_timeout,
+                render=render,
+                count=count,
             )
         except Exception as exc:  # pylint: disable=broad-exception-caught
             # Isolate a single seed's bad program (load error or runtime crash):

--- a/src/robocode/approaches/best_of_k_approach.py
+++ b/src/robocode/approaches/best_of_k_approach.py
@@ -113,7 +113,7 @@ class BestOfKApproach(LLMGenPlanApproach):
             self._primitives,
             seeds,
             self._max_steps,
-            self._episode_timeout_s,
+            self._eval_timeout,
         )
 
     def _driver_config(self, completion: dict[str, Any]) -> dict[str, Any]:

--- a/src/robocode/approaches/bilevel_planning_approach.py
+++ b/src/robocode/approaches/bilevel_planning_approach.py
@@ -5,8 +5,8 @@ sequence, which is then executed without replanning. This is a reference baselin
 whose planning cost grows with the object count `N`: it degrades (slow, then no
 plan within the timeout) as instances get harder, in contrast to a frozen
 generalized program. It runs entirely on the host (no LLM, no sandbox), so every
-attempt is free (`cost_usd=0.0`) and per-instance time is bounded by
-`planning_timeout` (planning) and `max_steps` (execution).
+attempt is free (`cost_usd=0.0`) and per-instance time is bounded by the shared
+`eval_timeout` (planning) and `max_steps` (execution).
 
 The bilevel planning models (predicates, operators, parameterized skills,
 samplers, and a transition simulator) come from `kinder_bilevel_planning`, built
@@ -43,7 +43,7 @@ class BilevelPlanningApproach(BaseApproach[Any, Any]):
         samples_per_step: int = 10,
         max_skill_horizon: int = 100,
         heuristic_name: str = "hff",
-        planning_timeout: float = 30.0,
+        eval_timeout: float = 30.0,
         **kwargs: Any,
     ) -> None:
         super().__init__(action_space, observation_space, seed, primitives, **kwargs)
@@ -52,7 +52,7 @@ class BilevelPlanningApproach(BaseApproach[Any, Any]):
         self._samples_per_step = samples_per_step
         self._max_skill_horizon = max_skill_horizon
         self._heuristic_name = heuristic_name
-        self._planning_timeout = planning_timeout
+        self._eval_timeout = eval_timeout
         # Fixed-count env: SesameModels depend only on the env, so build once and reuse.
         # Variable-count env: the models bake in the object count, so they are rebuilt
         # per count and cached by count (see _get_models).
@@ -121,7 +121,7 @@ class BilevelPlanningApproach(BaseApproach[Any, Any]):
             samples_per_step=self._samples_per_step,
             max_skill_horizon=self._max_skill_horizon,
             heuristic_name=self._heuristic_name,
-            planning_timeout=self._planning_timeout,
+            planning_timeout=self._eval_timeout,
         )
         self._agent = agent
 

--- a/src/robocode/approaches/genplan_driver.py
+++ b/src/robocode/approaches/genplan_driver.py
@@ -46,7 +46,7 @@ def main() -> None:
         "num_prompt_tasks": cfg["num_prompt_tasks"],
         "max_budget_usd": cfg["max_budget_usd"],
         "chain_of_thought": cfg["chain_of_thought"],
-        "episode_timeout_s": cfg["episode_timeout_s"],
+        "eval_timeout": cfg["eval_timeout"],
         "container_backend": "local",  # already isolated; run the loop in-process
     }
     approach: LLMGenPlanApproach

--- a/src/robocode/approaches/llm_genplan_approach.py
+++ b/src/robocode/approaches/llm_genplan_approach.py
@@ -61,7 +61,7 @@ class LLMGenPlanApproach(BaseApproach[_ObsType, _ActType]):
         max_debug_attempts: int | None = 4,
         max_budget_usd: float | None = 5.0,
         chain_of_thought: bool = True,
-        episode_timeout_s: float = 30.0,
+        eval_timeout: float = 30.0,
         use_docker: bool = True,
         container_backend: str | None = None,
         docker_image: str = "robocode-sandbox",
@@ -94,7 +94,7 @@ class LLMGenPlanApproach(BaseApproach[_ObsType, _ActType]):
         self._max_debug_attempts = max_debug_attempts
         self._max_budget_usd = max_budget_usd
         self._chain_of_thought = chain_of_thought
-        self._episode_timeout_s = episode_timeout_s
+        self._eval_timeout = eval_timeout
         self._docker_image = docker_image
         self._sif_path = Path(sif_path) if sif_path is not None else _DEFAULT_SIF
         self._generated: Any = None
@@ -187,7 +187,7 @@ class LLMGenPlanApproach(BaseApproach[_ObsType, _ActType]):
             "max_debug_attempts": self._max_debug_attempts,
             "max_budget_usd": self._max_budget_usd,
             "chain_of_thought": self._chain_of_thought,
-            "episode_timeout_s": self._episode_timeout_s,
+            "eval_timeout": self._eval_timeout,
         }
 
     def _train_in_container(self) -> None:
@@ -350,7 +350,7 @@ class LLMGenPlanApproach(BaseApproach[_ObsType, _ActType]):
             self._primitives,
             seeds,
             self._max_steps,
-            self._episode_timeout_s,
+            self._eval_timeout,
         )
 
     # ------------------------------------------------------------- delegation

--- a/src/robocode/prompts.py
+++ b/src/robocode/prompts.py
@@ -6,7 +6,7 @@ Single source of truth for the instructions fed to the coding-agent backends
 stdlib plus the already-centralized backend and MCP suffix constants, never the
 env or primitives packages, so it stays safe to import on the host during
 ``train()``. Dynamic strings (the primitives description, env-description text,
-the python-executable path) are passed in as arguments.
+the python-executable path, the eval-time budget) are passed in as arguments.
 
 Two axes of variation are kept orthogonal and are NEVER expressed as near-copies:
 - approach (agentic / CDL / genplan): legitimately different structural content,
@@ -18,6 +18,10 @@ own piece. The four agentic/CDL system prompts, for instance, share their
 file-discipline and subagent boilerplate verbatim and differ only in a short
 identity sentence and a blackbox-discovery clause, so they are composed from
 fragments here rather than stored as four full strings.
+
+The overall goal and the eval-time budget are stated once, at the top of the
+system prompt (``generalization_goal``): generalize to any instance, or specialize
+to one named instance, under the shared ``timeout``.
 """
 
 from robocode.mcp import (
@@ -258,33 +262,33 @@ The environment is described below.
 
 """
 
-# Shared task-prompt scaffold. The opener sentences and the interface-spec
-# wrapper are common to both approaches; only small slotted pieces (approach
-# kind, class-interface code, run commands, section ordering) differ.
-# The scaffold intro is an opener line plus a generalization clause. The clause
-# is the one piece that flips for per-instance baselines: generalized approaches
-# solve any instance, per-instance approaches specialize to a single seed.
-_SCAFFOLD_INTRO_OPENER = "You are writing {approach_kind} for {target}.\n\n"
-_GENERALIZE_CLAUSE = (
-    "Your approach should be general enough to solve any instance of this "
-    "environment (env.reset()), but it does NOT need to be adaptable to "
-    "different other environments."
-)
-_SCAFFOLD_INTRO = _SCAFFOLD_INTRO_OPENER + _GENERALIZE_CLAUSE
+# Task-prompt opener; the goal + eval budget live in the system prompt
+# (generalization_goal), so the scaffold is just this line.
+_SCAFFOLD_INTRO_OPENER = "You are writing {approach_kind} for {target}."
 
-# Per-instance baselines (one fresh agent run per eval seed) replace the
-# generalization clause with this directive, naming the concrete target instance.
-# In the read-source branch (which has no scaffold intro) it is prepended on its
-# own instead.
-_PER_INSTANCE_DIRECTIVE_TEMPLATE = (
-    "Your approach only needs to solve the single specific instance produced by "
-    "`{reset_call}`. You do NOT need to generalize to other instances "
-    "or environments; you may specialize entirely to this instance."
+# System-prompt goal: generalize to any instance, or specialize to one named
+# instance. Trailing space joins the eval-budget clause below.
+_GENERALIZE_GOAL = (
+    "Your program must generalize to any instance of this environment (any "
+    "env.reset()); it does not need to work on any other environment. "
+)
+_PER_INSTANCE_GOAL_TEMPLATE = (
+    "Your program only needs to solve the single instance produced by "
+    "`{reset_call}`; you may specialize entirely to it, and it does not need to "
+    "generalize to other instances or environments. "
+)
+
+# Eval-time wall-clock budget appended to the goal; {timeout} is the shared eval_timeout.
+_EVAL_BUDGET_CLAUSE = (
+    "At evaluation time your program is given {timeout:g} seconds of wall-clock "
+    "per instance; if it exceeds this budget it is stopped and the instance is "
+    "scored as a failure, so it must select actions efficiently rather than rely "
+    "on exhaustive search or slow planners."
 )
 
 
 def per_instance_directive(seed: int, count: int | None = None) -> str:
-    """The per-instance target directive, naming the exact reset call.
+    """The per-instance goal sentence, naming the exact reset call.
 
     For a variable-count env *count* pins the object count, so the agent develops
     against the same ``(seed, count)`` instance it is scored on rather than an
@@ -295,7 +299,27 @@ def per_instance_directive(seed: int, count: int | None = None) -> str:
         if count is None
         else f"env.reset(seed={seed}, options={{'object_count': {count}}})"
     )
-    return _PER_INSTANCE_DIRECTIVE_TEMPLATE.format(reset_call=reset_call)
+    return _PER_INSTANCE_GOAL_TEMPLATE.format(reset_call=reset_call)
+
+
+def generalization_goal(
+    timeout: float,
+    *,
+    per_instance_seed: int | None = None,
+    per_instance_count: int | None = None,
+) -> str:
+    """The goal + eval-budget statement placed at the top of the system prompt.
+
+    Generalized runs (``per_instance_seed=None``) must solve any instance; a
+    per-instance baseline names the single target instance instead. Both are then
+    told the per-instance wall-clock ``timeout`` enforced at evaluation.
+    """
+    goal = (
+        _GENERALIZE_GOAL
+        if per_instance_seed is None
+        else per_instance_directive(per_instance_seed, per_instance_count)
+    )
+    return goal + _EVAL_BUDGET_CLAUSE.format(timeout=timeout)
 
 
 _SOURCE_OPENER = (
@@ -426,7 +450,7 @@ _AGENTIC_WITH_DESCRIPTION = """\
 """
 
 _AGENTIC_WITH_SOURCE = """\
-{per_instance_directive}{source_opener}
+{source_opener}
 {geometry_prompt}
 {interface_spec}
 {modular_code_prompt}{budget_stewardship}\
@@ -769,19 +793,29 @@ def build_system_prompt(
     intro: str,
     blackbox: bool,
     backend_name: str,
+    timeout: float,
     mcp_tools: tuple[str, ...] = (),
     object_centric: bool = False,
+    per_instance_seed: int | None = None,
+    per_instance_count: int | None = None,
 ) -> str:
     """Compose a coding-agent system prompt from shared fragments.
 
-    ``intro`` is one of the composed intro constants (AGENTIC_INTRO[_BLACKBOX],
-    CDL_INTRO[_BLACKBOX]). The shared file-discipline block, blackbox-aware
-    subagent guidance, token-budget guidance, the backend-specific suffix, and
-    the optional MCP-tools suffix follow. For a variable-count (object_centric) env
-    the render guidance drops the flat-vector arbitrary-state mode.
+    After ``intro`` comes the goal + eval budget (``generalization_goal``):
+    generalize, or specialize to the ``per_instance_seed`` instance, under the
+    ``timeout``. Then the shared file-discipline, subagent, token-budget,
+    backend-suffix, and optional MCP-tools fragments. ``object_centric`` drops the
+    flat-vector render mode.
     """
+    goal = generalization_goal(
+        timeout,
+        per_instance_seed=per_instance_seed,
+        per_instance_count=per_instance_count,
+    )
     subagents = SYSTEM_SUBAGENTS_BLACKBOX if blackbox else SYSTEM_SUBAGENTS
-    system_prompt = intro + SYSTEM_FILE_DISCIPLINE + subagents + SYSTEM_TOKEN_BUDGET
+    system_prompt = (
+        intro + goal + " " + SYSTEM_FILE_DISCIPLINE + subagents + SYSTEM_TOKEN_BUDGET
+    )
     if backend_name == "opencode":
         system_prompt += OPENCODE_PROMPT_SUFFIX
     else:
@@ -853,21 +887,14 @@ def _env_description_section(blackbox_description: str | None) -> str:
     return BLACKBOX_DESCRIPTION_PREFIX + blackbox_description + "\n"
 
 
-def _scaffold_intro(
-    approach_kind: str,
-    blackbox: bool,
-    per_instance_seed: int | None = None,
-    per_instance_count: int | None = None,
-) -> str:
+def _scaffold_intro(approach_kind: str, blackbox: bool) -> str:
+    """The task-prompt opener line; the goal now lives in the system prompt."""
     target = (
         "an environment that you can only access as a black box"
         if blackbox
         else "the environment described below"
     )
-    if per_instance_seed is None:
-        return _SCAFFOLD_INTRO.format(approach_kind=approach_kind, target=target)
-    opener = _SCAFFOLD_INTRO_OPENER.format(approach_kind=approach_kind, target=target)
-    return opener + per_instance_directive(per_instance_seed, per_instance_count)
+    return _SCAFFOLD_INTRO_OPENER.format(approach_kind=approach_kind, target=target)
 
 
 def build_agentic_prompt(
@@ -878,17 +905,14 @@ def build_agentic_prompt(
     modular_code: bool,
     env_description: str | None,
     per_instance_seed: int | None = None,
-    per_instance_count: int | None = None,
     object_centric: bool = False,
 ) -> str:
     """Compose the monolithic-approach task prompt.
 
-    When ``per_instance_seed`` is set, the generalization clause is replaced by a
-    per-instance directive naming the target instance and a budget-stewardship note is
-    appended; ``per_instance_count`` pins the object count for a variable-count env so
-    the named instance matches what is scored. ``object_centric`` selects the
-    object-centric black-box interaction spec. With ``per_instance_seed=None`` and
-    ``object_centric=False`` the output is unchanged.
+    The goal + eval budget are in the system prompt, not here; a
+    ``per_instance_seed`` only adds the budget-stewardship note. ``object_centric``
+    selects the object-centric black-box interaction spec. With
+    ``per_instance_seed=None`` and ``object_centric=False`` the output is unchanged.
     """
     geometry_prompt = GEOMETRY_PROMPT if geometry else ""
     modular = MODULAR_CODE_PROMPT if modular_code else ""
@@ -899,12 +923,7 @@ def build_agentic_prompt(
     )
     if blackbox:
         return _AGENTIC_BLACKBOX.format(
-            scaffold_intro=_scaffold_intro(
-                "an approach",
-                blackbox=True,
-                per_instance_seed=per_instance_seed,
-                per_instance_count=per_instance_count,
-            ),
+            scaffold_intro=_scaffold_intro("an approach", blackbox=True),
             env_description_section=_env_description_section(env_description),
             blackbox_interaction_spec=blackbox_interaction_spec(
                 object_centric=object_centric, set_state_note=""
@@ -916,25 +935,14 @@ def build_agentic_prompt(
         )
     if env_description is not None:
         return _AGENTIC_WITH_DESCRIPTION.format(
-            scaffold_intro=_scaffold_intro(
-                "an approach",
-                blackbox=False,
-                per_instance_seed=per_instance_seed,
-                per_instance_count=per_instance_count,
-            ),
+            scaffold_intro=_scaffold_intro("an approach", blackbox=False),
             env_description=env_description,
             geometry_prompt=geometry_prompt,
             modular_code_prompt=modular,
             interface_spec=interface_spec,
             budget_stewardship=budget_stewardship,
         )
-    directive_block = (
-        per_instance_directive(per_instance_seed, per_instance_count) + "\n\n"
-        if per_instance_seed is not None
-        else ""
-    )
     return _AGENTIC_WITH_SOURCE.format(
-        per_instance_directive=directive_block,
         source_opener=_SOURCE_OPENER,
         geometry_prompt=geometry_prompt,
         modular_code_prompt=modular,

--- a/src/robocode/utils/episode.py
+++ b/src/robocode/utils/episode.py
@@ -171,7 +171,7 @@ def run_episode_with_timeout(
     seed: int,
     max_steps: int,
     *,
-    timeout: float | None,
+    timeout: float,
     render: bool = False,
     count: int | None = None,
 ) -> tuple[dict[str, Any], list[NDArray[np.uint8]], Any]:
@@ -180,10 +180,8 @@ def run_episode_with_timeout(
     The rollout runs in a forked worker (inheriting the live env and approach) so a
     hung or too-slow policy can be killed; on overrun it is scored unsolved
     (``metrics["timed_out"]``). A worker that dies before reporting (policy
-    exception, OOM, native crash) re-raises here. ``timeout=None`` runs in-process.
+    exception, OOM, native crash) re-raises here.
     """
-    if timeout is None:
-        return run_episode(env, approach, seed, max_steps, render=render, count=count)
     ctx = mp.get_context("fork")  # fork: the worker inherits the live env + approach
     with ctx.Manager() as manager:
         result = manager.dict()

--- a/src/robocode/utils/episode.py
+++ b/src/robocode/utils/episode.py
@@ -8,6 +8,7 @@ import os
 import signal
 import sys
 import traceback
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -136,6 +137,34 @@ def run_episode(
     return metrics, frames, state
 
 
+def run_in_forked_worker(
+    ctx: mp.context.ForkContext,
+    target: Callable[..., None],
+    args: tuple[Any, ...],
+    timeout: float,
+) -> tuple[str, int | None]:
+    """Run ``target(*args)`` in a forked worker, killing it if it overruns ``timeout``.
+
+    ``target`` writes its outcome into a shared dict it is handed in ``args`` (the
+    caller reads that dict afterward). Returns ``(outcome, exitcode)``: ``"timeout"``
+    means the worker overran and got a SIGINT, a short grace period, then SIGKILL;
+    ``"finished"`` means it exited on its own (an empty shared dict then means it died
+    before reporting).
+    """
+    proc = ctx.Process(target=target, args=args)
+    proc.start()
+    assert proc.pid is not None
+    proc.join(timeout)
+    if proc.is_alive():
+        os.kill(proc.pid, signal.SIGINT)
+        proc.join(3)
+        if proc.is_alive():
+            proc.kill()
+            proc.join()
+        return "timeout", proc.exitcode
+    return "finished", proc.exitcode
+
+
 def run_episode_with_timeout(
     env: Any,
     approach: BaseApproach,
@@ -158,19 +187,13 @@ def run_episode_with_timeout(
     ctx = mp.get_context("fork")  # fork: the worker inherits the live env + approach
     with ctx.Manager() as manager:
         result = manager.dict()
-        proc = ctx.Process(
-            target=_timed_episode_worker,
-            args=(env, approach, seed, max_steps, render, count, result),
+        outcome, exitcode = run_in_forked_worker(
+            ctx,
+            _timed_episode_worker,
+            (env, approach, seed, max_steps, render, count, result),
+            timeout,
         )
-        proc.start()
-        assert proc.pid is not None
-        proc.join(timeout)
-        if proc.is_alive():
-            os.kill(proc.pid, signal.SIGINT)
-            proc.join(3)
-            if proc.is_alive():
-                proc.kill()
-                proc.join()
+        if outcome == "timeout":
             metrics: dict[str, Any] = {
                 "total_reward": 0.0,
                 "num_steps": 0,
@@ -187,7 +210,7 @@ def run_episode_with_timeout(
             result.get(
                 "error",
                 f"eval episode worker (seed {seed}) exited with code "
-                f"{proc.exitcode} before reporting a result",
+                f"{exitcode} before reporting a result",
             )
         )
 

--- a/src/robocode/utils/episode.py
+++ b/src/robocode/utils/episode.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 import logging
+import multiprocessing as mp
+import os
+import signal
 import sys
+import traceback
 from pathlib import Path
 from typing import Any
 
@@ -130,6 +134,88 @@ def run_episode(
     if "object_count" in info:
         metrics["object_count"] = info["object_count"]
     return metrics, frames, state
+
+
+def run_episode_with_timeout(
+    env: Any,
+    approach: BaseApproach,
+    seed: int,
+    max_steps: int,
+    *,
+    timeout: float | None,
+    render: bool = False,
+    count: int | None = None,
+) -> tuple[dict[str, Any], list[NDArray[np.uint8]], Any]:
+    """Run one eval episode under a hard per-instance wall-clock ``timeout``.
+
+    The rollout runs in a forked worker (inheriting the live env and approach) so a
+    hung or too-slow policy can be killed; on overrun it is scored unsolved
+    (``metrics["timed_out"]``). A worker that dies before reporting (policy
+    exception, OOM, native crash) re-raises here. ``timeout=None`` runs in-process.
+    """
+    if timeout is None:
+        return run_episode(env, approach, seed, max_steps, render=render, count=count)
+    ctx = mp.get_context("fork")  # fork: the worker inherits the live env + approach
+    with ctx.Manager() as manager:
+        result = manager.dict()
+        proc = ctx.Process(
+            target=_timed_episode_worker,
+            args=(env, approach, seed, max_steps, render, count, result),
+        )
+        proc.start()
+        assert proc.pid is not None
+        proc.join(timeout)
+        if proc.is_alive():
+            os.kill(proc.pid, signal.SIGINT)
+            proc.join(3)
+            if proc.is_alive():
+                proc.kill()
+                proc.join()
+            metrics: dict[str, Any] = {
+                "total_reward": 0.0,
+                "num_steps": 0,
+                "solved": False,
+                "timed_out": True,
+            }
+            if count is not None:
+                metrics["object_count"] = count
+            return metrics, [], None
+        if "metrics" in result:
+            return result["metrics"], list(result["frames"]), result["final_state"]
+        # The worker died before reporting; surface it so the caller scores a crash.
+        raise RuntimeError(
+            result.get(
+                "error",
+                f"eval episode worker (seed {seed}) exited with code "
+                f"{proc.exitcode} before reporting a result",
+            )
+        )
+
+
+def _timed_episode_worker(
+    env: Any,
+    approach: BaseApproach,
+    seed: int,
+    max_steps: int,
+    render: bool,
+    count: int | None,
+    result: Any,
+) -> None:
+    """Run one episode in a subprocess and stash its outcome in ``result``.
+
+    The try/except deliberately carries a policy crash across the process boundary
+    as ``result["error"]`` for the parent to re-raise. ``metrics`` is written last,
+    so its presence means the run finished (a partial dict means the worker died).
+    """
+    try:
+        metrics, frames, final_state = run_episode(
+            env, approach, seed, max_steps, render=render, count=count
+        )
+        result["frames"] = frames
+        result["final_state"] = final_state
+        result["metrics"] = metrics
+    except Exception:  # pylint: disable=broad-exception-caught
+        result["error"] = traceback.format_exc()
 
 
 def summarize_by_count(

--- a/src/robocode/utils/genplan_validate.py
+++ b/src/robocode/utils/genplan_validate.py
@@ -9,8 +9,6 @@ this runs there too.
 from __future__ import annotations
 
 import multiprocessing as mp
-import os
-import signal
 import traceback
 from collections.abc import Callable
 from multiprocessing.managers import SyncManager
@@ -21,7 +19,11 @@ import gymnasium
 from gymnasium.spaces import Space
 
 from robocode.approaches.base_approach import BaseApproach
-from robocode.utils.episode import load_generated_approach, run_episode
+from robocode.utils.episode import (
+    load_generated_approach,
+    run_episode,
+    run_in_forked_worker,
+)
 
 
 def render_state(observation_space: Space[Any], obs: Any) -> str:
@@ -188,9 +190,10 @@ def _validate_episode(
     :func:`validate_tasks` and :func:`score_tasks`.
     """
     result = manager.dict()
-    proc = ctx.Process(
-        target=_episode_worker,
-        args=(
+    outcome, exitcode = run_in_forked_worker(
+        ctx,
+        _episode_worker,
+        (
             env,
             approach_path,
             action_space,
@@ -200,16 +203,9 @@ def _validate_episode(
             max_steps,
             result,
         ),
+        timeout,
     )
-    proc.start()
-    assert proc.pid is not None
-    proc.join(timeout)
-    if proc.is_alive():
-        os.kill(proc.pid, signal.SIGINT)
-        proc.join(3)
-        if proc.is_alive():
-            proc.kill()
-            proc.join()
+    if outcome == "timeout":
         return {
             "solved": False,
             "total_reward": 0.0,
@@ -231,7 +227,7 @@ def _validate_episode(
             "error_type": "worker-crashed",
             "feedback": (
                 f"On the task with seed {seed}, the episode worker died with "
-                f"exit code {proc.exitcode} before reporting a result (e.g. out "
+                f"exit code {exitcode} before reporting a result (e.g. out "
                 "of memory or a crash in native code). Make the code terminate "
                 "normally and reduce memory use."
             ),

--- a/tests/approaches/test_agentic_per_instance_approach.py
+++ b/tests/approaches/test_agentic_per_instance_approach.py
@@ -58,9 +58,10 @@ def test_solve_instance_targets_seed_and_scores_program(tmp_path, monkeypatch):
     env, approach = _make_approach(tmp_path)
 
     def fake_run(*, sandbox_dir, prompt, system_prompt, max_budget_usd, init_files):
-        del system_prompt, init_files
-        # The prompt targets the specific eval seed and carries budget stewardship.
-        assert "env.reset(seed=99)" in prompt
+        del init_files
+        # The system prompt targets the specific eval seed; the task prompt carries
+        # the budget-stewardship note.
+        assert "env.reset(seed=99)" in system_prompt
         assert "BUDGET:" in prompt
         assert max_budget_usd == pytest.approx(2.0)
         approach_file = sandbox_dir / "approach.py"
@@ -80,14 +81,14 @@ def test_solve_instance_targets_seed_and_scores_program(tmp_path, monkeypatch):
 
 
 def test_solve_instance_pins_count_in_prompt(tmp_path, monkeypatch):
-    """For a variable-count env the prompt names the pinned (seed, count) instance, so
-    the agent develops against exactly what it is scored on."""
+    """For a variable-count env the system prompt names the pinned (seed, count)
+    instance, so the agent develops against exactly what it is scored on."""
     env, approach = _make_approach(tmp_path)
     captured = {}
 
     def fake_run(*, sandbox_dir, prompt, system_prompt, max_budget_usd, init_files):
-        del sandbox_dir, system_prompt, max_budget_usd, init_files
-        captured["prompt"] = prompt
+        del sandbox_dir, prompt, max_budget_usd, init_files
+        captured["system_prompt"] = system_prompt
         # Stop before scoring: this test only checks the prompt the agent receives.
         return SandboxResult(
             success=False, output_file=None, error="stop", total_cost_usd=0.0
@@ -101,8 +102,9 @@ def test_solve_instance_pins_count_in_prompt(tmp_path, monkeypatch):
         output_subdir=tmp_path / "instance_0",
         count=4,
     )
-    assert "env.reset(seed=99, options={'object_count': 4})" in captured["prompt"]
-    assert "env.reset(seed=99)`" not in captured["prompt"]  # not the unpinned form
+    system_prompt = captured["system_prompt"]
+    assert "env.reset(seed=99, options={'object_count': 4})" in system_prompt
+    assert "env.reset(seed=99)`" not in system_prompt  # not the unpinned form
 
 
 def test_solve_instance_no_program_is_crashed(tmp_path, monkeypatch):

--- a/tests/approaches/test_bilevel_planning_approach.py
+++ b/tests/approaches/test_bilevel_planning_approach.py
@@ -28,7 +28,7 @@ def _make_approach(env: KinderGeom2DEnv) -> BilevelPlanningApproach:
         primitives={},
         env=env,
         max_steps=1000,
-        planning_timeout=30.0,
+        eval_timeout=30.0,
     )
 
 
@@ -103,7 +103,7 @@ def test_planning_failure_is_unsolved_not_crashed(tmp_path: Path) -> None:
         primitives={},
         env=env,
         max_steps=1000,
-        planning_timeout=0.001,
+        eval_timeout=0.001,
     )
     result = approach.solve_instance(
         env=env, seed=0, budget_usd=0.0, output_subdir=tmp_path

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -48,7 +48,7 @@ def test_learning_clause_shared_across_approaches():
 def test_system_prompt_agentic_non_blackbox():
     """Non-blackbox agentic system prompt reads source and ends with the suffix."""
     sp = prompts.build_system_prompt(
-        intro=prompts.AGENTIC_INTRO, blackbox=False, backend_name="claude"
+        intro=prompts.AGENTIC_INTRO, blackbox=False, backend_name="claude", timeout=30
     )
     assert "expert at writing policies" in sp
     assert "VERSION CONTROL" in sp
@@ -58,10 +58,24 @@ def test_system_prompt_agentic_non_blackbox():
     assert MCP_TOOLS_SYSTEM_PROMPT_SUFFIX not in sp
 
 
+def test_system_prompt_states_goal_and_eval_budget():
+    """The system prompt carries the generalize goal and the eval-time budget."""
+    sp = prompts.build_system_prompt(
+        intro=prompts.AGENTIC_INTRO, blackbox=False, backend_name="claude", timeout=30
+    )
+    assert "generalize to any instance" in sp
+    assert "30 seconds of wall-clock" in sp
+    # The goal sits between the intro and the file-discipline block.
+    assert sp.index("generalize to any instance") < sp.index("VERSION CONTROL")
+
+
 def test_system_prompt_blackbox_swaps_subagents():
     """Blackbox selects the empirical-exploration subagent guidance."""
     sp = prompts.build_system_prompt(
-        intro=prompts.AGENTIC_INTRO_BLACKBOX, blackbox=True, backend_name="claude"
+        intro=prompts.AGENTIC_INTRO_BLACKBOX,
+        blackbox=True,
+        backend_name="claude",
+        timeout=30,
     )
     assert "black box" in sp
     assert "run exploration experiments" in sp
@@ -71,7 +85,7 @@ def test_system_prompt_blackbox_swaps_subagents():
 def test_system_prompt_opencode_backend_suffix():
     """The opencode backend swaps in its own prompt suffix."""
     sp = prompts.build_system_prompt(
-        intro=prompts.AGENTIC_INTRO, blackbox=False, backend_name="opencode"
+        intro=prompts.AGENTIC_INTRO, blackbox=False, backend_name="opencode", timeout=30
     )
     assert sp.endswith(OPENCODE_PROMPT_SUFFIX)
     assert CLAUDE_PROMPT_SUFFIX not in sp
@@ -83,6 +97,7 @@ def test_system_prompt_mcp_suffix_blackbox_variant():
         intro=prompts.AGENTIC_INTRO_BLACKBOX,
         blackbox=True,
         backend_name="claude",
+        timeout=30,
         mcp_tools=("render_state",),
     )
     assert MCP_TOOLS_SYSTEM_PROMPT_SUFFIX_BLACKBOX in sp
@@ -95,6 +110,7 @@ def test_system_prompt_mcp_suffix_non_blackbox_variant():
         intro=prompts.AGENTIC_INTRO,
         blackbox=False,
         backend_name="claude",
+        timeout=30,
         mcp_tools=("render_state",),
     )
     assert MCP_TOOLS_SYSTEM_PROMPT_SUFFIX in sp
@@ -103,13 +119,77 @@ def test_system_prompt_mcp_suffix_non_blackbox_variant():
 def test_system_prompt_token_budget_on_both_approaches():
     """Token-budget guidance is appended to every system prompt (both approaches)."""
     agentic = prompts.build_system_prompt(
-        intro=prompts.AGENTIC_INTRO, blackbox=False, backend_name="claude"
+        intro=prompts.AGENTIC_INTRO, blackbox=False, backend_name="claude", timeout=30
     )
     cdl = prompts.build_system_prompt(
-        intro=prompts.CDL_INTRO, blackbox=False, backend_name="claude"
+        intro=prompts.CDL_INTRO, blackbox=False, backend_name="claude", timeout=30
     )
     assert "TOKEN BUDGET" in agentic
     assert "TOKEN BUDGET" in cdl
+
+
+# ---------------------------------------------------------------------------
+# generalization_goal: the goal + eval-budget statement in the system prompt
+# ---------------------------------------------------------------------------
+
+
+def test_generalization_goal_generalized():
+    """Without a per-instance seed the goal asks to generalize and names the budget."""
+    goal = prompts.generalization_goal(30)
+    assert "generalize to any instance" in goal
+    assert "30 seconds of wall-clock" in goal
+    assert "scored as a failure" in goal
+
+
+def test_generalization_goal_per_instance_names_reset_call():
+    """A per-instance seed swaps in the single-instance goal, still with the budget."""
+    goal = prompts.generalization_goal(30, per_instance_seed=7)
+    assert "generalize to any instance" not in goal
+    assert "env.reset(seed=7)" in goal
+    assert "specialize entirely to it" in goal
+    assert "30 seconds of wall-clock" in goal
+
+
+def test_generalization_goal_pins_count():
+    """A per-instance count names the pinned reset call in the goal."""
+    goal = prompts.generalization_goal(30, per_instance_seed=7, per_instance_count=4)
+    assert "env.reset(seed=7, options={'object_count': 4})" in goal
+
+
+def test_generalization_goal_timeout_formats_without_trailing_zero():
+    """The timeout renders compactly (30, not 30.0; a fractional value is kept)."""
+    assert "30 seconds" in prompts.generalization_goal(30.0)
+    assert "30.0 seconds" not in prompts.generalization_goal(30.0)
+    assert "0.5 seconds" in prompts.generalization_goal(0.5)
+
+
+def test_system_prompt_per_instance_goal():
+    """A per-instance seed names the target instance in the system-prompt goal."""
+    sp = prompts.build_system_prompt(
+        intro=prompts.AGENTIC_INTRO,
+        blackbox=False,
+        backend_name="claude",
+        timeout=30,
+        per_instance_seed=4242,
+    )
+    assert "generalize to any instance" not in sp
+    assert "env.reset(seed=4242)" in sp
+    assert "specialize entirely to it" in sp
+    assert "30 seconds of wall-clock" in sp
+
+
+def test_system_prompt_per_instance_count_pins_reset():
+    """A per-instance count pins the named reset call in the system prompt."""
+    sp = prompts.build_system_prompt(
+        intro=prompts.AGENTIC_INTRO,
+        blackbox=False,
+        backend_name="claude",
+        timeout=30,
+        per_instance_seed=7,
+        per_instance_count=4,
+    )
+    assert "env.reset(seed=7, options={'object_count': 4})" in sp
+    assert "env.reset(seed=7)`" not in sp
 
 
 # ---------------------------------------------------------------------------
@@ -444,17 +524,14 @@ _SOURCE_OPENER = (
     "Read the environment source files in this directory to understand the "
     "state type, action space, and dynamics."
 )
+# The goal moved to the system prompt, so the task-prompt scaffold is just the
+# opener line.
 _SCAFFOLD_CDL_DESCRIPTION = (
-    "You are writing a behavior-based approach for the environment described "
-    "below.\n\nYour approach should be general enough to solve any instance of "
-    "this environment (env.reset()), but it does NOT need to be adaptable to "
-    "different other environments."
+    "You are writing a behavior-based approach for the environment described below."
 )
 _SCAFFOLD_CDL_BLACKBOX = (
     "You are writing a behavior-based approach for an environment that you can "
-    "only access as a black box.\n\nYour approach should be general enough to "
-    "solve any instance of this environment (env.reset()), but it does NOT need "
-    "to be adaptable to different other environments."
+    "only access as a black box."
 )
 
 
@@ -473,9 +550,11 @@ def _cdl_behavior_impl(blackbox, helpers_note):
 
 
 def test_golden_system_prompt_agentic_nonblackbox_claude():
-    """Exact agentic (non-blackbox) system prompt: intro + shared tails + suffix."""
+    """Exact agentic (non-blackbox) system prompt: intro + goal + tails + suffix."""
     expected = (
         prompts.AGENTIC_INTRO
+        + prompts.generalization_goal(30)
+        + " "
         + prompts.SYSTEM_FILE_DISCIPLINE
         + prompts.SYSTEM_SUBAGENTS
         + prompts.SYSTEM_TOKEN_BUDGET
@@ -483,7 +562,10 @@ def test_golden_system_prompt_agentic_nonblackbox_claude():
     )
     assert (
         prompts.build_system_prompt(
-            intro=prompts.AGENTIC_INTRO, blackbox=False, backend_name="claude"
+            intro=prompts.AGENTIC_INTRO,
+            blackbox=False,
+            backend_name="claude",
+            timeout=30,
         )
         == expected
     )
@@ -493,6 +575,8 @@ def test_golden_system_prompt_cdl_blackbox_claude_with_mcp():
     """Exact CDL blackbox system prompt: blackbox subagents + blackbox MCP suffix."""
     expected = (
         prompts.CDL_INTRO_BLACKBOX
+        + prompts.generalization_goal(30)
+        + " "
         + prompts.SYSTEM_FILE_DISCIPLINE
         + prompts.SYSTEM_SUBAGENTS_BLACKBOX
         + prompts.SYSTEM_TOKEN_BUDGET
@@ -504,6 +588,7 @@ def test_golden_system_prompt_cdl_blackbox_claude_with_mcp():
             intro=prompts.CDL_INTRO_BLACKBOX,
             blackbox=True,
             backend_name="claude",
+            timeout=30,
             mcp_tools=("render_state",),
         )
         == expected
@@ -514,6 +599,8 @@ def test_golden_system_prompt_opencode_suffix():
     """Exact agentic system prompt under the opencode backend suffix."""
     expected = (
         prompts.AGENTIC_INTRO
+        + prompts.generalization_goal(30)
+        + " "
         + prompts.SYSTEM_FILE_DISCIPLINE
         + prompts.SYSTEM_SUBAGENTS
         + prompts.SYSTEM_TOKEN_BUDGET
@@ -521,7 +608,10 @@ def test_golden_system_prompt_opencode_suffix():
     )
     assert (
         prompts.build_system_prompt(
-            intro=prompts.AGENTIC_INTRO, blackbox=False, backend_name="opencode"
+            intro=prompts.AGENTIC_INTRO,
+            blackbox=False,
+            backend_name="opencode",
+            timeout=30,
         )
         == expected
     )
@@ -661,8 +751,9 @@ def test_no_doubled_blank_lines_in_any_task_prompt():
 
 
 # ---------------------------------------------------------------------------
-# Per-instance task-prompt delta: target-seed directive + budget stewardship,
-# byte-identical to the generalized prompt when no seed is given.
+# Per-instance delta: the goal/target-instance directive lives in the system
+# prompt (tested above). The task prompt only gains a budget-stewardship note,
+# and is byte-identical to the generalized task prompt when no seed is given.
 # ---------------------------------------------------------------------------
 
 
@@ -683,8 +774,8 @@ def test_per_instance_seed_none_is_unchanged():
         )
 
 
-def test_per_instance_seed_swaps_generalize_clause_with_description():
-    """With a description, the generalize clause is replaced by the seed directive."""
+def test_per_instance_seed_adds_budget_note_not_goal_to_task_prompt():
+    """The task prompt gains only the budget note; the goal/directive is not here."""
     p = prompts.build_agentic_prompt(
         blackbox=False,
         interface_spec=_IFACE,
@@ -693,16 +784,17 @@ def test_per_instance_seed_swaps_generalize_clause_with_description():
         env_description="ENVDESC",
         per_instance_seed=4242,
     )
-    assert "general enough to solve any instance" not in p
-    assert "env.reset(seed=4242)" in p
-    assert "you may specialize entirely to this instance" in p
     assert "BUDGET:" in p
     assert "seed 4242" in p
+    # The goal and the target-instance directive live in the system prompt only.
+    assert "env.reset(seed=4242)" not in p
+    assert "specialize entirely to it" not in p
+    assert "generalize to any instance" not in p
     assert "\n\n\n" not in p
 
 
-def test_per_instance_seed_prepends_directive_in_source_branch():
-    """The read-source branch (no scaffold intro) prepends the seed directive."""
+def test_per_instance_task_prompt_source_branch_starts_with_source_opener():
+    """The read-source task prompt still opens with the source instruction."""
     p = prompts.build_agentic_prompt(
         blackbox=False,
         interface_spec=_IFACE,
@@ -711,15 +803,14 @@ def test_per_instance_seed_prepends_directive_in_source_branch():
         env_description=None,
         per_instance_seed=7,
     )
-    assert p.startswith("Your approach only needs to solve")
-    assert "env.reset(seed=7)" in p
-    assert "Read the environment source files" in p
+    assert p.startswith("Read the environment source files")
+    assert "env.reset(seed=7)" not in p  # goal moved to the system prompt
     assert "BUDGET:" in p
     assert "\n\n\n" not in p
 
 
-def test_per_instance_seed_blackbox():
-    """Blackbox per-instance prompt swaps the clause and keeps the interaction spec."""
+def test_per_instance_task_prompt_blackbox_keeps_interaction_spec():
+    """The blackbox per-instance task prompt keeps env_client + budget, not the goal."""
     p = prompts.build_agentic_prompt(
         blackbox=True,
         interface_spec=_IFACE,
@@ -728,8 +819,7 @@ def test_per_instance_seed_blackbox():
         env_description=None,
         per_instance_seed=11,
     )
-    assert "general enough to solve any instance" not in p
-    assert "env.reset(seed=11)" in p
+    assert "env.reset(seed=11)" not in p
     assert "must NOT import `env_client`" in p
     assert "BUDGET:" in p
     assert "\n\n\n" not in p
@@ -741,25 +831,6 @@ def test_per_instance_directive_pins_count():
     assert "object_count" not in prompts.per_instance_directive(7)
     pinned = prompts.per_instance_directive(7, 4)
     assert "env.reset(seed=7, options={'object_count': 4})" in pinned
-
-
-def test_per_instance_count_names_pinned_reset_in_every_branch():
-    """A pinned object count names the exact scored instance in every prompt branch, so
-    the agent develops against what it is scored on (not an unpinned design-count
-    reset)."""
-    for blackbox, env in ((False, "ENVDESC"), (False, None), (True, None)):
-        p = prompts.build_agentic_prompt(
-            blackbox=blackbox,
-            interface_spec=_IFACE,
-            geometry=True,
-            modular_code=False,
-            env_description=env,
-            per_instance_seed=7,
-            per_instance_count=4,
-        )
-        assert "env.reset(seed=7, options={'object_count': 4})" in p
-        assert "env.reset(seed=7)`" not in p  # not the unpinned form
-        assert "\n\n\n" not in p
 
 
 def test_per_instance_no_doubled_blank_lines_grid():

--- a/tests/utils/test_episode.py
+++ b/tests/utils/test_episode.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import multiprocessing as mp
 import sys
 import time
 from pathlib import Path
@@ -20,6 +21,7 @@ from robocode.utils.episode import (
     load_generated_approach,
     run_episode,
     run_episode_with_timeout,
+    run_in_forked_worker,
     run_per_instance_eval,
     save_frames,
     save_video,
@@ -427,6 +429,38 @@ class _CrashApproach(BaseApproach[Any, Any]):
 
     def _get_action(self) -> Any:
         raise ValueError("boom")
+
+
+def _worker_writes_result(result: Any) -> None:
+    result["value"] = 42
+
+
+def _worker_sleeps(result: Any) -> None:
+    del result
+    time.sleep(30)
+
+
+def test_run_in_forked_worker_finishes() -> None:
+    """A worker that returns writes its result and reports 'finished'."""
+    ctx = mp.get_context("fork")
+    with ctx.Manager() as manager:
+        result = manager.dict()
+        outcome, exitcode = run_in_forked_worker(
+            ctx, _worker_writes_result, (result,), timeout=10
+        )
+        assert outcome == "finished"
+        assert result["value"] == 42
+        assert exitcode == 0
+
+
+def test_run_in_forked_worker_times_out() -> None:
+    """A worker that overruns the timeout is killed and reports 'timeout'."""
+    ctx = mp.get_context("fork")
+    with ctx.Manager() as manager:
+        result = manager.dict()
+        outcome, _ = run_in_forked_worker(ctx, _worker_sleeps, (result,), timeout=0.3)
+        assert outcome == "timeout"
+        assert "value" not in result
 
 
 def test_run_episode_returns_final_state() -> None:

--- a/tests/utils/test_episode.py
+++ b/tests/utils/test_episode.py
@@ -472,18 +472,6 @@ def test_run_episode_returns_final_state() -> None:
     assert final_state == np.array([3.0], dtype=np.float32)
 
 
-def test_run_episode_with_timeout_none_runs_in_process() -> None:
-    """Timeout=None matches run_episode and adds no timed_out flag."""
-    env = _CountEnv()
-    approach = _NoopApproach(env.action_space, env.observation_space, 0, {})
-    metrics, _, final_state = run_episode_with_timeout(
-        env, approach, seed=0, max_steps=10, timeout=None
-    )
-    assert metrics["solved"]
-    assert "timed_out" not in metrics
-    assert final_state == np.array([3.0], dtype=np.float32)
-
-
 def test_run_episode_with_timeout_solves_within_budget() -> None:
     """A fast policy finishes inside the forked worker and is scored normally."""
     env = _CountEnv()

--- a/tests/utils/test_episode.py
+++ b/tests/utils/test_episode.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import sys
+import time
 from pathlib import Path
 from typing import Any
 
@@ -18,6 +19,7 @@ from robocode.approaches.base_approach import BaseApproach, InstanceResult
 from robocode.utils.episode import (
     load_generated_approach,
     run_episode,
+    run_episode_with_timeout,
     run_per_instance_eval,
     save_frames,
     save_video,
@@ -383,37 +385,102 @@ def test_anti_cheat_not_enforced_without_bilevel_models(tmp_path: Path) -> None:
     assert hasattr(approach, "get_action")
 
 
+class _CountEnv(Env):
+    """A tiny env that terminates after three steps (goal at pos 3.0)."""
+
+    def __init__(self) -> None:
+        self.observation_space = Box(0.0, 10.0, shape=(1,), dtype=np.float32)
+        self.action_space = Box(-1.0, 1.0, shape=(1,), dtype=np.float32)
+        self._pos = 0.0
+
+    def reset(self, *, seed=None, options=None):
+        super().reset(seed=seed)
+        self._pos = 0.0
+        return np.array([self._pos], dtype=np.float32), {}
+
+    def step(self, action):
+        self._pos += 1.0
+        obs = np.array([self._pos], dtype=np.float32)
+        return obs, 0.0, self._pos >= 3.0, False, {}
+
+    def render(self):
+        return None
+
+
+class _NoopApproach(BaseApproach[Any, Any]):
+    """Always returns the zero action; the env drives termination."""
+
+    def _get_action(self) -> Any:
+        return np.zeros(1, dtype=np.float32)
+
+
+class _SlowApproach(BaseApproach[Any, Any]):
+    """Sleeps far past any test timeout, so the rollout must be killed."""
+
+    def _get_action(self) -> Any:
+        time.sleep(30)
+        return np.zeros(1, dtype=np.float32)
+
+
+class _CrashApproach(BaseApproach[Any, Any]):
+    """Raises on the first action, to exercise worker-crash propagation."""
+
+    def _get_action(self) -> Any:
+        raise ValueError("boom")
+
+
 def test_run_episode_returns_final_state() -> None:
     """run_episode returns the observation the episode ended on."""
-
-    class _CountEnv(Env):
-        def __init__(self) -> None:
-            self.observation_space = Box(0.0, 10.0, shape=(1,), dtype=np.float32)
-            self.action_space = Box(-1.0, 1.0, shape=(1,), dtype=np.float32)
-            self._pos = 0.0
-
-        def reset(self, *, seed=None, options=None):
-            super().reset(seed=seed)
-            self._pos = 0.0
-            return np.array([self._pos], dtype=np.float32), {}
-
-        def step(self, action):
-            self._pos += 1.0
-            obs = np.array([self._pos], dtype=np.float32)
-            return obs, 0.0, self._pos >= 3.0, False, {}
-
-        def render(self):
-            return None
-
-    class _NoopApproach(BaseApproach[Any, Any]):
-        def _get_action(self) -> Any:
-            return np.zeros(1, dtype=np.float32)
-
     env = _CountEnv()
     approach = _NoopApproach(env.action_space, env.observation_space, 0, {})
     metrics, _, final_state = run_episode(env, approach, seed=0, max_steps=10)
     assert metrics["solved"]
     assert final_state == np.array([3.0], dtype=np.float32)
+
+
+def test_run_episode_with_timeout_none_runs_in_process() -> None:
+    """Timeout=None matches run_episode and adds no timed_out flag."""
+    env = _CountEnv()
+    approach = _NoopApproach(env.action_space, env.observation_space, 0, {})
+    metrics, _, final_state = run_episode_with_timeout(
+        env, approach, seed=0, max_steps=10, timeout=None
+    )
+    assert metrics["solved"]
+    assert "timed_out" not in metrics
+    assert final_state == np.array([3.0], dtype=np.float32)
+
+
+def test_run_episode_with_timeout_solves_within_budget() -> None:
+    """A fast policy finishes inside the forked worker and is scored normally."""
+    env = _CountEnv()
+    approach = _NoopApproach(env.action_space, env.observation_space, 0, {})
+    metrics, _, _ = run_episode_with_timeout(
+        env, approach, seed=0, max_steps=10, timeout=30
+    )
+    assert metrics["solved"]
+    assert not metrics.get("timed_out")
+
+
+def test_run_episode_with_timeout_kills_slow_policy() -> None:
+    """A policy that overruns the budget is killed and scored unsolved."""
+    env = _CountEnv()
+    approach = _SlowApproach(env.action_space, env.observation_space, 0, {})
+    metrics, frames, final_state = run_episode_with_timeout(
+        env, approach, seed=0, max_steps=10, timeout=0.5
+    )
+    assert metrics["solved"] is False
+    assert metrics["timed_out"] is True
+    assert metrics["num_steps"] == 0
+    assert not frames
+    assert final_state is None
+
+
+def test_run_episode_with_timeout_reraises_worker_crash() -> None:
+    """A crash in the policy is carried back and re-raised for the caller to score."""
+    env = _CountEnv()
+    approach = _CrashApproach(env.action_space, env.observation_space, 0, {})
+    with pytest.raises(RuntimeError, match="boom"):
+        run_episode_with_timeout(env, approach, seed=0, max_steps=10, timeout=30)
 
 
 def test_save_frames_creates_pngs(


### PR DESCRIPTION
Ran into this while cleaning the prompts and decided to make it its own separate PR. This way, we have a single config value that sets timeouts for all our evals, both planner and agent code, and the timeout is sent also into the prompt so the agent knows not to write code that uses up too much time. Also a step towards cleaning up our eval