### PR TITLE
Record generation-time runtime metrics to results.json

### DIFF
--- a/experiments/analyze_results.py
+++ b/experiments/analyze_results.py
@@ -43,7 +43,9 @@ def _collect_results(search_dirs: list[Path]) -> pd.DataFrame:
                 row["seed"] = cfg["seed"]
 
             for key, value in results.items():
-                if key == "per_episode":
+                # per_episode is a list; gen_model_usage is a nested per-model dict.
+                # Both stay in results.json but are not flat DataFrame columns.
+                if key in ("per_episode", "gen_model_usage"):
                     continue
                 # by_count is a nested {count: {...}} dict; flatten its solve rates to
                 # numeric solve_rate@<count> columns so they aggregate across seeds.

--- a/experiments/run_experiment.py
+++ b/experiments/run_experiment.py
@@ -258,6 +258,9 @@ def _main(cfg: DictConfig) -> float:
     num_generations = getattr(approach, "num_generations", None)
     if num_generations is not None:
         results["num_generations"] = num_generations
+    gen_metrics = getattr(approach, "generation_metrics", None)
+    if gen_metrics is not None:
+        results.update(gen_metrics.to_dict())
     results_path = output_dir / "results.json"
     with open(results_path, "w", encoding="utf-8") as results_file:
         json.dump(results, results_file, indent=2)

--- a/src/robocode/approaches/agentic_approach.py
+++ b/src/robocode/approaches/agentic_approach.py
@@ -37,6 +37,7 @@ class AgenticApproach(GeneratedProgramApproach):
         )
 
         self.total_cost_usd = result.total_cost_usd
+        self.generation_metrics = result.generation_metrics
 
         if result.success and result.output_file is not None:
             if result.error:

--- a/src/robocode/approaches/agentic_base.py
+++ b/src/robocode/approaches/agentic_base.py
@@ -41,7 +41,11 @@ from robocode.utils.env_server import (
 from robocode.utils.episode import load_generated_approach
 from robocode.utils.rate_limit import run_with_rate_limit_retry
 from robocode.utils.sandbox import SandboxConfig
-from robocode.utils.sandbox_types import SandboxResult, resolve_container_backend
+from robocode.utils.sandbox_types import (
+    GenerationMetrics,
+    SandboxResult,
+    resolve_container_backend,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -122,6 +126,7 @@ class GeneratedProgramApproach(BaseApproach[_ObsType, _ActType]):
                 )
         self._generated: Any = None
         self.total_cost_usd: float | None = None
+        self.generation_metrics: GenerationMetrics | None = None
 
     def _build_agentic_prompts(
         self,

--- a/src/robocode/utils/apptainer_sandbox.py
+++ b/src/robocode/utils/apptainer_sandbox.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import logging
 import os
 import subprocess
+import time
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
@@ -311,6 +312,7 @@ async def run_agent_in_apptainer_sandbox(
         logger.info("System prompt:\n%s", config.system_prompt)
         logger.info("Prompt:\n%s", config.prompt)
 
+        wall_start = time.monotonic()
         proc = subprocess.Popen(  # pylint: disable=consider-using-with
             apptainer_cmd,
             env=env,
@@ -324,6 +326,7 @@ async def run_agent_in_apptainer_sandbox(
             proc,
             stream_log_path=config.sandbox_dir.parent / "stream.jsonl",
         )
+        wall_time_s = time.monotonic() - wall_start
 
         logger.info(
             "Apptainer session done: run_id=%s turns=%d cost=$%s error=%s",
@@ -336,7 +339,10 @@ async def run_agent_in_apptainer_sandbox(
         _final_commit(config.sandbox_dir)
 
         return _stream_result_to_sandbox_result(
-            stream, config.sandbox_dir, config.output_filename
+            stream,
+            config.sandbox_dir,
+            config.output_filename,
+            wall_time_s=wall_time_s,
         )
 
 

--- a/src/robocode/utils/backends/claude.py
+++ b/src/robocode/utils/backends/claude.py
@@ -12,6 +12,7 @@ import os
 import re
 import subprocess
 from pathlib import Path
+from typing import Any
 
 from omegaconf import DictConfig
 
@@ -214,6 +215,18 @@ class ClaudeBackend(AgentBackend):
         total_cost: float | None = None
         rate_limit_reset: str | None = None
         mcp_log: Path | None = None
+        num_tool_calls = 0
+        num_autocompactions = 0
+        num_permission_denials = 0
+        turn_limit_hit = False
+        input_tokens = 0
+        output_tokens = 0
+        cache_read_tokens = 0
+        cache_creation_tokens = 0
+        cli_duration_ms: int | None = None
+        cli_duration_api_ms: int | None = None
+        stop_reason: str | None = None
+        model_usage: dict[str, Any] = {}
 
         stream_log_fh = (
             open(stream_log_path, "a", encoding="utf-8")  # noqa: SIM115
@@ -286,6 +299,7 @@ class ClaudeBackend(AgentBackend):
                                 "image at build time."
                             )
                 elif subtype == "compact_boundary":
+                    num_autocompactions += 1
                     meta = msg.get("compact_metadata", {})
                     logger.info(
                         "Context compaction: trigger=%s, pre_tokens=%s",
@@ -308,6 +322,7 @@ class ClaudeBackend(AgentBackend):
                     )
                     os.killpg(proc.pid, 9)
                     is_error = True
+                    turn_limit_hit = True
                     error_text = (
                         f"Turn limit reached: {num_turns} >= " f"{self._max_turns}"
                     )
@@ -322,6 +337,7 @@ class ClaudeBackend(AgentBackend):
                         if m:
                             rate_limit_reset = m.group(0)
                     elif block.get("type") == "tool_use":
+                        num_tool_calls += 1
                         input_str = json.dumps(block.get("input", {}))
                         if len(input_str) > 300:
                             input_str = input_str[:300] + "..."
@@ -358,6 +374,16 @@ class ClaudeBackend(AgentBackend):
                 is_error = msg.get("is_error", False)
                 num_turns = msg.get("num_turns", 0)
                 total_cost = msg.get("total_cost_usd")
+                cli_duration_ms = msg.get("duration_ms")
+                cli_duration_api_ms = msg.get("duration_api_ms")
+                stop_reason = msg.get("stop_reason") or msg.get("terminal_reason")
+                num_permission_denials = len(msg.get("permission_denials", []))
+                model_usage = msg.get("modelUsage", {})
+                usage = msg.get("usage", {})
+                input_tokens = usage.get("input_tokens", 0)
+                output_tokens = usage.get("output_tokens", 0)
+                cache_read_tokens = usage.get("cache_read_input_tokens", 0)
+                cache_creation_tokens = usage.get("cache_creation_input_tokens", 0)
                 if is_error:
                     error_text = msg.get("result", "Unknown error")
                     if not rate_limit_reset:
@@ -394,6 +420,18 @@ class ClaudeBackend(AgentBackend):
             num_turns=num_turns,
             total_cost=total_cost,
             rate_limit_reset=rate_limit_reset,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_read_tokens=cache_read_tokens,
+            cache_creation_tokens=cache_creation_tokens,
+            num_tool_calls=num_tool_calls,
+            num_autocompactions=num_autocompactions,
+            num_permission_denials=num_permission_denials,
+            turn_limit_hit=turn_limit_hit,
+            cli_duration_ms=cli_duration_ms,
+            cli_duration_api_ms=cli_duration_api_ms,
+            stop_reason=stop_reason,
+            model_usage=model_usage,
         )
 
 

--- a/src/robocode/utils/backends/claude.py
+++ b/src/robocode/utils/backends/claude.py
@@ -371,19 +371,20 @@ class ClaudeBackend(AgentBackend):
                         logger.debug("Tool result: %s", tool_use_result)
 
             elif msg_type == "result":
+                # A single generation can span several CLI sessions (autocompaction
+                # or budget-continue re-inits the CLI, each emitting its own result).
+                # total_cost_usd and modelUsage are cumulative, so keep the latest;
+                # per-session fields accumulate. num_turns is counted from assistant
+                # messages above, not read here (the final session's value is stale).
                 is_error = msg.get("is_error", False)
-                num_turns = msg.get("num_turns", 0)
-                total_cost = msg.get("total_cost_usd")
-                cli_duration_ms = msg.get("duration_ms")
-                cli_duration_api_ms = msg.get("duration_api_ms")
-                stop_reason = msg.get("stop_reason") or msg.get("terminal_reason")
-                num_permission_denials = len(msg.get("permission_denials", []))
-                model_usage = msg.get("modelUsage", {})
-                usage = msg.get("usage", {})
-                input_tokens = usage.get("input_tokens", 0)
-                output_tokens = usage.get("output_tokens", 0)
-                cache_read_tokens = usage.get("cache_read_input_tokens", 0)
-                cache_creation_tokens = usage.get("cache_creation_input_tokens", 0)
+                total_cost = msg.get("total_cost_usd", total_cost)
+                model_usage = msg.get("modelUsage") or model_usage
+                stop_reason = msg.get("subtype") or stop_reason
+                num_permission_denials += len(msg.get("permission_denials", []))
+                cli_duration_ms = (cli_duration_ms or 0) + (msg.get("duration_ms") or 0)
+                cli_duration_api_ms = max(
+                    cli_duration_api_ms or 0, msg.get("duration_api_ms") or 0
+                )
                 if is_error:
                     error_text = msg.get("result", "Unknown error")
                     if not rate_limit_reset:
@@ -413,6 +414,14 @@ class ClaudeBackend(AgentBackend):
         if rate_limit_reset and not is_error:
             is_error = True
             error_text = f"Rate-limited: resets {rate_limit_reset}"
+
+        # Token counts come from the cumulative per-model usage, not the top-level
+        # ``usage`` (which is empty on a final budget-error session).
+        for usage in model_usage.values():
+            input_tokens += usage.get("inputTokens", 0)
+            output_tokens += usage.get("outputTokens", 0)
+            cache_read_tokens += usage.get("cacheReadInputTokens", 0)
+            cache_creation_tokens += usage.get("cacheCreationInputTokens", 0)
 
         return _StreamParseResult(
             is_error=is_error,

--- a/src/robocode/utils/docker_sandbox.py
+++ b/src/robocode/utils/docker_sandbox.py
@@ -44,6 +44,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import time
 import uuid
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -658,6 +659,7 @@ async def run_agent_in_docker_sandbox(
         logger.info("System prompt:\n%s", config.system_prompt)
         logger.info("Prompt:\n%s", config.prompt)
 
+        wall_start = time.monotonic()
         proc = subprocess.Popen(  # pylint: disable=consider-using-with
             docker_cmd,
             env=env,
@@ -671,6 +673,7 @@ async def run_agent_in_docker_sandbox(
             proc,
             stream_log_path=config.sandbox_dir.parent / "stream.jsonl",
         )
+        wall_time_s = time.monotonic() - wall_start
 
         logger.info(
             "Docker session done: container=%s turns=%d cost=$%s error=%s",
@@ -683,5 +686,8 @@ async def run_agent_in_docker_sandbox(
         _final_commit(config.sandbox_dir)
 
         return _stream_result_to_sandbox_result(
-            stream, config.sandbox_dir, config.output_filename
+            stream,
+            config.sandbox_dir,
+            config.output_filename,
+            wall_time_s=wall_time_s,
         )

--- a/src/robocode/utils/rate_limit.py
+++ b/src/robocode/utils/rate_limit.py
@@ -8,6 +8,7 @@ import logging
 import re
 import time
 from collections.abc import Callable
+from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -21,6 +22,7 @@ from robocode.utils.docker_sandbox import (
     run_agent_in_docker_sandbox,
 )
 from robocode.utils.sandbox import SandboxConfig, SandboxResult, run_agent_in_sandbox
+from robocode.utils.sandbox_types import GenerationMetrics
 
 logger = logging.getLogger(__name__)
 
@@ -79,6 +81,22 @@ def seconds_until_reset(reset_hour: int, is_utc: bool = False) -> float:
     return min(wait, _MAX_WAIT_SECS)
 
 
+def _fold_retry_metrics(
+    result: SandboxResult, aborted_tokens: int, aborted_cost: float, retries: int
+) -> SandboxResult:
+    """Record the discarded rate-limited attempts' count and spend on *result*."""
+    if retries == 0:
+        return result
+    base = result.generation_metrics or GenerationMetrics()
+    metrics = replace(
+        base,
+        rate_limit_retries=retries,
+        aborted_tokens=aborted_tokens,
+        aborted_cost_usd=aborted_cost,
+    )
+    return replace(result, generation_metrics=metrics)
+
+
 def run_with_rate_limit_retry(
     docker_config: DockerSandboxConfig | None,
     local_config: SandboxConfig | None,
@@ -86,6 +104,9 @@ def run_with_rate_limit_retry(
     apptainer_config: ApptainerSandboxConfig | None = None,
 ) -> SandboxResult:
     """Run the sandbox, retrying on rate-limit by sleeping until reset."""
+    aborted_tokens = 0
+    aborted_cost = 0.0
+    retries = 0
     while True:
         if apptainer_config is not None:
             result = run_async(
@@ -100,7 +121,12 @@ def run_with_rate_limit_retry(
             result = run_async(lambda: run_agent_in_sandbox(local_config, backend))
 
         if result.rate_limit_reset is None:
-            return result
+            return _fold_retry_metrics(result, aborted_tokens, aborted_cost, retries)
+
+        retries += 1
+        assert result.generation_metrics is not None
+        aborted_tokens += result.generation_metrics.total_tokens
+        aborted_cost += result.total_cost_usd or 0.0
 
         reset_hour, is_utc = parse_reset_hour(result.rate_limit_reset)
         wait_secs = seconds_until_reset(reset_hour, is_utc)

--- a/src/robocode/utils/sandbox.py
+++ b/src/robocode/utils/sandbox.py
@@ -35,6 +35,7 @@ from robocode.primitive_specs import (
 )
 from robocode.utils.backends import AgentBackend
 from robocode.utils.sandbox_types import (
+    GenerationMetrics,
     SandboxConfig,
     SandboxResult,
     _StreamParseResult,
@@ -213,9 +214,26 @@ def _stream_result_to_sandbox_result(
     stream: _StreamParseResult,
     sandbox_dir: Path,
     output_filename: str,
+    wall_time_s: float | None = None,
 ) -> SandboxResult:
     """Convert a :class:`_StreamParseResult` to a :class:`SandboxResult`."""
     cost = stream.total_cost
+    metrics = GenerationMetrics(
+        wall_time_s=wall_time_s,
+        cli_duration_ms=stream.cli_duration_ms,
+        cli_duration_api_ms=stream.cli_duration_api_ms,
+        num_turns=stream.num_turns,
+        input_tokens=stream.input_tokens,
+        output_tokens=stream.output_tokens,
+        cache_read_tokens=stream.cache_read_tokens,
+        cache_creation_tokens=stream.cache_creation_tokens,
+        num_tool_calls=stream.num_tool_calls,
+        num_autocompactions=stream.num_autocompactions,
+        num_permission_denials=stream.num_permission_denials,
+        turn_limit_hit=stream.turn_limit_hit,
+        stop_reason=stream.stop_reason,
+        model_usage=stream.model_usage,
+    )
 
     # A rate-limit error must propagate so the retry loop can wait and rerun the
     # whole sandbox; never evaluate a partial approach from a rate-limited run.
@@ -226,6 +244,7 @@ def _stream_result_to_sandbox_result(
             error=stream.error_text,
             total_cost_usd=cost,
             rate_limit_reset=stream.rate_limit_reset,
+            generation_metrics=metrics,
         )
 
     # The agent commits its best-effort approach.py as it iterates, so if that
@@ -239,12 +258,14 @@ def _stream_result_to_sandbox_result(
             output_file=output_path,
             error=stream.error_text,
             total_cost_usd=cost,
+            generation_metrics=metrics,
         )
     return SandboxResult(
         success=False,
         output_file=None,
         error=stream.error_text or f"Output file not found: {output_filename}",
         total_cost_usd=cost,
+        generation_metrics=metrics,
     )
 
 
@@ -341,6 +362,7 @@ async def run_agent_in_sandbox(
         if config.mcp_tools
         else None
     )
+    wall_start = time.monotonic()
     try:
         proc = subprocess.Popen(  # pylint: disable=consider-using-with
             cmd,
@@ -376,5 +398,8 @@ async def run_agent_in_sandbox(
     _final_commit(config.sandbox_dir)
 
     return _stream_result_to_sandbox_result(
-        stream, config.sandbox_dir, config.output_filename
+        stream,
+        config.sandbox_dir,
+        config.output_filename,
+        wall_time_s=time.monotonic() - wall_start,
     )

--- a/src/robocode/utils/sandbox.py
+++ b/src/robocode/utils/sandbox.py
@@ -394,6 +394,8 @@ async def run_agent_in_sandbox(
         stream.is_error,
     )
 
+    wall_time_s = time.monotonic() - wall_start
+
     # Auto-commit any uncommitted changes so nothing is lost.
     _final_commit(config.sandbox_dir)
 
@@ -401,5 +403,5 @@ async def run_agent_in_sandbox(
         stream,
         config.sandbox_dir,
         config.output_filename,
-        wall_time_s=time.monotonic() - wall_start,
+        wall_time_s=wall_time_s,
     )

--- a/src/robocode/utils/sandbox_types.py
+++ b/src/robocode/utils/sandbox_types.py
@@ -6,6 +6,7 @@ the sandbox module and the backend implementations.
 
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 CONTAINER_BACKENDS = ("docker", "apptainer", "local")
 
@@ -55,6 +56,62 @@ class SandboxConfig:
 
 
 @dataclass(frozen=True)
+class GenerationMetrics:
+    """Runtime metrics from one agent generation run.
+
+    These exist only while the generation subprocess is alive (the coding agent
+    writing approach.py); they are parsed from its CLI stream and persisted next
+    to the eval results. ``wall_time_s`` is our own end-to-end timer around the
+    subprocess; ``cli_duration_ms`` is the agent-session time the CLI reports.
+    """
+
+    wall_time_s: float | None = None
+    cli_duration_ms: int | None = None
+    cli_duration_api_ms: int | None = None
+    num_turns: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_creation_tokens: int = 0
+    num_tool_calls: int = 0
+    num_autocompactions: int = 0
+    num_permission_denials: int = 0
+    turn_limit_hit: bool = False
+    stop_reason: str | None = None
+    model_usage: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def total_tokens(self) -> int:
+        """Sum of input, output, and cache read/creation tokens."""
+        return (
+            self.input_tokens
+            + self.output_tokens
+            + self.cache_read_tokens
+            + self.cache_creation_tokens
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Flat ``gen_*`` keys for results.json (one analysis column each)."""
+        return {
+            "gen_wall_time_s": self.wall_time_s,
+            "gen_cli_duration_ms": self.cli_duration_ms,
+            "gen_cli_duration_api_ms": self.cli_duration_api_ms,
+            "gen_num_turns": self.num_turns,
+            "gen_input_tokens": self.input_tokens,
+            "gen_output_tokens": self.output_tokens,
+            "gen_cache_read_tokens": self.cache_read_tokens,
+            "gen_cache_creation_tokens": self.cache_creation_tokens,
+            "gen_total_tokens": self.total_tokens,
+            "gen_num_tool_calls": self.num_tool_calls,
+            "gen_num_autocompactions": self.num_autocompactions,
+            "gen_num_permission_denials": self.num_permission_denials,
+            "gen_turn_limit_hit": self.turn_limit_hit,
+            "gen_stop_reason": self.stop_reason,
+            "gen_model_usage": self.model_usage,
+        }
+
+
+@dataclass(frozen=True)
 class SandboxResult:
     """Result from a sandboxed agent run."""
 
@@ -63,6 +120,7 @@ class SandboxResult:
     error: str | None
     total_cost_usd: float | None = None
     rate_limit_reset: str | None = None  # e.g. "3am" from usage limit message
+    generation_metrics: GenerationMetrics | None = None
 
 
 @dataclass(frozen=True)
@@ -74,3 +132,15 @@ class _StreamParseResult:
     num_turns: int
     total_cost: float | None
     rate_limit_reset: str | None = None  # e.g. "3am" parsed from usage message
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_creation_tokens: int = 0
+    num_tool_calls: int = 0
+    num_autocompactions: int = 0
+    num_permission_denials: int = 0
+    turn_limit_hit: bool = False
+    cli_duration_ms: int | None = None
+    cli_duration_api_ms: int | None = None
+    stop_reason: str | None = None
+    model_usage: dict[str, Any] = field(default_factory=dict)

--- a/src/robocode/utils/sandbox_types.py
+++ b/src/robocode/utils/sandbox_types.py
@@ -79,6 +79,14 @@ class GenerationMetrics:
     turn_limit_hit: bool = False
     stop_reason: str | None = None
     model_usage: dict[str, Any] = field(default_factory=dict)
+    # Rate-limit interruptions. The retry loop sleeps until the usage window
+    # resets and reruns the whole sandbox; the interrupted attempts are dropped
+    # from evaluation but their count and spend are recorded here so runs that
+    # straddled a reset can be identified and excluded in analysis. The main
+    # fields above describe the final, successful attempt only.
+    rate_limit_retries: int = 0
+    aborted_tokens: int = 0
+    aborted_cost_usd: float = 0.0
 
     @property
     def total_tokens(self) -> int:
@@ -108,6 +116,9 @@ class GenerationMetrics:
             "gen_turn_limit_hit": self.turn_limit_hit,
             "gen_stop_reason": self.stop_reason,
             "gen_model_usage": self.model_usage,
+            "gen_rate_limit_retries": self.rate_limit_retries,
+            "gen_aborted_tokens": self.aborted_tokens,
+            "gen_aborted_cost_usd": self.aborted_cost_usd,
         }
 
 

--- a/tests/utils/test_backends.py
+++ b/tests/utils/test_backends.py
@@ -529,8 +529,14 @@ class TestClaudeParseStreamMetrics:
         proc.wait.return_value = 0
         return proc
 
-    def test_parse_captures_tokens_turns_tools(self) -> None:
-        """Tokens, turns, tool calls, autocompactions, and durations are parsed."""
+    def test_parse_aggregates_across_cli_sessions(self) -> None:
+        """One generation can span several CLI sessions; metrics aggregate.
+
+        Turns are counted from assistant messages (the final session's num_turns is
+        stale); tokens come from the cumulative per-model usage (the top-level usage is
+        empty on a budget-error session); cost and modelUsage keep the latest
+        (cumulative) value; per-session fields accumulate.
+        """
         events = [
             {
                 "type": "assistant",
@@ -549,39 +555,55 @@ class TestClaudeParseStreamMetrics:
             },
             {
                 "type": "result",
+                "subtype": "success",
                 "is_error": False,
-                "num_turns": 5,
-                "total_cost_usd": 0.37,
-                "duration_ms": 60000,
-                "duration_api_ms": 45000,
-                "stop_reason": "end_turn",
+                "num_turns": 8,
+                "total_cost_usd": 0.30,
+                "duration_ms": 1000,
+                "duration_api_ms": 2000,
                 "permission_denials": [{"tool": "Bash"}],
-                "modelUsage": {"claude-sonnet-4-6": {"inputTokens": 100}},
-                "usage": {
-                    "input_tokens": 100,
-                    "output_tokens": 50,
-                    "cache_read_input_tokens": 2000,
-                    "cache_creation_input_tokens": 10,
+                "modelUsage": {"claude-sonnet-5": {"inputTokens": 100}},
+            },
+            {
+                "type": "assistant",
+                "message": {"content": [{"type": "text", "text": "x"}]},
+            },
+            {
+                "type": "result",
+                "subtype": "error_max_budget_usd",
+                "is_error": True,
+                "num_turns": 1,
+                "total_cost_usd": 0.90,
+                "duration_ms": 500,
+                "duration_api_ms": 5000,
+                "permission_denials": [{"tool": "Write"}, {"tool": "Edit"}],
+                "modelUsage": {
+                    "claude-sonnet-5": {
+                        "inputTokens": 300,
+                        "outputTokens": 50,
+                        "cacheReadInputTokens": 2000,
+                        "cacheCreationInputTokens": 10,
+                    },
+                    "claude-haiku-4-5": {"inputTokens": 20},
                 },
+                "usage": {},
             },
         ]
         proc = self._make_mock_proc([json.dumps(e) + "\n" for e in events])
         result = ClaudeBackend(DEFAULT_BACKEND_CFG).parse_stream(proc)
 
-        assert not result.is_error
-        assert result.num_turns == 5
+        assert result.num_turns == 2  # two assistant messages, not the stale 1
         assert result.num_tool_calls == 2
         assert result.num_autocompactions == 1
-        assert result.num_permission_denials == 1
-        assert result.input_tokens == 100
+        assert result.num_permission_denials == 3  # 1 + 2 across sessions
+        assert result.input_tokens == 320  # 300 + 20, from the cumulative modelUsage
         assert result.output_tokens == 50
         assert result.cache_read_tokens == 2000
         assert result.cache_creation_tokens == 10
-        assert result.cli_duration_ms == 60000
-        assert result.cli_duration_api_ms == 45000
-        assert result.stop_reason == "end_turn"
-        assert result.model_usage == {"claude-sonnet-4-6": {"inputTokens": 100}}
-        assert result.total_cost == pytest.approx(0.37)
+        assert result.cli_duration_ms == 1500  # summed per-session
+        assert result.cli_duration_api_ms == 5000  # max (cumulative)
+        assert result.stop_reason == "error_max_budget_usd"  # last subtype
+        assert result.total_cost == pytest.approx(0.90)  # latest (cumulative)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/utils/test_backends.py
+++ b/tests/utils/test_backends.py
@@ -513,6 +513,78 @@ class TestProviderUtils:
 
 
 # ---------------------------------------------------------------------------
+# Claude stream parser
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeParseStreamMetrics:
+    """ClaudeBackend.parse_stream captures generation metrics from the stream."""
+
+    def _make_mock_proc(self, stdout_lines: list[str]) -> subprocess.Popen:
+        proc = MagicMock(spec=subprocess.Popen)
+        proc.stdout = iter(stdout_lines)
+        proc.stderr = MagicMock()
+        proc.stderr.read.return_value = ""
+        proc.returncode = 0
+        proc.wait.return_value = 0
+        return proc
+
+    def test_parse_captures_tokens_turns_tools(self) -> None:
+        """Tokens, turns, tool calls, autocompactions, and durations are parsed."""
+        events = [
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {"type": "text", "text": "planning"},
+                        {"type": "tool_use", "name": "Bash", "input": {"cmd": "ls"}},
+                        {"type": "tool_use", "name": "Write", "input": {"f": "a.py"}},
+                    ]
+                },
+            },
+            {
+                "type": "system",
+                "subtype": "compact_boundary",
+                "compact_metadata": {"trigger": "auto", "pre_tokens": 1000},
+            },
+            {
+                "type": "result",
+                "is_error": False,
+                "num_turns": 5,
+                "total_cost_usd": 0.37,
+                "duration_ms": 60000,
+                "duration_api_ms": 45000,
+                "stop_reason": "end_turn",
+                "permission_denials": [{"tool": "Bash"}],
+                "modelUsage": {"claude-sonnet-4-6": {"inputTokens": 100}},
+                "usage": {
+                    "input_tokens": 100,
+                    "output_tokens": 50,
+                    "cache_read_input_tokens": 2000,
+                    "cache_creation_input_tokens": 10,
+                },
+            },
+        ]
+        proc = self._make_mock_proc([json.dumps(e) + "\n" for e in events])
+        result = ClaudeBackend(DEFAULT_BACKEND_CFG).parse_stream(proc)
+
+        assert not result.is_error
+        assert result.num_turns == 5
+        assert result.num_tool_calls == 2
+        assert result.num_autocompactions == 1
+        assert result.num_permission_denials == 1
+        assert result.input_tokens == 100
+        assert result.output_tokens == 50
+        assert result.cache_read_tokens == 2000
+        assert result.cache_creation_tokens == 10
+        assert result.cli_duration_ms == 60000
+        assert result.cli_duration_api_ms == 45000
+        assert result.stop_reason == "end_turn"
+        assert result.model_usage == {"claude-sonnet-4-6": {"inputTokens": 100}}
+        assert result.total_cost == pytest.approx(0.37)
+
+
+# ---------------------------------------------------------------------------
 # OpenCode stream parser
 # ---------------------------------------------------------------------------
 

--- a/tests/utils/test_rate_limit.py
+++ b/tests/utils/test_rate_limit.py
@@ -1,0 +1,96 @@
+"""Tests for rate_limit.py."""
+
+from pathlib import Path
+
+from robocode.utils import rate_limit
+from robocode.utils.rate_limit import (
+    _fold_retry_metrics,
+    parse_reset_hour,
+    run_with_rate_limit_retry,
+)
+from robocode.utils.sandbox_types import GenerationMetrics, SandboxConfig, SandboxResult
+
+
+def _metrics(tokens: int) -> GenerationMetrics:
+    return GenerationMetrics(input_tokens=tokens)
+
+
+def _rate_limited(tokens: int, cost: float) -> SandboxResult:
+    return SandboxResult(
+        success=False,
+        output_file=None,
+        error="Rate-limited: resets 3am",
+        total_cost_usd=cost,
+        rate_limit_reset="3am",
+        generation_metrics=_metrics(tokens),
+    )
+
+
+def _succeeded(tokens: int, cost: float, path: Path) -> SandboxResult:
+    return SandboxResult(
+        success=True,
+        output_file=path,
+        error=None,
+        total_cost_usd=cost,
+        generation_metrics=_metrics(tokens),
+    )
+
+
+def test_fold_retry_metrics_noop_when_no_retries() -> None:
+    """With zero retries the result is returned untouched."""
+    result = _succeeded(300, 2.0, Path("approach.py"))
+    assert _fold_retry_metrics(result, 0, 0.0, 0) is result
+
+
+def test_fold_retry_metrics_records_aborted_spend() -> None:
+    """Retry count and aborted spend attach without disturbing final metrics."""
+    result = _succeeded(300, 2.0, Path("approach.py"))
+    folded = _fold_retry_metrics(
+        result, aborted_tokens=300, aborted_cost=1.5, retries=2
+    )
+    assert folded.generation_metrics is not None
+    assert folded.generation_metrics.rate_limit_retries == 2
+    assert folded.generation_metrics.aborted_tokens == 300
+    assert folded.generation_metrics.aborted_cost_usd == 1.5
+    # The final attempt's own totals are preserved.
+    assert folded.generation_metrics.input_tokens == 300
+    assert folded.total_cost_usd == 2.0
+
+
+def test_retry_loop_accumulates_aborted_attempts(tmp_path: Path, monkeypatch) -> None:
+    """Two rate-limited attempts then success: their spend is summed and counted."""
+    approach = tmp_path / "approach.py"
+    approach.write_text("x = 1\n")
+    results = iter(
+        [
+            _rate_limited(100, 0.5),
+            _rate_limited(200, 1.0),
+            _succeeded(300, 2.0, approach),
+        ]
+    )
+
+    async def fake_run(*_args, **_kwargs) -> SandboxResult:
+        return next(results)
+
+    monkeypatch.setattr(rate_limit, "run_agent_in_sandbox", fake_run)
+    monkeypatch.setattr(rate_limit.time, "sleep", lambda _s: None)
+
+    config = SandboxConfig(sandbox_dir=tmp_path)
+    final = run_with_rate_limit_retry(
+        None, config, backend=None  # type: ignore[arg-type]
+    )
+
+    assert final.success
+    assert final.generation_metrics is not None
+    assert final.generation_metrics.rate_limit_retries == 2
+    assert final.generation_metrics.aborted_tokens == 300  # 100 + 200
+    assert final.generation_metrics.aborted_cost_usd == 1.5  # 0.5 + 1.0
+    assert final.generation_metrics.input_tokens == 300  # final attempt only
+    assert final.total_cost_usd == 2.0
+
+
+def test_parse_reset_hour_pm_utc() -> None:
+    """A full usage message parses the reset hour and UTC flag."""
+    hour, is_utc = parse_reset_hour("You've hit your session limit. resets 11pm (UTC)")
+    assert hour == 23
+    assert is_utc is True

--- a/tests/utils/test_sandbox.py
+++ b/tests/utils/test_sandbox.py
@@ -22,12 +22,18 @@ def test_generation_metrics_to_dict_flat_keys() -> None:
         cache_read_tokens=2000,
         cache_creation_tokens=10,
         num_tool_calls=9,
+        rate_limit_retries=2,
+        aborted_tokens=300,
+        aborted_cost_usd=1.5,
     )
     d = m.to_dict()
     assert d["gen_wall_time_s"] == 12.5
     assert d["gen_num_turns"] == 7
     assert d["gen_num_tool_calls"] == 9
     assert d["gen_total_tokens"] == 2160
+    assert d["gen_rate_limit_retries"] == 2
+    assert d["gen_aborted_tokens"] == 300
+    assert d["gen_aborted_cost_usd"] == 1.5
     assert all(k.startswith("gen_") for k in d)
 
 

--- a/tests/utils/test_sandbox.py
+++ b/tests/utils/test_sandbox.py
@@ -7,7 +7,54 @@ from robocode.utils.sandbox import (
     SandboxConfig,
     SandboxResult,
     _is_path_within_sandbox,
+    _stream_result_to_sandbox_result,
 )
+from robocode.utils.sandbox_types import GenerationMetrics, _StreamParseResult
+
+
+def test_generation_metrics_to_dict_flat_keys() -> None:
+    """to_dict() emits flat gen_* keys and sums total_tokens."""
+    m = GenerationMetrics(
+        wall_time_s=12.5,
+        num_turns=7,
+        input_tokens=100,
+        output_tokens=50,
+        cache_read_tokens=2000,
+        cache_creation_tokens=10,
+        num_tool_calls=9,
+    )
+    d = m.to_dict()
+    assert d["gen_wall_time_s"] == 12.5
+    assert d["gen_num_turns"] == 7
+    assert d["gen_num_tool_calls"] == 9
+    assert d["gen_total_tokens"] == 2160
+    assert all(k.startswith("gen_") for k in d)
+
+
+def test_stream_result_carries_generation_metrics(tmp_path: Path) -> None:
+    """The stream->SandboxResult conversion attaches metrics and wall time."""
+    (tmp_path / "approach.py").write_text("x = 1\n")
+    stream = _StreamParseResult(
+        is_error=False,
+        error_text=None,
+        num_turns=4,
+        total_cost=0.42,
+        input_tokens=100,
+        output_tokens=50,
+        num_tool_calls=8,
+        num_autocompactions=2,
+        cli_duration_ms=1234,
+        stop_reason="end_turn",
+    )
+    result = _stream_result_to_sandbox_result(
+        stream, tmp_path, "approach.py", wall_time_s=9.0
+    )
+    assert result.success
+    assert result.generation_metrics is not None
+    assert result.generation_metrics.wall_time_s == 9.0
+    assert result.generation_metrics.num_turns == 4
+    assert result.generation_metrics.num_autocompactions == 2
+    assert result.generation_metrics.stop_reason == "end_turn"
 
 
 def test_path_within_sandbox(tmp_path: Path) -> None:


### PR DESCRIPTION
The coding-agent subprocess reports turns, tokens, wall-clock durations, tool calls, autocompactions, and permission denials in its CLI result stream, but only cost was persisted. Everything else was lost once generation ended, so experiment results carried no record of what a generation actually consumed.

This parses those fields in `ClaudeBackend.parse_stream`, bundles them into a `GenerationMetrics` dataclass, threads it through `SandboxResult` onto the approach, and emits flat `gen_*` keys into `results.json`. `analyze_results` picks up the scalar columns automatically; the nested per-model usage stays in `results.json` only.

Three details worth review:

- **Multi-session aggregation.** A single generation can span several CLI sessions (autocompaction and budget-continue re-init the CLI, each emitting its own `result` message). Reading the last one gave `num_turns=1`, an empty top-level `usage` block, and `duration_ms=5`, zeroing tokens and turns. Turns are now counted from assistant messages and tokens derived from the cumulative per-model `modelUsage`; per-session durations and denials accumulate; the CLI result subtype is recorded as `stop_reason`.
- **Rate-limit accounting.** When a generation hits the subscription cap, the retry loop sleeps until reset and reruns the whole sandbox, discarding the interrupted attempt. That made rate-limited runs indistinguishable from clean ones and under-reported their real spend. `rate_limit_retries`, `aborted_tokens`, and `aborted_cost_usd` now capture the dropped attempts; the main fields still describe the final attempt only, so affected runs can be excluded in analysis via `gen_rate_limit_retries > 0`.
- **Wall-clock timing** is wired into all three sandbox backends (docker, OS-level, apptainer).

**Validation:** verified against a real 5-session stream (122 turns, 2.7M tokens, budget stop), and 19 real docker experiment runs now carry populated `gen_*` fields. CI checks are green: 164 tests pass, mypy clean across 93 files, pylint 10.00/10. The apptainer timer has not been exercised on a live cluster run, but it is the same instrumentation as the verified docker path.
