### PR TITLE
Resume Claude Code sessions after retryable interruptions

### DIFF
--- a/src/robocode/utils/apptainer_sandbox.py
+++ b/src/robocode/utils/apptainer_sandbox.py
@@ -149,6 +149,7 @@ def _build_apptainer_cmd(
     auth_args: list[str],
     firewall_domains: list[str],
     agent_cmd: list[str],
+    extra_binds: list[str] | None = None,
 ) -> list[str]:
     """Assemble the full ``apptainer exec`` command line.
 
@@ -214,6 +215,8 @@ def _build_apptainer_cmd(
             "--bind",
             f"{kinder_baselines_abs}:/robocode/third-party/kinder-baselines",
         ]
+    for bind in extra_binds or []:
+        cmd += ["--bind", bind]
     cmd += [
         str(config.sif_path),
         "/usr/local/bin/entrypoint.sh",
@@ -279,6 +282,15 @@ async def run_agent_in_apptainer_sandbox(
         if config.mcp_tools:
             agent_cmd = _mcp_prestart_wrapper(agent_cmd, port=mcp_port)
 
+        # Persist the CLI session store under the sandbox dir (survives the
+        # ephemeral container) so a rate-limited run can be resumed via
+        # --continue in a fresh retry container. Claude only.
+        session_binds: list[str] = []
+        if backend_name == "claude":
+            sessions_dir = config.sandbox_dir / ".agent_sessions"
+            sessions_dir.mkdir(exist_ok=True)
+            session_binds = [f"{sessions_dir.resolve()}:/home/node/.claude/projects"]
+
         apptainer_cmd = _build_apptainer_cmd(
             config,
             sandbox_abs=sandbox_abs,
@@ -292,6 +304,7 @@ async def run_agent_in_apptainer_sandbox(
             auth_args=auth_args,
             firewall_domains=firewall_domains,
             agent_cmd=agent_cmd,
+            extra_binds=session_binds,
         )
 
         backend.setup_sandbox_files(

--- a/src/robocode/utils/apptainer_sandbox.py
+++ b/src/robocode/utils/apptainer_sandbox.py
@@ -46,7 +46,10 @@ from robocode.utils.backends import (
     firewall_domains_for_provider,
     provider_from_model,
 )
-from robocode.utils.claude_auth import throwaway_claude_config
+from robocode.utils.claude_auth import (
+    sandbox_claude_session_store,
+    throwaway_claude_config,
+)
 from robocode.utils.docker_sandbox import (
     DOCKER_PYTHON,
     _filtered_repo_mounts,
@@ -287,8 +290,7 @@ async def run_agent_in_apptainer_sandbox(
         # --continue in a fresh retry container. Claude only.
         session_binds: list[str] = []
         if backend_name == "claude":
-            sessions_dir = config.sandbox_dir / ".agent_sessions"
-            sessions_dir.mkdir(exist_ok=True)
+            sessions_dir = sandbox_claude_session_store(config.sandbox_dir)
             session_binds = [f"{sessions_dir.resolve()}:/home/node/.claude/projects"]
 
         apptainer_cmd = _build_apptainer_cmd(

--- a/src/robocode/utils/apptainer_sandbox.py
+++ b/src/robocode/utils/apptainer_sandbox.py
@@ -33,6 +33,8 @@ import os
 import subprocess
 import time
 import uuid
+from collections.abc import Iterator
+from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -44,6 +46,7 @@ from robocode.utils.backends import (
     firewall_domains_for_provider,
     provider_from_model,
 )
+from robocode.utils.claude_auth import throwaway_claude_config
 from robocode.utils.docker_sandbox import (
     DOCKER_PYTHON,
     _filtered_repo_mounts,
@@ -81,10 +84,11 @@ class ApptainerSandboxConfig(SandboxConfig):
     sif_path: Path = _DEFAULT_SIF
 
 
+@contextmanager
 def _build_apptainer_auth_args(
     backend_name: str,
-) -> tuple[list[str], dict[str, str]]:
-    """Return Apptainer CLI args and env vars for backend authentication.
+) -> Iterator[tuple[list[str], dict[str, str]]]:
+    """Yield Apptainer CLI args and env vars for backend authentication.
 
     Mirrors :func:`docker_sandbox._build_docker_auth_args`. Secrets (the
     Claude OAuth token, provider API keys) are returned as host env vars
@@ -94,50 +98,45 @@ def _build_apptainer_auth_args(
     via ``ps`` / ``/proc/<pid>/cmdline`` on shared nodes). Only non-secret
     bind mounts are returned as CLI args.
 
-    The ``~/.claude`` bind-mount fallback relies on the image being built
-    with build.sh / build_sif.sh (which pass USER_UID/USER_GID build args
-    so the in-container node user matches the host's UID and can read host
-    files). Without that, the in-container CLI would see the host config
-    as inaccessible and overwrite it.
+    The credentials fallback uses a writable throwaway copy, never the live
+    host config, so experiment reads and writes cannot leak across runs or into
+    the operator's Claude history.
     """
     apptainer_args: list[str] = []
     extra_env: dict[str, str] = {}
 
-    if backend_name == "claude":
-        oauth_token = _get_claude_oauth_token()
-        if oauth_token:
-            # APPTAINERENV_ prefix, not an inline --env flag, so the secret is
-            # injected into the container (surviving --cleanenv) without ever
-            # appearing on the command line.
-            extra_env["APPTAINERENV_CLAUDE_CODE_OAUTH_TOKEN"] = oauth_token
+    with ExitStack() as stack:
+        if backend_name == "claude":
+            oauth_token = _get_claude_oauth_token()
+            if oauth_token:
+                # APPTAINERENV_ prefix, not an inline --env flag, so the secret is
+                # injected into the container (surviving --cleanenv) without ever
+                # appearing on the command line.
+                extra_env["APPTAINERENV_CLAUDE_CODE_OAUTH_TOKEN"] = oauth_token
+            else:
+                logger.warning(
+                    "No Claude OAuth token found; falling back to a throwaway "
+                    "credentials-only config. Run `claude login` on the host "
+                    "if the container cannot authenticate."
+                )
+                claude_copy = stack.enter_context(throwaway_claude_config())
+                apptainer_args += ["--bind", f"{claude_copy}:/home/node/.claude"]
         else:
-            logger.warning(
-                "No Claude OAuth token found; falling back to ~/.claude "
-                "bind-mount. Requires the image to be built via build_sif.sh "
-                "(matching host UID/GID). Run `claude login` on the host "
-                "if the container cannot authenticate."
-            )
-            host_claude_cfg = Path(
-                os.environ.get("CLAUDE_CONFIG_DIR", str(Path.home() / ".claude"))
-            )
-            apptainer_args += ["--bind", f"{host_claude_cfg}:/home/node/.claude"]
-    else:
-        opencode_data = Path.home() / ".local" / "share" / "opencode"
-        if opencode_data.exists():
-            apptainer_args += [
-                "--bind",
-                f"{opencode_data}:/home/node/.local/share/opencode",
-            ]
+            opencode_data = Path.home() / ".local" / "share" / "opencode"
+            if opencode_data.exists():
+                apptainer_args += [
+                    "--bind",
+                    f"{opencode_data}:/home/node/.local/share/opencode",
+                ]
 
-        for info in PROVIDERS.values():
-            if info.api_key_env:
-                val = os.environ.get(info.api_key_env)
-                if val:
-                    # APPTAINERENV_ prefix keeps the key off argv (see the
-                    # OAuth token note above).
-                    extra_env[f"APPTAINERENV_{info.api_key_env}"] = val
+            for info in PROVIDERS.values():
+                if info.api_key_env:
+                    val = os.environ.get(info.api_key_env)
+                    if val:
+                        # APPTAINERENV_ keeps the key off argv (see above).
+                        extra_env[f"APPTAINERENV_{info.api_key_env}"] = val
 
-    return apptainer_args, extra_env
+        yield apptainer_args, extra_env
 
 
 def _build_apptainer_cmd(
@@ -248,16 +247,17 @@ async def run_agent_in_apptainer_sandbox(
     sandbox_abs = str(config.sandbox_dir.resolve())
     run_id = f"apptainer-sandbox-{uuid.uuid4().hex[:8]}"
 
-    with _filtered_repo_mounts(
-        blackbox=config.blackbox,
-        include_bilevel="bilevel_models" in config.primitive_names,
-    ) as (
-        filtered_src,
-        filtered_kindergarden,
-        filtered_kinder_baselines,
+    with (
+        _filtered_repo_mounts(
+            blackbox=config.blackbox,
+            include_bilevel="bilevel_models" in config.primitive_names,
+        ) as (
+            filtered_src,
+            filtered_kindergarden,
+            filtered_kinder_baselines,
+        ),
+        _build_apptainer_auth_args(backend_name) as (auth_args, auth_env),
     ):
-        auth_args, auth_env = _build_apptainer_auth_args(backend_name)
-
         firewall_domains: list[str] = []
         if backend_name == "opencode":
             firewall_domains = firewall_domains_for_provider(
@@ -381,15 +381,17 @@ def run_genplan_in_apptainer(
             f"SIF image not found at {sif_path}; build it with: bash docker/build_sif.sh"
         )
     run_id = f"apptainer-genplan-{uuid.uuid4().hex[:8]}"
-    with _filtered_repo_mounts(
-        keep_primitives=True, include_bilevel=include_bilevel
-    ) as (
-        filtered_src,
-        filtered_kindergarden,
-        filtered_kinder_baselines,
+    auth_backend = "claude" if completion_cfg["provider"] == "cli" else "opencode"
+    with (
+        _filtered_repo_mounts(
+            keep_primitives=True, include_bilevel=include_bilevel
+        ) as (
+            filtered_src,
+            filtered_kindergarden,
+            filtered_kinder_baselines,
+        ),
+        _build_apptainer_auth_args(auth_backend) as (auth_args, auth_env),
     ):
-        auth_backend = "claude" if completion_cfg["provider"] == "cli" else "opencode"
-        auth_args, auth_env = _build_apptainer_auth_args(auth_backend)
         firewall_domains = firewall_domains_for_provider(
             completion_cfg["provider"], completion_cfg.get("base_url", "")
         )

--- a/src/robocode/utils/backends/claude.py
+++ b/src/robocode/utils/backends/claude.py
@@ -135,12 +135,17 @@ class ClaudeBackend(AgentBackend):
             "--model",
             config.model,
             "--dangerously-skip-permissions",
-            "--no-session-persistence",
             "--tools",
             tools,
             "--setting-sources",
             "project",
         ]
+        # Persist the session (no --no-session-persistence) so a run interrupted
+        # by the usage cap can be continued. --continue resumes the most recent
+        # conversation in the working directory, which is unique to this
+        # generation, so it reattaches to exactly this run's context.
+        if config.resume_previous_session:
+            args.append("--continue")
         if config.system_prompt:
             args += ["--system-prompt", config.system_prompt]
         if config.max_budget_usd > 0:

--- a/src/robocode/utils/backends/claude.py
+++ b/src/robocode/utils/backends/claude.py
@@ -35,6 +35,9 @@ _RATE_LIMIT_RE = re.compile(
     r".*?resets\s+(\d{1,2}(?:am|pm))(?:\s*\(?([A-Za-z][A-Za-z/_]*)\)?)?",
     re.IGNORECASE,
 )
+_OUTPUT_TOKEN_LIMIT_RE = re.compile(
+    r"response exceeded (?:the )?\d+ output token maximum", re.IGNORECASE
+)
 
 _VALIDATE_SANDBOX_SCRIPT = """\
 #!/usr/bin/env python3
@@ -219,6 +222,7 @@ class ClaudeBackend(AgentBackend):
         num_turns = 0
         total_cost: float | None = None
         rate_limit_reset: str | None = None
+        output_token_limit_hit = False
         mcp_log: Path | None = None
         num_tool_calls = 0
         num_autocompactions = 0
@@ -341,6 +345,8 @@ class ClaudeBackend(AgentBackend):
                         m = _RATE_LIMIT_RE.search(text)
                         if m:
                             rate_limit_reset = m.group(0)
+                        if _OUTPUT_TOKEN_LIMIT_RE.search(text):
+                            output_token_limit_hit = True
                     elif block.get("type") == "tool_use":
                         num_tool_calls += 1
                         input_str = json.dumps(block.get("input", {}))
@@ -391,11 +397,13 @@ class ClaudeBackend(AgentBackend):
                     cli_duration_api_ms or 0, msg.get("duration_api_ms") or 0
                 )
                 if is_error:
-                    error_text = msg.get("result", "Unknown error")
+                    error_text = str(msg.get("result") or "Unknown error")
                     if not rate_limit_reset:
                         m = _RATE_LIMIT_RE.search(error_text)
                         if m:
                             rate_limit_reset = m.group(0)
+                    if _OUTPUT_TOKEN_LIMIT_RE.search(error_text or ""):
+                        output_token_limit_hit = True
 
         proc.wait()
 
@@ -404,6 +412,12 @@ class ClaudeBackend(AgentBackend):
 
         assert proc.stderr is not None
         stderr_output = proc.stderr.read()
+        if not rate_limit_reset and stderr_output:
+            m = _RATE_LIMIT_RE.search(stderr_output)
+            if m:
+                rate_limit_reset = m.group(0)
+        if stderr_output and _OUTPUT_TOKEN_LIMIT_RE.search(stderr_output):
+            output_token_limit_hit = True
         if proc.returncode != 0 and not is_error:
             is_error = True
             error_text = (
@@ -411,14 +425,13 @@ class ClaudeBackend(AgentBackend):
                 if stderr_output
                 else f"Process exited with code {proc.returncode}"
             )
-            if not rate_limit_reset and stderr_output:
-                m = _RATE_LIMIT_RE.search(stderr_output)
-                if m:
-                    rate_limit_reset = m.group(0)
 
         if rate_limit_reset and not is_error:
             is_error = True
             error_text = f"Rate-limited: resets {rate_limit_reset}"
+        if output_token_limit_hit and not is_error:
+            is_error = True
+            error_text = "Claude response exceeded the output token maximum"
 
         # Token counts come from the cumulative per-model usage, not the top-level
         # ``usage`` (which is empty on a final budget-error session).
@@ -434,6 +447,7 @@ class ClaudeBackend(AgentBackend):
             num_turns=num_turns,
             total_cost=total_cost,
             rate_limit_reset=rate_limit_reset,
+            output_token_limit_hit=output_token_limit_hit,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             cache_read_tokens=cache_read_tokens,

--- a/src/robocode/utils/backends/claude.py
+++ b/src/robocode/utils/backends/claude.py
@@ -32,12 +32,14 @@ logger = logging.getLogger(__name__)
 
 _RATE_LIMIT_RE = re.compile(
     r"(?:out of extra usage|hit your (?:\w+\s+)*limit)"
-    r".*?resets\s+(\d{1,2}(?:am|pm))(?:\s*\(?([A-Za-z][A-Za-z/_]*)\)?)?",
+    r".*?resets\s+(\d{1,2}(?::\d{2})?(?:am|pm))"
+    r"(?:\s*\(?([A-Za-z][A-Za-z/_]*)\)?)?",
     re.IGNORECASE,
 )
 _OUTPUT_TOKEN_LIMIT_RE = re.compile(
     r"response exceeded (?:the )?\d+ output token maximum", re.IGNORECASE
 )
+_PROMPT_TOO_LONG_RE = re.compile(r"\bprompt is too long\b", re.IGNORECASE)
 
 _VALIDATE_SANDBOX_SCRIPT = """\
 #!/usr/bin/env python3
@@ -223,6 +225,7 @@ class ClaudeBackend(AgentBackend):
         total_cost: float | None = None
         rate_limit_reset: str | None = None
         output_token_limit_hit = False
+        prompt_too_long_hit = False
         mcp_log: Path | None = None
         num_tool_calls = 0
         num_autocompactions = 0
@@ -347,6 +350,8 @@ class ClaudeBackend(AgentBackend):
                             rate_limit_reset = m.group(0)
                         if _OUTPUT_TOKEN_LIMIT_RE.search(text):
                             output_token_limit_hit = True
+                        if _PROMPT_TOO_LONG_RE.search(text):
+                            prompt_too_long_hit = True
                     elif block.get("type") == "tool_use":
                         num_tool_calls += 1
                         input_str = json.dumps(block.get("input", {}))
@@ -404,6 +409,8 @@ class ClaudeBackend(AgentBackend):
                             rate_limit_reset = m.group(0)
                     if _OUTPUT_TOKEN_LIMIT_RE.search(error_text or ""):
                         output_token_limit_hit = True
+                    if _PROMPT_TOO_LONG_RE.search(error_text):
+                        prompt_too_long_hit = True
 
         proc.wait()
 
@@ -418,6 +425,8 @@ class ClaudeBackend(AgentBackend):
                 rate_limit_reset = m.group(0)
         if stderr_output and _OUTPUT_TOKEN_LIMIT_RE.search(stderr_output):
             output_token_limit_hit = True
+        if stderr_output and _PROMPT_TOO_LONG_RE.search(stderr_output):
+            prompt_too_long_hit = True
         if proc.returncode != 0 and not is_error:
             is_error = True
             error_text = (
@@ -432,6 +441,9 @@ class ClaudeBackend(AgentBackend):
         if output_token_limit_hit and not is_error:
             is_error = True
             error_text = "Claude response exceeded the output token maximum"
+        if prompt_too_long_hit and not is_error:
+            is_error = True
+            error_text = "Claude prompt is too long"
 
         # Token counts come from the cumulative per-model usage, not the top-level
         # ``usage`` (which is empty on a final budget-error session).
@@ -448,6 +460,7 @@ class ClaudeBackend(AgentBackend):
             total_cost=total_cost,
             rate_limit_reset=rate_limit_reset,
             output_token_limit_hit=output_token_limit_hit,
+            prompt_too_long_hit=prompt_too_long_hit,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             cache_read_tokens=cache_read_tokens,

--- a/src/robocode/utils/claude_auth.py
+++ b/src/robocode/utils/claude_auth.py
@@ -1,0 +1,77 @@
+"""Isolated Claude configuration used by experiment CLI processes."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+_CREDENTIALS = ".credentials.json"
+
+
+def host_claude_config_dir() -> Path:
+    """Return the operator's Claude configuration directory."""
+    return Path(os.environ.get("CLAUDE_CONFIG_DIR", str(Path.home() / ".claude")))
+
+
+def _copy_credentials(destination: Path) -> Path | None:
+    """Copy host credentials into *destination*, returning the copied path.
+
+    Token-based authentication does not need a credentials file.  In that case
+    there may be nothing to copy, which is intentionally not an error here.
+    """
+    destination.mkdir(parents=True, exist_ok=True)
+    copied = destination / _CREDENTIALS
+    # Never follow a file or symlink left by the previous agent process.
+    copied.unlink(missing_ok=True)
+    credentials = host_claude_config_dir() / _CREDENTIALS
+    if not credentials.is_file():
+        return None
+    shutil.copy2(credentials, copied)
+    return copied
+
+
+@contextmanager
+def throwaway_claude_config() -> Iterator[Path]:
+    """Yield a writable config containing only a copy of host credentials.
+
+    The operator's transcripts, history, memory, settings, and job artifacts
+    never enter the sandbox, and writes or token refreshes cannot reach the
+    operator's live Claude directory.
+    """
+    tmp_dir = Path(tempfile.mkdtemp(prefix="robocode-claude-"))
+    try:
+        config_dir = tmp_dir / ".claude"
+        config_dir.mkdir()
+        copied = _copy_credentials(config_dir)
+        if copied is None:
+            raise RuntimeError(
+                f"No Claude credentials at {host_claude_config_dir() / _CREDENTIALS}. "
+                "Run `claude login` on the host, or set "
+                "CLAUDE_CODE_OAUTH_TOKEN."
+            )
+        yield config_dir
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+@contextmanager
+def sandbox_claude_config(sandbox_dir: Path) -> Iterator[Path]:
+    """Yield a resumable sandbox-local config without retaining credentials.
+
+    Session state remains under ``.agent_home`` between rate-limit attempts,
+    while the copied credential is removed after every CLI process.  This
+    prevents either reads from or writes to the operator's live config and
+    avoids leaving an authentication secret in experiment output.
+    """
+    config_dir = sandbox_dir / ".agent_home"
+    config_dir.mkdir(exist_ok=True)
+    copied = _copy_credentials(config_dir)
+    try:
+        yield config_dir
+    finally:
+        if copied is not None:
+            copied.unlink(missing_ok=True)

--- a/src/robocode/utils/claude_auth.py
+++ b/src/robocode/utils/claude_auth.py
@@ -14,7 +14,25 @@ _CREDENTIALS = ".credentials.json"
 
 def host_claude_config_dir() -> Path:
     """Return the operator's Claude configuration directory."""
-    return Path(os.environ.get("CLAUDE_CONFIG_DIR", str(Path.home() / ".claude")))
+    return Path(
+        os.environ.get("CLAUDE_CONFIG_DIR", str(Path.home() / ".claude"))
+    ).expanduser()
+
+
+def _checked_sandbox_subdir(sandbox_dir: Path, name: str) -> Path:
+    """Create a real direct child of *sandbox_dir*, rejecting symlink escapes."""
+    path = sandbox_dir / name
+    if path.is_symlink():
+        raise RuntimeError(f"Refusing symlinked Claude state directory: {path}")
+    path.mkdir(exist_ok=True)
+    if not path.is_dir() or path.resolve().parent != sandbox_dir.resolve():
+        raise RuntimeError(f"Claude state directory escaped the sandbox: {path}")
+    return path
+
+
+def sandbox_claude_session_store(sandbox_dir: Path) -> Path:
+    """Return the checked, sandbox-local persistent session-store directory."""
+    return _checked_sandbox_subdir(sandbox_dir, ".agent_sessions")
 
 
 def _copy_credentials(destination: Path) -> Path | None:
@@ -67,8 +85,7 @@ def sandbox_claude_config(sandbox_dir: Path) -> Iterator[Path]:
     prevents either reads from or writes to the operator's live config and
     avoids leaving an authentication secret in experiment output.
     """
-    config_dir = sandbox_dir / ".agent_home"
-    config_dir.mkdir(exist_ok=True)
+    config_dir = _checked_sandbox_subdir(sandbox_dir, ".agent_home")
     copied = _copy_credentials(config_dir)
     try:
         yield config_dir

--- a/src/robocode/utils/docker_sandbox.py
+++ b/src/robocode/utils/docker_sandbox.py
@@ -64,7 +64,10 @@ from robocode.utils.backends import (
     firewall_domains_for_provider,
     provider_from_model,
 )
-from robocode.utils.claude_auth import throwaway_claude_config
+from robocode.utils.claude_auth import (
+    sandbox_claude_session_store,
+    throwaway_claude_config,
+)
 from robocode.utils.sandbox import (
     SandboxConfig,
     SandboxResult,
@@ -574,8 +577,7 @@ async def run_agent_in_docker_sandbox(
         # working directory). Only Claude stores sessions at this path.
         session_volumes: list[str] = []
         if backend_name == "claude":
-            sessions_dir = config.sandbox_dir / ".agent_sessions"
-            sessions_dir.mkdir(exist_ok=True)
+            sessions_dir = sandbox_claude_session_store(config.sandbox_dir)
             session_volumes = [f"{sessions_dir.resolve()}:/home/node/.claude/projects"]
 
         docker_cmd = _docker_run_prefix(

--- a/src/robocode/utils/docker_sandbox.py
+++ b/src/robocode/utils/docker_sandbox.py
@@ -247,6 +247,7 @@ def _docker_run_prefix(
     firewall_domains: list[str],
     env_args: list[str] | None = None,
     map_host_gateway: bool = False,
+    extra_volumes: list[str] | None = None,
 ) -> list[str]:
     """Build the shared ``docker run`` prefix: caps, env, auth, mounts, image.
 
@@ -296,6 +297,8 @@ def _docker_run_prefix(
             f"{filtered_kinder_baselines.resolve()}"
             ":/robocode/third-party/kinder-baselines",
         ]
+    for volume in extra_volumes or []:
+        cmd += ["-v", volume]
     cmd += ["-w", "/sandbox", image]
     return cmd
 
@@ -592,6 +595,16 @@ async def run_agent_in_docker_sandbox(
             # OpenCode also needs access to its own telemetry/update servers.
             # firewall_domains.append("registry.npmjs.org")
 
+        # Persist the CLI session store on the host, under the sandbox dir, which
+        # survives the container --rm. A run interrupted by the usage cap can then
+        # be resumed in a fresh retry container (--continue in the same /sandbox
+        # working directory). Only Claude stores sessions at this path.
+        session_volumes: list[str] = []
+        if backend_name == "claude":
+            sessions_dir = config.sandbox_dir / ".agent_sessions"
+            sessions_dir.mkdir(exist_ok=True)
+            session_volumes = [f"{sessions_dir.resolve()}:/home/node/.claude/projects"]
+
         docker_cmd = _docker_run_prefix(
             container_name,
             config.docker_image,
@@ -601,6 +614,7 @@ async def run_agent_in_docker_sandbox(
             filtered_kinder_baselines,
             auth_args,
             firewall_domains,
+            extra_volumes=session_volumes,
             env_args=[
                 "-e",
                 f"CLAUDE_CODE_MAX_OUTPUT_TOKENS={config.max_output_tokens}",

--- a/src/robocode/utils/docker_sandbox.py
+++ b/src/robocode/utils/docker_sandbox.py
@@ -47,7 +47,7 @@ import tempfile
 import time
 import uuid
 from collections.abc import Iterator
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -64,6 +64,7 @@ from robocode.utils.backends import (
     firewall_domains_for_provider,
     provider_from_model,
 )
+from robocode.utils.claude_auth import throwaway_claude_config
 from robocode.utils.sandbox import (
     SandboxConfig,
     SandboxResult,
@@ -422,18 +423,14 @@ def _build_docker_auth_args(
     """Yield Docker CLI args and env vars for backend authentication.
 
     For Claude: OAuth token, or -- as a fallback when no token is found -- a
-    THROWAWAY COPY of ~/.claude bind-mounted read-write. Mounting the live host
-    ~/.claude would let anything the container writes under it, notably Claude
-    auto-memory, persist on the host and reach the next run; the copy is discarded
-    when this context exits, so writes stay ephemeral while the CLI can still read
-    the credentials and refresh session state.
+    writable, throwaway config containing only copied credentials. The CLI
+    cannot read the operator's history or memory, and its writes and token
+    refreshes are discarded when this context exits.
     For OpenCode: ~/.local/share/opencode bind-mount + API key passthrough.
     """
     docker_args: list[str] = []
     extra_env: dict[str, str] = {}
-    cleanup_dir: Path | None = None
-
-    try:
+    with ExitStack() as stack:
         if backend_name == "claude":
             oauth_token = _get_claude_oauth_token()
             if oauth_token:
@@ -442,31 +439,10 @@ def _build_docker_auth_args(
             else:
                 logger.warning(
                     "No Claude OAuth token found (env var or Keychain); falling "
-                    "back to a throwaway copy of ~/.claude. Run `claude login` on "
-                    "the host if the container cannot authenticate."
+                    "back to a throwaway credentials-only config. Run `claude "
+                    "login` on the host if the container cannot authenticate."
                 )
-                host_claude_cfg = Path(
-                    os.environ.get("CLAUDE_CONFIG_DIR", str(Path.home() / ".claude"))
-                )
-                cleanup_dir = Path(tempfile.mkdtemp(prefix="robocode-claude-"))
-                claude_copy = cleanup_dir / ".claude"
-                # Copy only what auth needs; skip the heavy, sensitive session
-                # dirs so they neither cost a per-run copy nor become readable in
-                # the sandbox. symlinks=True copies links verbatim, so a dangling
-                # link (e.g. debug/latest) does not abort the copy.
-                shutil.copytree(
-                    host_claude_cfg,
-                    claude_copy,
-                    symlinks=True,
-                    ignore=shutil.ignore_patterns(
-                        "projects",
-                        "todos",
-                        "shell-snapshots",
-                        "statsig",
-                        "debug",
-                        "history.jsonl",
-                    ),
-                )
+                claude_copy = stack.enter_context(throwaway_claude_config())
                 docker_args += ["-v", f"{claude_copy}:/home/node/.claude"]
         else:
             # OpenCode: bind-mount auth store and pass through API key env vars.
@@ -486,9 +462,6 @@ def _build_docker_auth_args(
                         extra_env[info.api_key_env] = val
 
         yield docker_args, extra_env
-    finally:
-        if cleanup_dir is not None:
-            shutil.rmtree(cleanup_dir, ignore_errors=True)
 
 
 def _mcp_prestart_wrapper(agent_cmd: list[str], port: int = MCP_HTTP_PORT) -> list[str]:

--- a/src/robocode/utils/rate_limit.py
+++ b/src/robocode/utils/rate_limit.py
@@ -1,4 +1,4 @@
-"""Helpers for running sandboxed agents with rate-limit retry."""
+"""Helpers for resuming sandboxed agents after retryable interruptions."""
 
 from __future__ import annotations
 
@@ -30,6 +30,15 @@ _DEFAULT_RESET_HOUR = 3  # fallback hour if we can't parse the reset time
 # Subscription usage caps reset on a 5-hour window, so a wait longer than this
 # means we mis-parsed the reset time. Cap the sleep; the retry loop re-checks.
 _MAX_WAIT_SECS = 5.5 * 3600
+# Avoid an infinite resume loop when a model repeatedly produces an oversized
+# response, especially for configurations where both cost and turns are unlimited.
+_MAX_OUTPUT_TOKEN_RETRIES = 2
+
+_OUTPUT_TOKEN_RESUME_PROMPT = (
+    "Continue the task from where the previous response was interrupted because it "
+    "exceeded the output-token limit. Be concise: do not repeat prior reasoning or "
+    "emit a long explanation. Use tools directly and finish the implementation."
+)
 
 
 def run_async(make_coro: Callable[[], Any]) -> SandboxResult:
@@ -82,15 +91,25 @@ def seconds_until_reset(reset_hour: int, is_utc: bool = False) -> float:
 
 
 def _fold_retry_metrics(
-    result: SandboxResult, aborted_tokens: int, aborted_cost: float, retries: int
+    result: SandboxResult,
+    aborted_tokens: int,
+    aborted_cost: float,
+    rate_limit_retries: int,
+    output_token_retries: int = 0,
 ) -> SandboxResult:
-    """Record the discarded rate-limited attempts' count and spend on *result*."""
-    if retries == 0:
+    """Record discarded retryable attempts' counts and spend on *result*."""
+    if (
+        rate_limit_retries == 0
+        and output_token_retries == 0
+        and aborted_tokens == 0
+        and aborted_cost == 0.0
+    ):
         return result
     base = result.generation_metrics or GenerationMetrics()
     metrics = replace(
         base,
-        rate_limit_retries=retries,
+        rate_limit_retries=rate_limit_retries,
+        output_token_retries=output_token_retries,
         aborted_tokens=aborted_tokens,
         aborted_cost_usd=aborted_cost,
     )
@@ -112,7 +131,7 @@ def run_with_rate_limit_retry(
     backend: AgentBackend,
     apptainer_config: ApptainerSandboxConfig | None = None,
 ) -> SandboxResult:
-    """Run the sandbox, retrying on rate-limit by sleeping until reset.
+    """Run the sandbox, resuming after retryable Claude interruptions.
 
     Each retry resumes the interrupted conversation (--continue) with the
     budget the run had left, so an agent that hit the usage cap continues its
@@ -129,14 +148,24 @@ def run_with_rate_limit_retry(
     aborted_tokens = 0
     aborted_turns = 0
     aborted_cost = 0.0
-    retries = 0
+    rate_limit_retries = 0
+    output_token_retries = 0
     while True:
         result = _run_active_sandbox(active, backend)
 
-        if result.rate_limit_reset is None:
-            return _fold_retry_metrics(result, aborted_tokens, aborted_cost, retries)
+        rate_limited = result.rate_limit_reset is not None
+        output_token_limited = result.output_token_limit_hit
+        if not rate_limited and not output_token_limited:
+            return _fold_retry_metrics(
+                result,
+                aborted_tokens,
+                aborted_cost,
+                rate_limit_retries,
+                output_token_retries,
+            )
 
-        retries += 1
+        if rate_limited:
+            rate_limit_retries += 1
         assert result.generation_metrics is not None
         aborted_tokens += result.generation_metrics.total_tokens
         aborted_turns += result.generation_metrics.num_turns
@@ -160,21 +189,54 @@ def run_with_rate_limit_retry(
                     else "the turn budget is exhausted"
                 )
             )
-            logger.warning("Not retrying rate-limited run because %s.", reason)
-            return _fold_retry_metrics(result, aborted_tokens, aborted_cost, retries)
+            logger.warning("Not resuming interrupted run because %s.", reason)
+            return _fold_retry_metrics(
+                result,
+                aborted_tokens,
+                aborted_cost,
+                rate_limit_retries,
+                output_token_retries,
+            )
 
-        reset_hour, is_utc = parse_reset_hour(result.rate_limit_reset)
-        wait_secs = seconds_until_reset(reset_hour, is_utc)
-        hours = wait_secs / 3600
-        logger.warning(
-            "Rate-limited (%s). Sleeping %.1f hours until %d:05 %s ...",
-            result.error,
-            hours,
-            reset_hour,
-            "UTC" if is_utc else "local",
-        )
-        time.sleep(wait_secs)
-        logger.info("Woke up after rate-limit sleep, resuming with remaining budget...")
+        if output_token_limited and output_token_retries >= _MAX_OUTPUT_TOKEN_RETRIES:
+            logger.warning(
+                "Not resuming after output-token overflow: retry limit (%d) reached.",
+                _MAX_OUTPUT_TOKEN_RETRIES,
+            )
+            return _fold_retry_metrics(
+                result,
+                aborted_tokens,
+                aborted_cost,
+                rate_limit_retries,
+                output_token_retries,
+            )
+
+        if rate_limited:
+            assert result.rate_limit_reset is not None
+            reset_hour, is_utc = parse_reset_hour(result.rate_limit_reset)
+            wait_secs = seconds_until_reset(reset_hour, is_utc)
+            hours = wait_secs / 3600
+            logger.warning(
+                "Rate-limited (%s). Sleeping %.1f hours until %d:05 %s ...",
+                result.error,
+                hours,
+                reset_hour,
+                "UTC" if is_utc else "local",
+            )
+            time.sleep(wait_secs)
+            logger.info(
+                "Woke up after rate-limit sleep, resuming with remaining budget..."
+            )
+            resume_prompt = active.prompt
+        else:
+            output_token_retries += 1
+            logger.warning(
+                "Claude exceeded its output-token maximum; resuming with remaining "
+                "budget (attempt %d/%d).",
+                output_token_retries,
+                _MAX_OUTPUT_TOKEN_RETRIES,
+            )
+            resume_prompt = _OUTPUT_TOKEN_RESUME_PROMPT
 
         # Zero means unlimited for both fields; exhausted positive limits were
         # handled above, so every finite remainder here is strictly positive.
@@ -182,6 +244,7 @@ def run_with_rate_limit_retry(
         active = replace(
             active,
             resume_previous_session=True,
+            prompt=resume_prompt,
             max_budget_usd=original_budget - aborted_cost if original_budget else 0.0,
             max_turns=remaining_turns,
         )

--- a/src/robocode/utils/rate_limit.py
+++ b/src/robocode/utils/rate_limit.py
@@ -97,28 +97,39 @@ def _fold_retry_metrics(
     return replace(result, generation_metrics=metrics)
 
 
+def _run_active_sandbox(config: SandboxConfig, backend: AgentBackend) -> SandboxResult:
+    """Dispatch to the sandbox runner matching the config's backend type."""
+    if isinstance(config, ApptainerSandboxConfig):
+        return run_async(lambda: run_agent_in_apptainer_sandbox(config, backend))
+    if isinstance(config, DockerSandboxConfig):
+        return run_async(lambda: run_agent_in_docker_sandbox(config, backend))
+    return run_async(lambda: run_agent_in_sandbox(config, backend))
+
+
 def run_with_rate_limit_retry(
     docker_config: DockerSandboxConfig | None,
     local_config: SandboxConfig | None,
     backend: AgentBackend,
     apptainer_config: ApptainerSandboxConfig | None = None,
 ) -> SandboxResult:
-    """Run the sandbox, retrying on rate-limit by sleeping until reset."""
+    """Run the sandbox, retrying on rate-limit by sleeping until reset.
+
+    Each retry resumes the interrupted conversation (--continue) with the
+    budget the run had left, so an agent that hit the usage cap continues its
+    work rather than restarting cold, and the total budget it spends matches a
+    run that never hit the cap.
+    """
+    active: SandboxConfig | None = apptainer_config or docker_config or local_config
+    assert active is not None
+    original_budget = active.max_budget_usd
+    original_turns = active.max_turns
+
     aborted_tokens = 0
+    aborted_turns = 0
     aborted_cost = 0.0
     retries = 0
     while True:
-        if apptainer_config is not None:
-            result = run_async(
-                lambda: run_agent_in_apptainer_sandbox(apptainer_config, backend)
-            )
-        elif docker_config is not None:
-            result = run_async(
-                lambda: run_agent_in_docker_sandbox(docker_config, backend)
-            )
-        else:
-            assert local_config is not None
-            result = run_async(lambda: run_agent_in_sandbox(local_config, backend))
+        result = _run_active_sandbox(active, backend)
 
         if result.rate_limit_reset is None:
             return _fold_retry_metrics(result, aborted_tokens, aborted_cost, retries)
@@ -126,6 +137,7 @@ def run_with_rate_limit_retry(
         retries += 1
         assert result.generation_metrics is not None
         aborted_tokens += result.generation_metrics.total_tokens
+        aborted_turns += result.generation_metrics.num_turns
         aborted_cost += result.total_cost_usd or 0.0
 
         reset_hour, is_utc = parse_reset_hour(result.rate_limit_reset)
@@ -139,4 +151,16 @@ def run_with_rate_limit_retry(
             "UTC" if is_utc else "local",
         )
         time.sleep(wait_secs)
-        logger.info("Woke up after rate-limit sleep, retrying...")
+        logger.info("Woke up after rate-limit sleep, resuming with remaining budget...")
+
+        # 0 turns means unlimited, so keep it; otherwise carry what is left,
+        # never dropping to 0 (which would silently re-grant unlimited turns).
+        remaining_turns = (
+            max(original_turns - aborted_turns, 1) if original_turns else 0
+        )
+        active = replace(
+            active,
+            resume_previous_session=True,
+            max_budget_usd=max(original_budget - aborted_cost, 0.0),
+            max_turns=remaining_turns,
+        )

--- a/src/robocode/utils/rate_limit.py
+++ b/src/robocode/utils/rate_limit.py
@@ -33,11 +33,20 @@ _MAX_WAIT_SECS = 5.5 * 3600
 # Avoid an infinite resume loop when a model repeatedly produces an oversized
 # response, especially for configurations where both cost and turns are unlimited.
 _MAX_OUTPUT_TOKEN_RETRIES = 2
+_MAX_PROMPT_TOO_LONG_RETRIES = 2
 
 _OUTPUT_TOKEN_RESUME_PROMPT = (
     "Continue the task from where the previous response was interrupted because it "
     "exceeded the output-token limit. Be concise: do not repeat prior reasoning or "
     "emit a long explanation. Use tools directly and finish the implementation."
+)
+_COMPACT_PROMPT = (
+    "/compact Preserve the task requirements, decisions, failed approaches, and "
+    "current implementation state. Drop verbose tool output and repeated reasoning."
+)
+_CONTEXT_RESUME_PROMPT = (
+    "Continue the task from the compacted conversation. Inspect the current files, "
+    "use tools directly, and finish the implementation concisely."
 )
 
 
@@ -55,27 +64,38 @@ def run_async(make_coro: Callable[[], Any]) -> SandboxResult:
         return pool.submit(_run).result()
 
 
-def parse_reset_hour(reset_str: str) -> tuple[int, bool]:
-    """Parse a reset message into (hour_24, is_utc).
+def parse_reset_time(reset_str: str) -> tuple[int, int, bool]:
+    """Parse a reset message into (hour_24, minute, is_utc).
 
-    Handles bare times like '3am' as well as full messages such as "You've hit your
-    session limit . resets 11pm (UTC)". The timezone flag matters because the box may
-    not be in UTC.
+    Handles bare times like ``3am`` and minute-bearing times like ``1:30pm``
+    as well as full usage-limit messages. The timezone flag matters because
+    the box may not be in UTC.
     """
     text = reset_str.strip().lower()
-    match = re.search(r"(\d{1,2})\s*(am|pm)", text)
+    match = re.search(r"(\d{1,2})(?::(\d{2}))?\s*(am|pm)", text)
     if not match:
-        return _DEFAULT_RESET_HOUR, False
+        return _DEFAULT_RESET_HOUR, 0, False
     hour = int(match.group(1))
-    period = match.group(2)
+    minute = int(match.group(2) or 0)
+    period = match.group(3)
+    if not 1 <= hour <= 12 or not 0 <= minute <= 59:
+        return _DEFAULT_RESET_HOUR, 0, False
     if period == "am":
         hour = 0 if hour == 12 else hour
     else:
         hour = hour if hour == 12 else hour + 12
-    return hour, "utc" in text
+    return hour, minute, "utc" in text
 
 
-def seconds_until_reset(reset_hour: int, is_utc: bool = False) -> float:
+def parse_reset_hour(reset_str: str) -> tuple[int, bool]:
+    """Parse a reset message into (hour_24, is_utc), for compatibility."""
+    hour, _minute, is_utc = parse_reset_time(reset_str)
+    return hour, is_utc
+
+
+def seconds_until_reset(
+    reset_hour: int, is_utc: bool = False, reset_minute: int = 0
+) -> float:
     """Return seconds until the given reset hour, capped at the window length.
 
     When ``is_utc`` the hour is interpreted in UTC (and compared against UTC
@@ -83,7 +103,9 @@ def seconds_until_reset(reset_hour: int, is_utc: bool = False) -> float:
     so a misparsed time cannot cause a multi-hour oversleep.
     """
     now = datetime.now(timezone.utc) if is_utc else datetime.now().astimezone()
-    target = now.replace(hour=reset_hour, minute=5, second=0, microsecond=0)
+    target = now.replace(
+        hour=reset_hour, minute=reset_minute, second=0, microsecond=0
+    ) + timedelta(minutes=5)
     if target <= now:
         target += timedelta(days=1)
     wait = (target - now).total_seconds()
@@ -96,11 +118,13 @@ def _fold_retry_metrics(
     aborted_cost: float,
     rate_limit_retries: int,
     output_token_retries: int = 0,
+    prompt_too_long_retries: int = 0,
 ) -> SandboxResult:
     """Record discarded retryable attempts' counts and spend on *result*."""
     if (
         rate_limit_retries == 0
         and output_token_retries == 0
+        and prompt_too_long_retries == 0
         and aborted_tokens == 0
         and aborted_cost == 0.0
     ):
@@ -110,6 +134,7 @@ def _fold_retry_metrics(
         base,
         rate_limit_retries=rate_limit_retries,
         output_token_retries=output_token_retries,
+        prompt_too_long_retries=prompt_too_long_retries,
         aborted_tokens=aborted_tokens,
         aborted_cost_usd=aborted_cost,
     )
@@ -150,18 +175,32 @@ def run_with_rate_limit_retry(
     aborted_cost = 0.0
     rate_limit_retries = 0
     output_token_retries = 0
+    prompt_too_long_retries = 0
+
+    def budget_stop_reason(latest: SandboxResult) -> str | None:
+        """Explain why another process cannot safely receive carried budget."""
+        if original_budget > 0 and latest.total_cost_usd is None:
+            return "the interrupted attempt did not report its cost"
+        if 0 < original_budget <= aborted_cost:
+            return "the dollar budget is exhausted"
+        if 0 < original_turns <= aborted_turns:
+            return "the turn budget is exhausted"
+        return None
+
     while True:
         result = _run_active_sandbox(active, backend)
 
         rate_limited = result.rate_limit_reset is not None
         output_token_limited = result.output_token_limit_hit
-        if not rate_limited and not output_token_limited:
+        prompt_too_long = result.prompt_too_long_hit
+        if not rate_limited and not output_token_limited and not prompt_too_long:
             return _fold_retry_metrics(
                 result,
                 aborted_tokens,
                 aborted_cost,
                 rate_limit_retries,
                 output_token_retries,
+                prompt_too_long_retries,
             )
 
         if rate_limited:
@@ -176,19 +215,8 @@ def run_with_rate_limit_retry(
         # unbounded second run.  Likewise, without a reported cost we cannot
         # carry a positive dollar budget forward without changing the
         # experimental condition.
-        missing_cost = original_budget > 0 and result.total_cost_usd is None
-        budget_exhausted = 0 < original_budget <= aborted_cost
-        turns_exhausted = 0 < original_turns <= aborted_turns
-        if missing_cost or budget_exhausted or turns_exhausted:
-            reason = (
-                "the interrupted attempt did not report its cost"
-                if missing_cost
-                else (
-                    "the dollar budget is exhausted"
-                    if budget_exhausted
-                    else "the turn budget is exhausted"
-                )
-            )
+        reason = budget_stop_reason(result)
+        if reason is not None:
             logger.warning("Not resuming interrupted run because %s.", reason)
             return _fold_retry_metrics(
                 result,
@@ -196,6 +224,7 @@ def run_with_rate_limit_retry(
                 aborted_cost,
                 rate_limit_retries,
                 output_token_retries,
+                prompt_too_long_retries,
             )
 
         if output_token_limited and output_token_retries >= _MAX_OUTPUT_TOKEN_RETRIES:
@@ -209,18 +238,97 @@ def run_with_rate_limit_retry(
                 aborted_cost,
                 rate_limit_retries,
                 output_token_retries,
+                prompt_too_long_retries,
             )
+
+        if prompt_too_long and not rate_limited:
+            if prompt_too_long_retries >= _MAX_PROMPT_TOO_LONG_RETRIES:
+                logger.warning(
+                    "Not resuming after an oversized prompt: compaction retry limit "
+                    "(%d) reached.",
+                    _MAX_PROMPT_TOO_LONG_RETRIES,
+                )
+                return _fold_retry_metrics(
+                    result,
+                    aborted_tokens,
+                    aborted_cost,
+                    rate_limit_retries,
+                    output_token_retries,
+                    prompt_too_long_retries,
+                )
+
+            remaining_turns = original_turns - aborted_turns if original_turns else 0
+            compact_config = replace(
+                active,
+                resume_previous_session=True,
+                prompt=_COMPACT_PROMPT,
+                max_budget_usd=(
+                    original_budget - aborted_cost if original_budget else 0.0
+                ),
+                max_turns=remaining_turns,
+            )
+            logger.warning(
+                "Claude reported that its prompt is too long; compacting the "
+                "isolated session before resuming (attempt %d/%d).",
+                prompt_too_long_retries + 1,
+                _MAX_PROMPT_TOO_LONG_RETRIES,
+            )
+            compact_result = _run_active_sandbox(compact_config, backend)
+            assert compact_result.generation_metrics is not None
+            compact_metrics = compact_result.generation_metrics
+            aborted_tokens += compact_metrics.total_tokens
+            aborted_turns += compact_metrics.num_turns
+            aborted_cost += compact_result.total_cost_usd or 0.0
+
+            # The sandbox runner may report "output file not found" for the local
+            # /compact command. The compact-boundary stream event is the reliable
+            # success signal; other failures must not be mistaken for compaction.
+            compacted = compact_metrics.num_autocompactions > 0
+            reason = budget_stop_reason(compact_result)
+            if not compacted or reason is not None:
+                if reason is None:
+                    reason = "Claude did not confirm that conversation compaction ran"
+                logger.warning("Not resuming oversized prompt because %s.", reason)
+                compact_result = replace(
+                    compact_result,
+                    prompt_too_long_hit=True,
+                    generation_metrics=replace(
+                        compact_metrics, prompt_too_long_hit=True
+                    ),
+                )
+                return _fold_retry_metrics(
+                    compact_result,
+                    aborted_tokens,
+                    aborted_cost,
+                    rate_limit_retries,
+                    output_token_retries,
+                    prompt_too_long_retries,
+                )
+
+            prompt_too_long_retries += 1
+            remaining_turns = original_turns - aborted_turns if original_turns else 0
+            active = replace(
+                compact_config,
+                prompt=_CONTEXT_RESUME_PROMPT,
+                max_budget_usd=(
+                    original_budget - aborted_cost if original_budget else 0.0
+                ),
+                max_turns=remaining_turns,
+            )
+            continue
 
         if rate_limited:
             assert result.rate_limit_reset is not None
-            reset_hour, is_utc = parse_reset_hour(result.rate_limit_reset)
-            wait_secs = seconds_until_reset(reset_hour, is_utc)
+            reset_hour, reset_minute, is_utc = parse_reset_time(result.rate_limit_reset)
+            wait_secs = seconds_until_reset(reset_hour, is_utc, reset_minute)
             hours = wait_secs / 3600
             logger.warning(
-                "Rate-limited (%s). Sleeping %.1f hours until %d:05 %s ...",
+                "Rate-limited (%s). Sleeping %.1f hours for reset at %02d:%02d %s "
+                "(plus 5-minute grace) ...",
                 result.error,
                 hours,
                 reset_hour,
+                reset_minute,
                 "UTC" if is_utc else "local",
             )
             time.sleep(wait_secs)

--- a/src/robocode/utils/rate_limit.py
+++ b/src/robocode/utils/rate_limit.py
@@ -116,8 +116,10 @@ def run_with_rate_limit_retry(
 
     Each retry resumes the interrupted conversation (--continue) with the
     budget the run had left, so an agent that hit the usage cap continues its
-    work rather than restarting cold, and the total budget it spends matches a
-    run that never hit the cap.
+    work rather than restarting cold without receiving a fresh experimental
+    budget. Rehydrating the transcript may itself consume uncached input tokens,
+    so a resumed run is recorded explicitly and is not claimed to be identical
+    to an uninterrupted run.
     """
     active: SandboxConfig | None = apptainer_config or docker_config or local_config
     assert active is not None
@@ -140,6 +142,27 @@ def run_with_rate_limit_retry(
         aborted_turns += result.generation_metrics.num_turns
         aborted_cost += result.total_cost_usd or 0.0
 
+        # Both CLI limits use zero to mean unlimited.  Never turn an exhausted
+        # positive limit into zero on a retry, which would silently grant an
+        # unbounded second run.  Likewise, without a reported cost we cannot
+        # carry a positive dollar budget forward without changing the
+        # experimental condition.
+        missing_cost = original_budget > 0 and result.total_cost_usd is None
+        budget_exhausted = 0 < original_budget <= aborted_cost
+        turns_exhausted = 0 < original_turns <= aborted_turns
+        if missing_cost or budget_exhausted or turns_exhausted:
+            reason = (
+                "the interrupted attempt did not report its cost"
+                if missing_cost
+                else (
+                    "the dollar budget is exhausted"
+                    if budget_exhausted
+                    else "the turn budget is exhausted"
+                )
+            )
+            logger.warning("Not retrying rate-limited run because %s.", reason)
+            return _fold_retry_metrics(result, aborted_tokens, aborted_cost, retries)
+
         reset_hour, is_utc = parse_reset_hour(result.rate_limit_reset)
         wait_secs = seconds_until_reset(reset_hour, is_utc)
         hours = wait_secs / 3600
@@ -153,14 +176,12 @@ def run_with_rate_limit_retry(
         time.sleep(wait_secs)
         logger.info("Woke up after rate-limit sleep, resuming with remaining budget...")
 
-        # 0 turns means unlimited, so keep it; otherwise carry what is left,
-        # never dropping to 0 (which would silently re-grant unlimited turns).
-        remaining_turns = (
-            max(original_turns - aborted_turns, 1) if original_turns else 0
-        )
+        # Zero means unlimited for both fields; exhausted positive limits were
+        # handled above, so every finite remainder here is strictly positive.
+        remaining_turns = original_turns - aborted_turns if original_turns else 0
         active = replace(
             active,
             resume_previous_session=True,
-            max_budget_usd=max(original_budget - aborted_cost, 0.0),
+            max_budget_usd=original_budget - aborted_cost if original_budget else 0.0,
             max_turns=remaining_turns,
         )

--- a/src/robocode/utils/sandbox.py
+++ b/src/robocode/utils/sandbox.py
@@ -103,6 +103,7 @@ __pycache__/
 *.mp4
 agent_log.txt
 .mcp/
+.agent_sessions/
 mcp_renders/
 """
 

--- a/src/robocode/utils/sandbox.py
+++ b/src/robocode/utils/sandbox.py
@@ -20,12 +20,12 @@ to override the default binary paths.
 from __future__ import annotations
 
 import logging
-import os
 import shutil
 import socket
 import subprocess
 import sys
 import time
+from contextlib import nullcontext
 from pathlib import Path
 
 from robocode.mcp import MCP_START_SCRIPT
@@ -35,6 +35,7 @@ from robocode.primitive_specs import (
     REMOTE_MODULE_PRIMITIVES,
 )
 from robocode.utils.backends import AgentBackend
+from robocode.utils.claude_auth import sandbox_claude_config
 from robocode.utils.sandbox_types import (
     GenerationMetrics,
     SandboxConfig,
@@ -314,29 +315,6 @@ def _final_commit(sandbox_dir: Path) -> None:
         logger.info("No uncommitted changes to commit in sandbox.")
 
 
-def _redirect_claude_config_to_sandbox(sandbox_dir: Path) -> str:
-    """Point the Claude CLI's config and session store inside the sandbox.
-
-    The CLI writes its conversation transcripts (needed to resume after a rate
-    limit), history, and caches to the returned directory instead of the host
-    ``~/.claude``, so a local run leaves nothing on the host and cleanup is just
-    removing the sandbox dir. Host credentials are symlinked in, not copied, so
-    auth works without duplicating the secret into the sandbox; token auth via
-    ``CLAUDE_CODE_OAUTH_TOKEN`` reaches the CLI through the environment and needs
-    no file.
-    """
-    agent_home = sandbox_dir / ".agent_home"
-    agent_home.mkdir(exist_ok=True)
-    host_claude = Path(
-        os.environ.get("CLAUDE_CONFIG_DIR", str(Path.home() / ".claude"))
-    )
-    creds = host_claude / ".credentials.json"
-    link = agent_home / ".credentials.json"
-    if creds.exists() and not link.exists():
-        link.symlink_to(creds)
-    return str(agent_home)
-
-
 async def run_agent_in_sandbox(
     config: SandboxConfig,
     backend: AgentBackend,
@@ -377,10 +355,6 @@ async def run_agent_in_sandbox(
     _initial_commit(config.sandbox_dir)
 
     env = backend.build_env(config)
-    if backend.name == "claude":
-        env["CLAUDE_CONFIG_DIR"] = _redirect_claude_config_to_sandbox(
-            config.sandbox_dir
-        )
     sandbox_abs = str(config.sandbox_dir.resolve())
 
     logger.info("Running: %s (cwd=%s)", " ".join(cmd[:6]) + " ...", sandbox_abs)
@@ -393,22 +367,30 @@ async def run_agent_in_sandbox(
         else None
     )
     wall_start = time.monotonic()
+    claude_config = (
+        sandbox_claude_config(config.sandbox_dir)
+        if backend.name == "claude"
+        else nullcontext(None)
+    )
     try:
-        proc = subprocess.Popen(  # pylint: disable=consider-using-with
-            cmd,
-            cwd=sandbox_abs,
-            env=env,
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            start_new_session=True,
-        )
+        with claude_config as config_dir:
+            if config_dir is not None:
+                env["CLAUDE_CONFIG_DIR"] = str(config_dir)
+            proc = subprocess.Popen(  # pylint: disable=consider-using-with
+                cmd,
+                cwd=sandbox_abs,
+                env=env,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                start_new_session=True,
+            )
 
-        stream = backend.parse_stream(
-            proc,
-            stream_log_path=config.sandbox_dir.parent / "stream.jsonl",
-        )
+            stream = backend.parse_stream(
+                proc,
+                stream_log_path=config.sandbox_dir.parent / "stream.jsonl",
+            )
     finally:
         if server_proc is not None:
             server_proc.terminate()

--- a/src/robocode/utils/sandbox.py
+++ b/src/robocode/utils/sandbox.py
@@ -235,19 +235,21 @@ def _stream_result_to_sandbox_result(
         num_autocompactions=stream.num_autocompactions,
         num_permission_denials=stream.num_permission_denials,
         turn_limit_hit=stream.turn_limit_hit,
+        output_token_limit_hit=stream.output_token_limit_hit,
         stop_reason=stream.stop_reason,
         model_usage=stream.model_usage,
     )
 
-    # A rate-limit error must propagate so the retry loop can wait and rerun the
-    # whole sandbox; never evaluate a partial approach from a rate-limited run.
-    if stream.rate_limit_reset is not None:
+    # Retryable interruptions must propagate before considering a partial output.
+    # The retry loop resumes the same conversation with the remaining budget.
+    if stream.rate_limit_reset is not None or stream.output_token_limit_hit:
         return SandboxResult(
             success=False,
             output_file=None,
             error=stream.error_text,
             total_cost_usd=cost,
             rate_limit_reset=stream.rate_limit_reset,
+            output_token_limit_hit=stream.output_token_limit_hit,
             generation_metrics=metrics,
         )
 

--- a/src/robocode/utils/sandbox.py
+++ b/src/robocode/utils/sandbox.py
@@ -236,13 +236,18 @@ def _stream_result_to_sandbox_result(
         num_permission_denials=stream.num_permission_denials,
         turn_limit_hit=stream.turn_limit_hit,
         output_token_limit_hit=stream.output_token_limit_hit,
+        prompt_too_long_hit=stream.prompt_too_long_hit,
         stop_reason=stream.stop_reason,
         model_usage=stream.model_usage,
     )
 
     # Retryable interruptions must propagate before considering a partial output.
     # The retry loop resumes the same conversation with the remaining budget.
-    if stream.rate_limit_reset is not None or stream.output_token_limit_hit:
+    if (
+        stream.rate_limit_reset is not None
+        or stream.output_token_limit_hit
+        or stream.prompt_too_long_hit
+    ):
         return SandboxResult(
             success=False,
             output_file=None,
@@ -250,6 +255,7 @@ def _stream_result_to_sandbox_result(
             total_cost_usd=cost,
             rate_limit_reset=stream.rate_limit_reset,
             output_token_limit_hit=stream.output_token_limit_hit,
+            prompt_too_long_hit=stream.prompt_too_long_hit,
             generation_metrics=metrics,
         )
 

--- a/src/robocode/utils/sandbox.py
+++ b/src/robocode/utils/sandbox.py
@@ -20,6 +20,7 @@ to override the default binary paths.
 from __future__ import annotations
 
 import logging
+import os
 import shutil
 import socket
 import subprocess
@@ -104,6 +105,7 @@ __pycache__/
 agent_log.txt
 .mcp/
 .agent_sessions/
+.agent_home/
 mcp_renders/
 """
 
@@ -312,6 +314,29 @@ def _final_commit(sandbox_dir: Path) -> None:
         logger.info("No uncommitted changes to commit in sandbox.")
 
 
+def _redirect_claude_config_to_sandbox(sandbox_dir: Path) -> str:
+    """Point the Claude CLI's config and session store inside the sandbox.
+
+    The CLI writes its conversation transcripts (needed to resume after a rate
+    limit), history, and caches to the returned directory instead of the host
+    ``~/.claude``, so a local run leaves nothing on the host and cleanup is just
+    removing the sandbox dir. Host credentials are symlinked in, not copied, so
+    auth works without duplicating the secret into the sandbox; token auth via
+    ``CLAUDE_CODE_OAUTH_TOKEN`` reaches the CLI through the environment and needs
+    no file.
+    """
+    agent_home = sandbox_dir / ".agent_home"
+    agent_home.mkdir(exist_ok=True)
+    host_claude = Path(
+        os.environ.get("CLAUDE_CONFIG_DIR", str(Path.home() / ".claude"))
+    )
+    creds = host_claude / ".credentials.json"
+    link = agent_home / ".credentials.json"
+    if creds.exists() and not link.exists():
+        link.symlink_to(creds)
+    return str(agent_home)
+
+
 async def run_agent_in_sandbox(
     config: SandboxConfig,
     backend: AgentBackend,
@@ -352,6 +377,10 @@ async def run_agent_in_sandbox(
     _initial_commit(config.sandbox_dir)
 
     env = backend.build_env(config)
+    if backend.name == "claude":
+        env["CLAUDE_CONFIG_DIR"] = _redirect_claude_config_to_sandbox(
+            config.sandbox_dir
+        )
     sandbox_abs = str(config.sandbox_dir.resolve())
 
     logger.info("Running: %s (cwd=%s)", " ".join(cmd[:6]) + " ...", sandbox_abs)

--- a/src/robocode/utils/sandbox_types.py
+++ b/src/robocode/utils/sandbox_types.py
@@ -83,15 +83,18 @@ class GenerationMetrics:
     num_permission_denials: int = 0
     turn_limit_hit: bool = False
     output_token_limit_hit: bool = False
+    prompt_too_long_hit: bool = False
     stop_reason: str | None = None
     model_usage: dict[str, Any] = field(default_factory=dict)
     # Retryable interruptions. The loop resumes with only the remaining budget;
-    # rate limits wait for the usage window, while output-token overflows retry
-    # immediately. Keep discarded attempts separate from final-attempt metrics
-    # so affected generations can be identified and excluded in analysis. The
-    # main fields above describe the final attempt only.
+    # rate limits wait for the usage window, output-token overflows retry
+    # immediately, and oversized prompts first run /compact. Keep discarded
+    # attempts separate from final-attempt metrics so affected generations can
+    # be identified and excluded in analysis. The main fields above describe
+    # the final attempt only.
     rate_limit_retries: int = 0
     output_token_retries: int = 0
+    prompt_too_long_retries: int = 0
     aborted_tokens: int = 0
     aborted_cost_usd: float = 0.0
 
@@ -122,10 +125,12 @@ class GenerationMetrics:
             "gen_num_permission_denials": self.num_permission_denials,
             "gen_turn_limit_hit": self.turn_limit_hit,
             "gen_output_token_limit_hit": self.output_token_limit_hit,
+            "gen_prompt_too_long_hit": self.prompt_too_long_hit,
             "gen_stop_reason": self.stop_reason,
             "gen_model_usage": self.model_usage,
             "gen_rate_limit_retries": self.rate_limit_retries,
             "gen_output_token_retries": self.output_token_retries,
+            "gen_prompt_too_long_retries": self.prompt_too_long_retries,
             "gen_aborted_tokens": self.aborted_tokens,
             "gen_aborted_cost_usd": self.aborted_cost_usd,
         }
@@ -141,6 +146,7 @@ class SandboxResult:
     total_cost_usd: float | None = None
     rate_limit_reset: str | None = None  # e.g. "3am" from usage limit message
     output_token_limit_hit: bool = False
+    prompt_too_long_hit: bool = False
     generation_metrics: GenerationMetrics | None = None
 
 
@@ -154,6 +160,7 @@ class _StreamParseResult:
     total_cost: float | None
     rate_limit_reset: str | None = None  # e.g. "3am" parsed from usage message
     output_token_limit_hit: bool = False
+    prompt_too_long_hit: bool = False
     input_tokens: int = 0
     output_tokens: int = 0
     cache_read_tokens: int = 0

--- a/src/robocode/utils/sandbox_types.py
+++ b/src/robocode/utils/sandbox_types.py
@@ -53,11 +53,10 @@ class SandboxConfig:
     # (they share the host network namespace); DockerSandboxConfig overrides this
     # to host.docker.internal (mapped to the host gateway via --add-host).
     local_model_host: str = "127.0.0.1"
-    # Resume the prior CLI conversation in this sandbox's working directory
-    # instead of starting fresh. Set by the rate-limit retry loop so an agent
-    # interrupted by the usage cap continues with its conversation context and
-    # remaining (carried-over) budget. Resume overhead can still differ from an
-    # uninterrupted run and is exposed by the retry metrics below.
+    # Resume the isolated CLI conversation belonging to this sandbox after a
+    # retryable interruption, carrying over only the remaining budget. Resume
+    # overhead can still differ from an uninterrupted run and is exposed by the
+    # retry metrics below.
     resume_previous_session: bool = False
 
 
@@ -83,14 +82,16 @@ class GenerationMetrics:
     num_autocompactions: int = 0
     num_permission_denials: int = 0
     turn_limit_hit: bool = False
+    output_token_limit_hit: bool = False
     stop_reason: str | None = None
     model_usage: dict[str, Any] = field(default_factory=dict)
-    # Rate-limit interruptions. The retry loop sleeps until the usage window
-    # resets and reruns the whole sandbox; the interrupted attempts are dropped
-    # from evaluation but their count and spend are recorded here so runs that
-    # straddled a reset can be identified and excluded in analysis. The main
-    # fields above describe the final, successful attempt only.
+    # Retryable interruptions. The loop resumes with only the remaining budget;
+    # rate limits wait for the usage window, while output-token overflows retry
+    # immediately. Keep discarded attempts separate from final-attempt metrics
+    # so affected generations can be identified and excluded in analysis. The
+    # main fields above describe the final attempt only.
     rate_limit_retries: int = 0
+    output_token_retries: int = 0
     aborted_tokens: int = 0
     aborted_cost_usd: float = 0.0
 
@@ -120,9 +121,11 @@ class GenerationMetrics:
             "gen_num_autocompactions": self.num_autocompactions,
             "gen_num_permission_denials": self.num_permission_denials,
             "gen_turn_limit_hit": self.turn_limit_hit,
+            "gen_output_token_limit_hit": self.output_token_limit_hit,
             "gen_stop_reason": self.stop_reason,
             "gen_model_usage": self.model_usage,
             "gen_rate_limit_retries": self.rate_limit_retries,
+            "gen_output_token_retries": self.output_token_retries,
             "gen_aborted_tokens": self.aborted_tokens,
             "gen_aborted_cost_usd": self.aborted_cost_usd,
         }
@@ -137,6 +140,7 @@ class SandboxResult:
     error: str | None
     total_cost_usd: float | None = None
     rate_limit_reset: str | None = None  # e.g. "3am" from usage limit message
+    output_token_limit_hit: bool = False
     generation_metrics: GenerationMetrics | None = None
 
 
@@ -149,6 +153,7 @@ class _StreamParseResult:
     num_turns: int
     total_cost: float | None
     rate_limit_reset: str | None = None  # e.g. "3am" parsed from usage message
+    output_token_limit_hit: bool = False
     input_tokens: int = 0
     output_tokens: int = 0
     cache_read_tokens: int = 0

--- a/src/robocode/utils/sandbox_types.py
+++ b/src/robocode/utils/sandbox_types.py
@@ -55,9 +55,9 @@ class SandboxConfig:
     local_model_host: str = "127.0.0.1"
     # Resume the prior CLI conversation in this sandbox's working directory
     # instead of starting fresh. Set by the rate-limit retry loop so an agent
-    # interrupted by the usage cap continues with its full context and its
-    # remaining (carried-over) budget, making the run equivalent to one that
-    # never hit the cap.
+    # interrupted by the usage cap continues with its conversation context and
+    # remaining (carried-over) budget. Resume overhead can still differ from an
+    # uninterrupted run and is exposed by the retry metrics below.
     resume_previous_session: bool = False
 
 

--- a/src/robocode/utils/sandbox_types.py
+++ b/src/robocode/utils/sandbox_types.py
@@ -53,6 +53,12 @@ class SandboxConfig:
     # (they share the host network namespace); DockerSandboxConfig overrides this
     # to host.docker.internal (mapped to the host gateway via --add-host).
     local_model_host: str = "127.0.0.1"
+    # Resume the prior CLI conversation in this sandbox's working directory
+    # instead of starting fresh. Set by the rate-limit retry loop so an agent
+    # interrupted by the usage cap continues with its full context and its
+    # remaining (carried-over) budget, making the run equivalent to one that
+    # never hit the cap.
+    resume_previous_session: bool = False
 
 
 @dataclass(frozen=True)

--- a/tests/utils/test_apptainer_sandbox.py
+++ b/tests/utils/test_apptainer_sandbox.py
@@ -197,31 +197,44 @@ def test_build_cmd_auth_args_inserted(tmp_path: Path) -> None:
 def test_opencode_auth_passes_api_keys(monkeypatch) -> None:  # type: ignore
     """Provider API keys are forwarded via APPTAINERENV_ env vars, not argv."""
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-value")
-    args, env = _build_apptainer_auth_args("opencode")
-    assert env.get("APPTAINERENV_ANTHROPIC_API_KEY") == "sk-test-value"
-    # The secret must not appear on the command line.
-    assert not any("sk-test-value" in a for a in args)
+    with _build_apptainer_auth_args("opencode") as (args, env):
+        assert env.get("APPTAINERENV_ANTHROPIC_API_KEY") == "sk-test-value"
+        # The secret must not appear on the command line.
+        assert not any("sk-test-value" in a for a in args)
 
 
 def test_claude_auth_uses_env_token(monkeypatch) -> None:  # type: ignore
     """CLAUDE_CODE_OAUTH_TOKEN is forwarded via APPTAINERENV_, never on argv."""
     monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-test")
-    args, env = _build_apptainer_auth_args("claude")
-    assert env.get("APPTAINERENV_CLAUDE_CODE_OAUTH_TOKEN") == "sk-ant-oat01-test"
-    # The token must not appear on the command line (visible via `ps`).
-    assert not any("sk-ant-oat01-test" in a for a in args)
-    assert not any("--bind" in a for a in args)
+    with _build_apptainer_auth_args("claude") as (args, env):
+        assert env.get("APPTAINERENV_CLAUDE_CODE_OAUTH_TOKEN") == "sk-ant-oat01-test"
+        # The token must not appear on the command line (visible via `ps`).
+        assert not any("sk-ant-oat01-test" in a for a in args)
+        assert not any("--bind" in a for a in args)
 
 
-def test_claude_auth_falls_back_to_bind(monkeypatch) -> None:  # type: ignore
-    """When no token is found, falls back to bind-mounting ~/.claude."""
+def test_claude_auth_binds_credentials_only(  # type: ignore
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The fallback mount is a throwaway credentials-only copy."""
     monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
     # Force the resolver to report no token (avoid Keychain hit on dev macOS).
     monkeypatch.setattr(
         "robocode.utils.apptainer_sandbox._get_claude_oauth_token",
         lambda: None,
     )
-    args, env = _build_apptainer_auth_args("claude")
-    assert not env  # no env vars when bind is used
-    assert "--bind" in args
-    assert any(arg.endswith(":/home/node/.claude") for arg in args)
+    host = tmp_path / ".claude"
+    (host / "projects").mkdir(parents=True)
+    (host / "projects" / "past.jsonl").write_text("past")
+    (host / ".credentials.json").write_text("credentials")
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(host))
+
+    with _build_apptainer_auth_args("claude") as (args, env):
+        assert not env
+        bind = next(arg for arg in args if arg.endswith(":/home/node/.claude"))
+        mounted = Path(bind.split(":", 1)[0])
+        assert mounted != host
+        assert [path.name for path in mounted.iterdir()] == [".credentials.json"]
+        copied = mounted
+
+    assert not copied.exists()

--- a/tests/utils/test_backends.py
+++ b/tests/utils/test_backends.py
@@ -104,6 +104,22 @@ class TestClaudeBackend:
         cmd = ClaudeBackend(DEFAULT_BACKEND_CFG).build_cli_cmd(config)
         assert "--max-budget-usd" not in cmd
 
+    def test_build_cli_cmd_persists_session_by_default(self, tmp_path: Path) -> None:
+        """Sessions persist (resumable) and no --continue without a resume request."""
+        config = SandboxConfig(sandbox_dir=tmp_path, prompt="hi")
+        cmd = ClaudeBackend(DEFAULT_BACKEND_CFG).build_cli_cmd(config)
+        assert "--no-session-persistence" not in cmd
+        assert "--continue" not in cmd
+
+    def test_build_cli_cmd_resume_adds_continue(self, tmp_path: Path) -> None:
+        """resume_previous_session appends --continue to reattach to the run."""
+        config = SandboxConfig(
+            sandbox_dir=tmp_path, prompt="hi", resume_previous_session=True
+        )
+        cmd = ClaudeBackend(DEFAULT_BACKEND_CFG).build_cli_cmd(config)
+        assert "--continue" in cmd
+        assert "--no-session-persistence" not in cmd
+
     def test_build_cli_cmd_includes_tools(self, tmp_path: Path) -> None:
         """All standard tools are listed in --tools."""
         config = SandboxConfig(sandbox_dir=tmp_path, prompt="hi")

--- a/tests/utils/test_backends.py
+++ b/tests/utils/test_backends.py
@@ -193,6 +193,13 @@ class TestClaudeBackend:
         assert m is not None
         assert m.group(1) == "2pm"
 
+    def test_claude_rate_limit_regex_session_limit_with_minutes(self) -> None:
+        """Matches the current minute-bearing session-limit message."""
+        msg = "You've hit your session limit · resets 1:30pm (UTC)"
+        m = _RATE_LIMIT_RE.search(msg)
+        assert m is not None
+        assert m.group(1) == "1:30pm"
+
 
 # ---------------------------------------------------------------------------
 # OpenCodeBackend
@@ -673,6 +680,19 @@ class TestClaudeParseStreamMetrics:
         assert result.is_error
         assert result.output_token_limit_hit
         assert result.total_cost == 0.5
+
+    def test_parse_detects_prompt_too_long_in_assistant_text(self) -> None:
+        """An oversized prompt is exposed for the compaction recovery path."""
+        event = {
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": "Prompt is too long"}]},
+        }
+        proc = self._make_mock_proc([json.dumps(event) + "\n"])
+
+        result = ClaudeBackend(DEFAULT_BACKEND_CFG).parse_stream(proc)
+
+        assert result.is_error
+        assert result.prompt_too_long_hit
 
 
 # ---------------------------------------------------------------------------

--- a/tests/utils/test_backends.py
+++ b/tests/utils/test_backends.py
@@ -536,13 +536,18 @@ class TestProviderUtils:
 class TestClaudeParseStreamMetrics:
     """ClaudeBackend.parse_stream captures generation metrics from the stream."""
 
-    def _make_mock_proc(self, stdout_lines: list[str]) -> subprocess.Popen:
+    def _make_mock_proc(
+        self,
+        stdout_lines: list[str],
+        stderr_output: str = "",
+        returncode: int = 0,
+    ) -> subprocess.Popen:
         proc = MagicMock(spec=subprocess.Popen)
         proc.stdout = iter(stdout_lines)
         proc.stderr = MagicMock()
-        proc.stderr.read.return_value = ""
-        proc.returncode = 0
-        proc.wait.return_value = 0
+        proc.stderr.read.return_value = stderr_output
+        proc.returncode = returncode
+        proc.wait.return_value = returncode
         return proc
 
     def test_parse_aggregates_across_cli_sessions(self) -> None:
@@ -620,6 +625,54 @@ class TestClaudeParseStreamMetrics:
         assert result.cli_duration_api_ms == 5000  # max (cumulative)
         assert result.stop_reason == "error_max_budget_usd"  # last subtype
         assert result.total_cost == pytest.approx(0.90)  # latest (cumulative)
+
+    def test_parse_detects_output_token_limit_in_assistant_text(self) -> None:
+        """The retry signal is detected from Claude's observed API error text."""
+        events = [
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": (
+                                "API Error: Claude's response exceeded the 32768 "
+                                "output token maximum. To configure this behavior, "
+                                "set CLAUDE_CODE_MAX_OUTPUT_TOKENS."
+                            ),
+                        }
+                    ]
+                },
+            }
+        ]
+        proc = self._make_mock_proc([json.dumps(e) + "\n" for e in events])
+
+        result = ClaudeBackend(DEFAULT_BACKEND_CFG).parse_stream(proc)
+
+        assert result.is_error
+        assert result.output_token_limit_hit
+        assert "output token maximum" in (result.error_text or "")
+
+    def test_parse_detects_output_token_limit_in_stderr(self) -> None:
+        """The retry signal is not lost when a result already marked an error."""
+        event = {
+            "type": "result",
+            "subtype": "error_during_execution",
+            "is_error": True,
+            "result": "API request failed",
+            "total_cost_usd": 0.5,
+        }
+        proc = self._make_mock_proc(
+            [json.dumps(event) + "\n"],
+            stderr_output=("Claude's response exceeded the 32768 output token maximum"),
+            returncode=1,
+        )
+
+        result = ClaudeBackend(DEFAULT_BACKEND_CFG).parse_stream(proc)
+
+        assert result.is_error
+        assert result.output_token_limit_hit
+        assert result.total_cost == 0.5
 
 
 # ---------------------------------------------------------------------------

--- a/tests/utils/test_docker_sandbox.py
+++ b/tests/utils/test_docker_sandbox.py
@@ -266,6 +266,25 @@ def test_docker_run_prefix_adds_bilevel_when_present(tmp_path: Path) -> None:
     assert "ROBOCODE_UV_EXTRA_ARGS=--extra bilevel" in cmd
 
 
+def test_docker_run_prefix_adds_extra_volumes(tmp_path: Path) -> None:
+    """extra_volumes become -v mounts (used to persist the resumable session)."""
+    sessions = tmp_path / ".agent_sessions"
+    volume = f"{sessions.resolve()}:/home/node/.claude/projects"
+    cmd = _docker_run_prefix(
+        "c",
+        "img",
+        tmp_path,
+        tmp_path / "src",
+        tmp_path / "kg",
+        None,
+        [],
+        [],
+        extra_volumes=[volume],
+    )
+    assert volume in cmd
+    assert cmd[cmd.index(volume) - 1] == "-v"
+
+
 def test_is_local_model() -> None:
     """Local model servers (ollama/vllm) are detected; remote API models are not."""
     assert _is_local_model("ollama/qwen3:0.6b")

--- a/tests/utils/test_docker_sandbox.py
+++ b/tests/utils/test_docker_sandbox.py
@@ -33,7 +33,9 @@ from pathlib import Path
 import pytest
 
 from robocode.environments.kinder_geom2d_env import KinderGeom2DEnv
-from robocode.utils.backends import DEFAULT_BACKEND
+from robocode.utils import rate_limit
+from robocode.utils.backends import DEFAULT_BACKEND, DEFAULT_BACKEND_CFG
+from robocode.utils.backends.claude import ClaudeBackend
 from robocode.utils.docker_sandbox import (
     DOCKER_PYTHON,
     DockerSandboxConfig,
@@ -44,6 +46,7 @@ from robocode.utils.docker_sandbox import (
     _is_local_model,
     _setup_sandbox_dir,
 )
+from robocode.utils.rate_limit import run_with_rate_limit_retry
 from robocode.utils.env_server import (
     ENV_CLIENT_SRC,
     env_server_running,
@@ -283,6 +286,61 @@ def test_docker_run_prefix_adds_extra_volumes(tmp_path: Path) -> None:
     )
     assert volume in cmd
     assert cmd[cmd.index(volume) - 1] == "-v"
+
+
+# A fake claude that runs inside the container: the counter lives in /sandbox
+# (bind-mounted, bounds the loop) and the marker in the mounted session store
+# ($HOME/.claude/projects), so the marker being visible on the second container
+# proves the store survived the first container's --rm.
+_FAKE_DOCKER_CLAUDE = r"""#!/bin/bash
+COUNTER=/sandbox/fake_counter.txt
+n=$(cat "$COUNTER" 2>/dev/null || echo 0); n=$((n+1)); echo "$n" > "$COUNTER"
+PROJ="$HOME/.claude/projects"; mkdir -p "$PROJ"; MARKER="$PROJ/resume_marker.txt"
+cont=no; [[ " $* " == *" --continue "* ]] && cont=yes
+if [ "$n" -eq 1 ]; then
+  echo "s1" > "$MARKER"
+  echo '{"type":"result","subtype":"error","is_error":true,"result":"hit your limit resets 3am","total_cost_usd":0.5,"modelUsage":{}}'
+  exit 1
+fi
+if [ "$cont" = yes ] && [ -f "$MARKER" ]; then
+  printf 'class GeneratedApproach:\n    pass\n' > /sandbox/approach.py
+  echo '{"type":"result","subtype":"success","is_error":false,"result":"done","total_cost_usd":1.0,"modelUsage":{}}'
+  exit 0
+fi
+echo '{"type":"result","subtype":"error","is_error":true,"result":"not resumed","total_cost_usd":0.0,"modelUsage":{}}'
+exit 1
+"""
+
+
+@requires_docker
+def test_docker_resume_persists_session_across_containers(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A rate-limited container resumes in a fresh one; the store survives --rm."""
+    fake = tmp_path / "fake_claude.sh"
+    fake.write_text(_FAKE_DOCKER_CLAUDE)
+    fake.chmod(0o755)
+    monkeypatch.setenv("ROBOCODE_CLAUDE_CMD", "/sandbox/fake_claude.sh")
+    monkeypatch.setattr(rate_limit.time, "sleep", lambda _s: None)
+
+    config = DockerSandboxConfig(
+        sandbox_dir=tmp_path / "sandbox",
+        init_files={"fake_claude.sh": fake},
+        output_filename="approach.py",
+        prompt="solve it",
+        mcp_tools=(),
+    )
+    final = run_with_rate_limit_retry(
+        config, None, backend=ClaudeBackend(DEFAULT_BACKEND_CFG)
+    )
+
+    assert final.success
+    assert final.generation_metrics is not None
+    assert final.generation_metrics.rate_limit_retries == 1
+    # The marker the first container wrote into the mounted session store is
+    # present on the host, so it survived the --rm and reached the retry.
+    marker = config.sandbox_dir / ".agent_sessions" / "resume_marker.txt"
+    assert marker.exists()
 
 
 def test_is_local_model() -> None:

--- a/tests/utils/test_docker_sandbox.py
+++ b/tests/utils/test_docker_sandbox.py
@@ -39,6 +39,7 @@ from robocode.utils.backends.claude import ClaudeBackend
 from robocode.utils.docker_sandbox import (
     DOCKER_PYTHON,
     DockerSandboxConfig,
+    _build_docker_auth_args,
     _copy_src,
     _docker_run_prefix,
     _filtered_repo_mounts,
@@ -46,12 +47,12 @@ from robocode.utils.docker_sandbox import (
     _is_local_model,
     _setup_sandbox_dir,
 )
-from robocode.utils.rate_limit import run_with_rate_limit_retry
 from robocode.utils.env_server import (
     ENV_CLIENT_SRC,
     env_server_running,
     serialize_space,
 )
+from robocode.utils.rate_limit import run_with_rate_limit_retry
 
 _DOCKER_IMAGE = "robocode-sandbox"
 
@@ -286,6 +287,32 @@ def test_docker_run_prefix_adds_extra_volumes(tmp_path: Path) -> None:
     )
     assert volume in cmd
     assert cmd[cmd.index(volume) - 1] == "-v"
+
+
+def test_claude_auth_mount_excludes_host_state(tmp_path: Path, monkeypatch) -> None:
+    """Credential fallback cannot expose or modify the live host config."""
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    monkeypatch.setattr(
+        "robocode.utils.docker_sandbox._get_claude_oauth_token", lambda: None
+    )
+    host = tmp_path / ".claude"
+    (host / "projects").mkdir(parents=True)
+    (host / "projects" / "past.jsonl").write_text("past")
+    (host / "CLAUDE.md").write_text("operator memory")
+    (host / ".credentials.json").write_text("credentials")
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(host))
+
+    with _build_docker_auth_args("claude") as (args, env):
+        assert not env
+        mount = next(arg for arg in args if arg.endswith(":/home/node/.claude"))
+        mounted = Path(mount.split(":", 1)[0])
+        assert mounted != host
+        assert [path.name for path in mounted.iterdir()] == [".credentials.json"]
+        (mounted / ".credentials.json").write_text("refreshed")
+        copied = mounted
+
+    assert (host / ".credentials.json").read_text() == "credentials"
+    assert not copied.exists()
 
 
 # A fake claude that runs inside the container: the counter lives in /sandbox

--- a/tests/utils/test_rate_limit.py
+++ b/tests/utils/test_rate_limit.py
@@ -15,7 +15,7 @@ def _metrics(tokens: int, turns: int = 0) -> GenerationMetrics:
     return GenerationMetrics(input_tokens=tokens, num_turns=turns)
 
 
-def _rate_limited(tokens: int, cost: float, turns: int = 0) -> SandboxResult:
+def _rate_limited(tokens: int, cost: float | None, turns: int = 0) -> SandboxResult:
     return SandboxResult(
         success=False,
         output_file=None,
@@ -120,6 +120,61 @@ def test_retry_loop_resumes_with_carried_budget(tmp_path: Path, monkeypatch) -> 
     assert captured[2].resume_previous_session is True
     assert captured[2].max_budget_usd == 3.5  # 5.0 - (0.5 + 1.0)
     assert captured[2].max_turns == 20  # 50 - (20 + 10)
+
+
+def test_retry_does_not_turn_exhausted_limits_into_unlimited(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """An exhausted positive limit stops instead of becoming unlimited zero."""
+    results = iter([_rate_limited(100, 5.0, turns=50)])
+    captured: list[SandboxConfig] = []
+    slept: list[float] = []
+
+    async def fake_run(config: SandboxConfig, _backend) -> SandboxResult:
+        captured.append(config)
+        return next(results)
+
+    monkeypatch.setattr(rate_limit, "run_agent_in_sandbox", fake_run)
+    monkeypatch.setattr(rate_limit.time, "sleep", slept.append)
+    config = SandboxConfig(sandbox_dir=tmp_path, max_budget_usd=5.0, max_turns=50)
+
+    final = run_with_rate_limit_retry(
+        None, config, backend=None  # type: ignore[arg-type]
+    )
+
+    assert not final.success
+    assert len(captured) == 1
+    assert not slept
+    assert final.generation_metrics is not None
+    assert final.generation_metrics.rate_limit_retries == 1
+
+
+def test_retry_stops_when_interrupted_cost_is_unknown(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A finite budget cannot be carried safely without an attempt cost."""
+    results = iter([_rate_limited(100, None)])
+    captured: list[SandboxConfig] = []
+
+    async def fake_run(config: SandboxConfig, _backend) -> SandboxResult:
+        captured.append(config)
+        return next(results)
+
+    monkeypatch.setattr(rate_limit, "run_agent_in_sandbox", fake_run)
+    monkeypatch.setattr(
+        rate_limit.time,
+        "sleep",
+        lambda _seconds: (_ for _ in ()).throw(AssertionError("must not sleep")),
+    )
+
+    final = run_with_rate_limit_retry(
+        None,
+        SandboxConfig(sandbox_dir=tmp_path, max_budget_usd=5.0),
+        backend=None,  # type: ignore[arg-type]
+    )
+
+    assert not final.success
+    assert len(captured) == 1
 
 
 def test_parse_reset_hour_pm_utc() -> None:

--- a/tests/utils/test_rate_limit.py
+++ b/tests/utils/test_rate_limit.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from robocode.utils import rate_limit
 from robocode.utils.rate_limit import (
     _fold_retry_metrics,
@@ -36,6 +38,17 @@ def _succeeded(tokens: int, cost: float, path: Path, turns: int = 0) -> SandboxR
     )
 
 
+def _output_limited(tokens: int, cost: float | None, turns: int = 0) -> SandboxResult:
+    return SandboxResult(
+        success=False,
+        output_file=None,
+        error="Claude response exceeded the output token maximum",
+        total_cost_usd=cost,
+        output_token_limit_hit=True,
+        generation_metrics=_metrics(tokens, turns),
+    )
+
+
 def test_fold_retry_metrics_noop_when_no_retries() -> None:
     """With zero retries the result is returned untouched."""
     result = _succeeded(300, 2.0, Path("approach.py"))
@@ -46,7 +59,7 @@ def test_fold_retry_metrics_records_aborted_spend() -> None:
     """Retry count and aborted spend attach without disturbing final metrics."""
     result = _succeeded(300, 2.0, Path("approach.py"))
     folded = _fold_retry_metrics(
-        result, aborted_tokens=300, aborted_cost=1.5, retries=2
+        result, aborted_tokens=300, aborted_cost=1.5, rate_limit_retries=2
     )
     assert folded.generation_metrics is not None
     assert folded.generation_metrics.rate_limit_retries == 2
@@ -175,6 +188,71 @@ def test_retry_stops_when_interrupted_cost_is_unknown(
 
     assert not final.success
     assert len(captured) == 1
+
+
+def test_output_token_limit_resumes_with_remaining_budget(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """An oversized response resumes immediately with a concise prompt."""
+    approach = tmp_path / "approach.py"
+    approach.write_text("x = 1\n")
+    results = iter(
+        [
+            _output_limited(100, 0.75, turns=4),
+            _succeeded(200, 1.0, approach, turns=2),
+        ]
+    )
+    captured: list[SandboxConfig] = []
+
+    async def fake_run(config: SandboxConfig, _backend) -> SandboxResult:
+        captured.append(config)
+        return next(results)
+
+    monkeypatch.setattr(rate_limit, "run_agent_in_sandbox", fake_run)
+    monkeypatch.setattr(
+        rate_limit.time,
+        "sleep",
+        lambda _seconds: (_ for _ in ()).throw(AssertionError("must not sleep")),
+    )
+    config = SandboxConfig(sandbox_dir=tmp_path, max_budget_usd=5.0, max_turns=20)
+
+    final = run_with_rate_limit_retry(
+        None, config, backend=None  # type: ignore[arg-type]
+    )
+
+    assert final.success
+    assert len(captured) == 2
+    assert captured[1].resume_previous_session
+    assert captured[1].max_budget_usd == 4.25
+    assert captured[1].max_turns == 16
+    assert "Be concise" in captured[1].prompt
+    assert final.generation_metrics is not None
+    assert final.generation_metrics.output_token_retries == 1
+    assert final.generation_metrics.aborted_tokens == 100
+    assert final.generation_metrics.aborted_cost_usd == 0.75
+
+
+def test_output_token_limit_retry_count_is_bounded(tmp_path: Path, monkeypatch) -> None:
+    """Repeated oversized responses cannot loop forever with unlimited budgets."""
+    results = iter([_output_limited(10, 0.1) for _ in range(3)])
+    captured: list[SandboxConfig] = []
+
+    async def fake_run(config: SandboxConfig, _backend) -> SandboxResult:
+        captured.append(config)
+        return next(results)
+
+    monkeypatch.setattr(rate_limit, "run_agent_in_sandbox", fake_run)
+    final = run_with_rate_limit_retry(
+        None,
+        SandboxConfig(sandbox_dir=tmp_path, max_budget_usd=0.0, max_turns=0),
+        backend=None,  # type: ignore[arg-type]
+    )
+
+    assert not final.success
+    assert len(captured) == 3  # initial attempt plus two resumptions
+    assert final.generation_metrics is not None
+    assert final.generation_metrics.output_token_retries == 2
+    assert final.generation_metrics.aborted_cost_usd == pytest.approx(0.3)
 
 
 def test_parse_reset_hour_pm_utc() -> None:

--- a/tests/utils/test_rate_limit.py
+++ b/tests/utils/test_rate_limit.py
@@ -8,7 +8,9 @@ from robocode.utils import rate_limit
 from robocode.utils.rate_limit import (
     _fold_retry_metrics,
     parse_reset_hour,
+    parse_reset_time,
     run_with_rate_limit_retry,
+    seconds_until_reset,
 )
 from robocode.utils.sandbox_types import GenerationMetrics, SandboxConfig, SandboxResult
 
@@ -46,6 +48,29 @@ def _output_limited(tokens: int, cost: float | None, turns: int = 0) -> SandboxR
         total_cost_usd=cost,
         output_token_limit_hit=True,
         generation_metrics=_metrics(tokens, turns),
+    )
+
+
+def _prompt_too_long(tokens: int, cost: float | None, turns: int = 0) -> SandboxResult:
+    return SandboxResult(
+        success=False,
+        output_file=None,
+        error="Prompt is too long",
+        total_cost_usd=cost,
+        prompt_too_long_hit=True,
+        generation_metrics=_metrics(tokens, turns),
+    )
+
+
+def _compacted(tokens: int, cost: float | None, turns: int = 0) -> SandboxResult:
+    return SandboxResult(
+        success=False,
+        output_file=None,
+        error="output file not found",
+        total_cost_usd=cost,
+        generation_metrics=GenerationMetrics(
+            input_tokens=tokens, num_turns=turns, num_autocompactions=1
+        ),
     )
 
 
@@ -255,8 +280,141 @@ def test_output_token_limit_retry_count_is_bounded(tmp_path: Path, monkeypatch) 
     assert final.generation_metrics.aborted_cost_usd == pytest.approx(0.3)
 
 
+def test_prompt_too_long_compacts_then_resumes_with_remaining_budget(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """An oversized context is compacted before work resumes."""
+    approach = tmp_path / "approach.py"
+    approach.write_text("x = 1\n")
+    results = iter(
+        [
+            _prompt_too_long(100, 0.5, turns=4),
+            _compacted(50, 0.25),
+            _succeeded(200, 1.0, approach, turns=2),
+        ]
+    )
+    captured: list[SandboxConfig] = []
+
+    async def fake_run(config: SandboxConfig, _backend) -> SandboxResult:
+        captured.append(config)
+        return next(results)
+
+    monkeypatch.setattr(rate_limit, "run_agent_in_sandbox", fake_run)
+    config = SandboxConfig(sandbox_dir=tmp_path, max_budget_usd=5.0, max_turns=20)
+
+    final = run_with_rate_limit_retry(
+        None, config, backend=None  # type: ignore[arg-type]
+    )
+
+    assert final.success
+    assert len(captured) == 3
+    assert captured[1].resume_previous_session
+    assert captured[1].prompt.startswith("/compact ")
+    assert captured[1].max_budget_usd == 4.5
+    assert captured[1].max_turns == 16
+    assert captured[2].resume_previous_session
+    assert "compacted conversation" in captured[2].prompt
+    assert captured[2].max_budget_usd == 4.25
+    assert captured[2].max_turns == 16
+    assert final.generation_metrics is not None
+    assert final.generation_metrics.prompt_too_long_retries == 1
+    assert final.generation_metrics.aborted_tokens == 150
+    assert final.generation_metrics.aborted_cost_usd == 0.75
+
+
+def test_prompt_too_long_stops_if_compaction_is_not_confirmed(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A failed /compact is not mistaken for a safe continuation."""
+    results = iter(
+        [
+            _prompt_too_long(100, 0.5),
+            SandboxResult(
+                success=False,
+                output_file=None,
+                error="Error during compaction: Conversation too long",
+                total_cost_usd=0.25,
+                generation_metrics=_metrics(50),
+            ),
+        ]
+    )
+    captured: list[SandboxConfig] = []
+
+    async def fake_run(config: SandboxConfig, _backend) -> SandboxResult:
+        captured.append(config)
+        return next(results)
+
+    monkeypatch.setattr(rate_limit, "run_agent_in_sandbox", fake_run)
+    final = run_with_rate_limit_retry(
+        None,
+        SandboxConfig(sandbox_dir=tmp_path, max_budget_usd=5.0),
+        backend=None,  # type: ignore[arg-type]
+    )
+
+    assert not final.success
+    assert final.prompt_too_long_hit
+    assert len(captured) == 2
+    assert final.generation_metrics is not None
+    assert final.generation_metrics.prompt_too_long_hit
+    assert final.generation_metrics.prompt_too_long_retries == 0
+    assert final.generation_metrics.aborted_cost_usd == 0.75
+
+
+def test_prompt_too_long_compaction_retries_are_bounded(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Repeated context exhaustion cannot compact forever without limits."""
+    results = iter(
+        [
+            _prompt_too_long(10, 0.1),
+            _compacted(10, 0.1),
+            _prompt_too_long(10, 0.1),
+            _compacted(10, 0.1),
+            _prompt_too_long(10, 0.1),
+        ]
+    )
+    captured: list[SandboxConfig] = []
+
+    async def fake_run(config: SandboxConfig, _backend) -> SandboxResult:
+        captured.append(config)
+        return next(results)
+
+    monkeypatch.setattr(rate_limit, "run_agent_in_sandbox", fake_run)
+    final = run_with_rate_limit_retry(
+        None,
+        SandboxConfig(sandbox_dir=tmp_path, max_budget_usd=0.0, max_turns=0),
+        backend=None,  # type: ignore[arg-type]
+    )
+
+    assert not final.success
+    assert len(captured) == 5
+    assert final.generation_metrics is not None
+    assert final.generation_metrics.prompt_too_long_retries == 2
+    assert final.generation_metrics.aborted_cost_usd == pytest.approx(0.5)
+
+
 def test_parse_reset_hour_pm_utc() -> None:
     """A full usage message parses the reset hour and UTC flag."""
     hour, is_utc = parse_reset_hour("You've hit your session limit. resets 11pm (UTC)")
     assert hour == 23
     assert is_utc is True
+
+
+def test_parse_reset_time_with_minutes() -> None:
+    """Minute-bearing session resets retain the minute and timezone."""
+    parsed = parse_reset_time("You've hit your session limit · resets 1:30pm (UTC)")
+    assert parsed == (13, 30, True)
+
+
+def test_seconds_until_minute_bearing_reset(monkeypatch) -> None:
+    """The sleep targets five minutes after the parsed reset minute."""
+
+    class FixedDateTime(rate_limit.datetime):
+        """Datetime with a stable current time for reset calculations."""
+
+        @classmethod
+        def now(cls, tz=None):
+            return cls(2026, 7, 22, 12, 0, tzinfo=tz)
+
+    monkeypatch.setattr(rate_limit, "datetime", FixedDateTime)
+    assert seconds_until_reset(13, is_utc=True, reset_minute=30) == 95 * 60

--- a/tests/utils/test_rate_limit.py
+++ b/tests/utils/test_rate_limit.py
@@ -11,28 +11,28 @@ from robocode.utils.rate_limit import (
 from robocode.utils.sandbox_types import GenerationMetrics, SandboxConfig, SandboxResult
 
 
-def _metrics(tokens: int) -> GenerationMetrics:
-    return GenerationMetrics(input_tokens=tokens)
+def _metrics(tokens: int, turns: int = 0) -> GenerationMetrics:
+    return GenerationMetrics(input_tokens=tokens, num_turns=turns)
 
 
-def _rate_limited(tokens: int, cost: float) -> SandboxResult:
+def _rate_limited(tokens: int, cost: float, turns: int = 0) -> SandboxResult:
     return SandboxResult(
         success=False,
         output_file=None,
         error="Rate-limited: resets 3am",
         total_cost_usd=cost,
         rate_limit_reset="3am",
-        generation_metrics=_metrics(tokens),
+        generation_metrics=_metrics(tokens, turns),
     )
 
 
-def _succeeded(tokens: int, cost: float, path: Path) -> SandboxResult:
+def _succeeded(tokens: int, cost: float, path: Path, turns: int = 0) -> SandboxResult:
     return SandboxResult(
         success=True,
         output_file=path,
         error=None,
         total_cost_usd=cost,
-        generation_metrics=_metrics(tokens),
+        generation_metrics=_metrics(tokens, turns),
     )
 
 
@@ -87,6 +87,39 @@ def test_retry_loop_accumulates_aborted_attempts(tmp_path: Path, monkeypatch) ->
     assert final.generation_metrics.aborted_cost_usd == 1.5  # 0.5 + 1.0
     assert final.generation_metrics.input_tokens == 300  # final attempt only
     assert final.total_cost_usd == 2.0
+
+
+def test_retry_loop_resumes_with_carried_budget(tmp_path: Path, monkeypatch) -> None:
+    """Retries resume the session and continue with the budget/turns left over."""
+    approach = tmp_path / "approach.py"
+    approach.write_text("x = 1\n")
+    results = iter(
+        [
+            _rate_limited(100, 0.5, turns=20),
+            _rate_limited(200, 1.0, turns=10),
+            _succeeded(300, 2.0, approach, turns=5),
+        ]
+    )
+    captured: list[SandboxConfig] = []
+
+    async def fake_run(config: SandboxConfig, _backend) -> SandboxResult:
+        captured.append(config)
+        return next(results)
+
+    monkeypatch.setattr(rate_limit, "run_agent_in_sandbox", fake_run)
+    monkeypatch.setattr(rate_limit.time, "sleep", lambda _s: None)
+
+    config = SandboxConfig(sandbox_dir=tmp_path, max_budget_usd=5.0, max_turns=50)
+    run_with_rate_limit_retry(None, config, backend=None)  # type: ignore[arg-type]
+
+    # First attempt runs fresh; each retry resumes with the budget/turns left.
+    assert captured[0].resume_previous_session is False
+    assert captured[1].resume_previous_session is True
+    assert captured[1].max_budget_usd == 4.5  # 5.0 - 0.5
+    assert captured[1].max_turns == 30  # 50 - 20
+    assert captured[2].resume_previous_session is True
+    assert captured[2].max_budget_usd == 3.5  # 5.0 - (0.5 + 1.0)
+    assert captured[2].max_turns == 20  # 50 - (20 + 10)
 
 
 def test_parse_reset_hour_pm_utc() -> None:

--- a/tests/utils/test_resume_integration.py
+++ b/tests/utils/test_resume_integration.py
@@ -152,6 +152,49 @@ print(json.dumps({"type": "result", "subtype": "success", "is_error": False,
 """
 
 
+_PROMPT_TOO_LONG_FAKE_CLAUDE = """\
+#!/usr/bin/env python3
+import json, os, pathlib, sys
+
+counter = pathlib.Path.cwd() / "fake_counter.txt"
+n = (int(counter.read_text()) if counter.exists() else 0) + 1
+counter.write_text(str(n))
+marker = pathlib.Path(os.environ["CLAUDE_CONFIG_DIR"]) / "context_marker.txt"
+prompt = sys.argv[sys.argv.index("-p") + 1]
+
+if n == 1:
+    marker.write_text("oversized")
+    print(json.dumps({"type": "assistant", "message": {"content": [{
+        "type": "text", "text": "Prompt is too long"
+    }]}}))
+    print(json.dumps({"type": "result", "subtype": "error_during_execution",
+                      "is_error": True, "result": "Prompt is too long",
+                      "total_cost_usd": 0.5, "modelUsage": {}}))
+    sys.exit(1)
+
+resumed = "--continue" in sys.argv and marker.exists()
+if n == 2 and resumed and prompt.startswith("/compact "):
+    print(json.dumps({"type": "system", "subtype": "compact_boundary",
+                      "compact_metadata": {"trigger": "manual",
+                                           "pre_tokens": 1000}}))
+    print(json.dumps({"type": "result", "subtype": "success", "is_error": False,
+                      "result": "Conversation compacted", "total_cost_usd": 0.25,
+                      "modelUsage": {}}))
+    sys.exit(0)
+
+if n != 3 or not resumed or "compacted conversation" not in prompt:
+    print(json.dumps({"type": "result", "subtype": "error", "is_error": True,
+                      "result": "invalid compaction recovery", "total_cost_usd": 0.0,
+                      "modelUsage": {}}))
+    sys.exit(1)
+
+pathlib.Path("approach.py").write_text("class GeneratedApproach:\\n    pass\\n")
+print(json.dumps({"type": "result", "subtype": "success", "is_error": False,
+                  "result": "done", "total_cost_usd": 0.25,
+                  "modelUsage": {}}))
+"""
+
+
 def test_end_to_end_resume_with_fake_cli(tmp_path: Path, monkeypatch) -> None:
     """A rate-limited first attempt is resumed and completes on retry."""
     fake = tmp_path / "fake_claude.py"
@@ -250,3 +293,31 @@ def test_end_to_end_resume_after_output_token_limit(
     assert final.generation_metrics is not None
     assert final.generation_metrics.output_token_retries == 1
     assert final.generation_metrics.aborted_cost_usd == 0.5
+
+
+def test_end_to_end_compact_then_resume_after_prompt_too_long(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The exact context error triggers /compact before continuing work."""
+    fake = tmp_path / "prompt_too_long_fake_claude.py"
+    fake.write_text(_PROMPT_TOO_LONG_FAKE_CLAUDE)
+    fake.chmod(0o755)
+    monkeypatch.setenv("ROBOCODE_CLAUDE_CMD", str(fake))
+    config = SandboxConfig(
+        sandbox_dir=tmp_path / "sandbox-prompt-too-long",
+        prompt="solve it",
+        output_filename="approach.py",
+        max_budget_usd=2.0,
+        max_turns=10,
+        mcp_tools=(),
+    )
+
+    final = run_with_rate_limit_retry(
+        None, config, backend=ClaudeBackend(DEFAULT_BACKEND_CFG)
+    )
+
+    assert final.success
+    assert (config.sandbox_dir / "fake_counter.txt").read_text() == "3"
+    assert final.generation_metrics is not None
+    assert final.generation_metrics.prompt_too_long_retries == 1
+    assert final.generation_metrics.aborted_cost_usd == 0.75

--- a/tests/utils/test_resume_integration.py
+++ b/tests/utils/test_resume_integration.py
@@ -1,0 +1,92 @@
+"""End-to-end test of the rate-limit resume flow with a fake Claude CLI.
+
+A real usage-cap interruption cannot be triggered on demand, so this swaps the
+``claude`` binary (via ``ROBOCODE_CLAUDE_CMD``) for a stand-in that reports a
+rate limit on its first invocation and completes on the second. The whole real
+path runs unchanged: ``run_with_rate_limit_retry`` -> ``run_agent_in_sandbox``
+(subprocess launch, ``CLAUDE_CONFIG_DIR`` redirect, session dir) ->
+``parse_stream`` -> rate-limit detection -> resume with ``--continue``.
+
+The stand-in only completes when it is both resumed (``--continue`` is present)
+and can see the session state it persisted on the first attempt, so a passing
+run proves the flag reaches the CLI and the session store survives the retry.
+"""
+
+from pathlib import Path
+
+from robocode.utils import rate_limit
+from robocode.utils.backends import DEFAULT_BACKEND_CFG
+from robocode.utils.backends.claude import ClaudeBackend
+from robocode.utils.rate_limit import run_with_rate_limit_retry
+from robocode.utils.sandbox import SandboxConfig
+
+# A fake ``claude``: first call persists a session marker under CLAUDE_CONFIG_DIR
+# and reports a usage-cap error; the retry succeeds only when resumed and able to
+# read that marker back. A counter outside the sandbox bounds it to two calls.
+_FAKE_CLAUDE = """\
+#!/usr/bin/env python3
+import json, os, pathlib, sys
+
+counter = pathlib.Path(os.environ["FAKE_CLAUDE_COUNTER"])
+n = (int(counter.read_text()) if counter.exists() else 0) + 1
+counter.write_text(str(n))
+
+marker = pathlib.Path(os.environ["CLAUDE_CONFIG_DIR"]) / "resume_marker.txt"
+
+
+def emit(obj):
+    print(json.dumps(obj))
+
+
+if n == 1:
+    marker.write_text("session-1")
+    emit({"type": "result", "subtype": "error", "is_error": True,
+          "result": "You've hit your limit resets 3am", "total_cost_usd": 0.5,
+          "modelUsage": {"claude": {"inputTokens": 100, "outputTokens": 50,
+                                    "cacheReadInputTokens": 0,
+                                    "cacheCreationInputTokens": 0}}})
+    sys.exit(1)
+
+resumed = "--continue" in sys.argv and marker.exists()
+if not resumed:
+    emit({"type": "result", "subtype": "error", "is_error": True,
+          "result": "not resumed", "total_cost_usd": 0.0, "modelUsage": {}})
+    sys.exit(1)
+
+pathlib.Path("approach.py").write_text("class GeneratedApproach:\\n    pass\\n")
+emit({"type": "result", "subtype": "success", "is_error": False,
+      "result": "done", "total_cost_usd": 1.0,
+      "modelUsage": {"claude": {"inputTokens": 300, "outputTokens": 100,
+                                "cacheReadInputTokens": 0,
+                                "cacheCreationInputTokens": 0}}})
+"""
+
+
+def test_end_to_end_resume_with_fake_cli(tmp_path: Path, monkeypatch) -> None:
+    """A rate-limited first attempt is resumed and completes on retry."""
+    fake = tmp_path / "fake_claude.py"
+    fake.write_text(_FAKE_CLAUDE)
+    fake.chmod(0o755)
+    counter = tmp_path / "counter.txt"
+    monkeypatch.setenv("ROBOCODE_CLAUDE_CMD", str(fake))
+    monkeypatch.setenv("FAKE_CLAUDE_COUNTER", str(counter))
+    monkeypatch.setattr(rate_limit.time, "sleep", lambda _s: None)
+
+    config = SandboxConfig(
+        sandbox_dir=tmp_path / "sandbox",
+        prompt="solve it",
+        output_filename="approach.py",
+        model="sonnet",
+        max_budget_usd=5.0,
+        mcp_tools=(),
+    )
+    final = run_with_rate_limit_retry(
+        None, config, backend=ClaudeBackend(DEFAULT_BACKEND_CFG)
+    )
+
+    assert final.success
+    assert final.output_file == config.sandbox_dir / "approach.py"
+    assert final.generation_metrics is not None
+    assert final.generation_metrics.rate_limit_retries == 1
+    assert final.generation_metrics.aborted_cost_usd == 0.5
+    assert counter.read_text() == "2"  # exactly one rate-limit, then one resume

--- a/tests/utils/test_resume_integration.py
+++ b/tests/utils/test_resume_integration.py
@@ -113,6 +113,45 @@ emit({"type": "result", "subtype": "success", "is_error": False,
 """
 
 
+_OUTPUT_LIMIT_FAKE_CLAUDE = """\
+#!/usr/bin/env python3
+import json, os, pathlib, sys
+
+counter = pathlib.Path.cwd() / "fake_counter.txt"
+n = (int(counter.read_text()) if counter.exists() else 0) + 1
+counter.write_text(str(n))
+marker = pathlib.Path(os.environ["CLAUDE_CONFIG_DIR"]) / "output_limit_marker.txt"
+prompt = sys.argv[sys.argv.index("-p") + 1]
+
+if n == 1:
+    marker.write_text("interrupted")
+    print(json.dumps({"type": "assistant", "message": {"content": [{
+        "type": "text", "text": "API Error: Claude's response exceeded the 32768 "
+        "output token maximum. To configure this behavior, set the "
+        "CLAUDE_CODE_MAX_OUTPUT_TOKENS environment variable."
+    }]}}))
+    print(json.dumps({"type": "result", "subtype": "error_during_execution",
+                      "is_error": True, "result": "response exceeded the 32768 "
+                      "output token maximum", "total_cost_usd": 0.5,
+                      "modelUsage": {}}))
+    sys.exit(1)
+
+resumed = (
+    "--continue" in sys.argv and marker.exists() and "Be concise" in prompt
+)
+if not resumed:
+    print(json.dumps({"type": "result", "subtype": "error", "is_error": True,
+                      "result": "not resumed concisely", "total_cost_usd": 0.0,
+                      "modelUsage": {}}))
+    sys.exit(1)
+
+pathlib.Path("approach.py").write_text("class GeneratedApproach:\\n    pass\\n")
+print(json.dumps({"type": "result", "subtype": "success", "is_error": False,
+                  "result": "done", "total_cost_usd": 0.25,
+                  "modelUsage": {}}))
+"""
+
+
 def test_end_to_end_resume_with_fake_cli(tmp_path: Path, monkeypatch) -> None:
     """A rate-limited first attempt is resumed and completes on retry."""
     fake = tmp_path / "fake_claude.py"
@@ -183,3 +222,31 @@ def test_parallel_runs_resume_only_their_own_session(
         assert (config.sandbox_dir / "fake_counter.txt").read_text() == "2"
         assert result.generation_metrics is not None
         assert result.generation_metrics.rate_limit_retries == 1
+
+
+def test_end_to_end_resume_after_output_token_limit(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The observed Claude output-limit error resumes with remaining budget."""
+    fake = tmp_path / "output_limit_fake_claude.py"
+    fake.write_text(_OUTPUT_LIMIT_FAKE_CLAUDE)
+    fake.chmod(0o755)
+    monkeypatch.setenv("ROBOCODE_CLAUDE_CMD", str(fake))
+    config = SandboxConfig(
+        sandbox_dir=tmp_path / "sandbox-output-limit",
+        prompt="solve it",
+        output_filename="approach.py",
+        max_budget_usd=2.0,
+        max_turns=10,
+        mcp_tools=(),
+    )
+
+    final = run_with_rate_limit_retry(
+        None, config, backend=ClaudeBackend(DEFAULT_BACKEND_CFG)
+    )
+
+    assert final.success
+    assert (config.sandbox_dir / "fake_counter.txt").read_text() == "2"
+    assert final.generation_metrics is not None
+    assert final.generation_metrics.output_token_retries == 1
+    assert final.generation_metrics.aborted_cost_usd == 0.5

--- a/tests/utils/test_resume_integration.py
+++ b/tests/utils/test_resume_integration.py
@@ -12,13 +12,14 @@ and can see the session state it persisted on the first attempt, so a passing
 run proves the flag reaches the CLI and the session store survives the retry.
 """
 
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 from robocode.utils import rate_limit
 from robocode.utils.backends import DEFAULT_BACKEND_CFG
 from robocode.utils.backends.claude import ClaudeBackend
 from robocode.utils.rate_limit import run_with_rate_limit_retry
-from robocode.utils.sandbox import SandboxConfig
+from robocode.utils.sandbox import SandboxConfig, SandboxResult
 
 # A fake ``claude``: first call persists a session marker under CLAUDE_CONFIG_DIR
 # and reports a usage-cap error; the retry succeeds only when resumed and able to
@@ -62,6 +63,56 @@ emit({"type": "result", "subtype": "success", "is_error": False,
 """
 
 
+_PARALLEL_FAKE_CLAUDE = """\
+#!/usr/bin/env python3
+import json, os, pathlib, sys, time
+
+cwd = pathlib.Path.cwd()
+counter = cwd / "fake_counter.txt"
+n = (int(counter.read_text()) if counter.exists() else 0) + 1
+counter.write_text(str(n))
+prompt = sys.argv[sys.argv.index("-p") + 1]
+marker = pathlib.Path(os.environ["CLAUDE_CONFIG_DIR"]) / "resume_marker.txt"
+
+
+def emit(obj):
+    print(json.dumps(obj))
+
+
+if n == 1:
+    marker.write_text(prompt)
+    gate = pathlib.Path(os.environ["FAKE_CLAUDE_PARALLEL_GATE"])
+    (gate / f"ready-{prompt}").write_text("ready")
+    deadline = time.monotonic() + 10
+    while len(list(gate.glob("ready-*"))) < 2 and time.monotonic() < deadline:
+        time.sleep(0.01)
+    if len(list(gate.glob("ready-*"))) < 2:
+        emit({"type": "result", "subtype": "error", "is_error": True,
+              "result": "parallel test timed out", "total_cost_usd": 0.0,
+              "modelUsage": {}})
+        sys.exit(1)
+    emit({"type": "result", "subtype": "error", "is_error": True,
+          "result": "You've hit your limit resets 3am", "total_cost_usd": 0.5,
+          "modelUsage": {}})
+    sys.exit(1)
+
+resumed_own_session = (
+    "--continue" in sys.argv and marker.exists() and marker.read_text() == prompt
+)
+if not resumed_own_session:
+    emit({"type": "result", "subtype": "error", "is_error": True,
+          "result": "resumed another run", "total_cost_usd": 0.0,
+          "modelUsage": {}})
+    sys.exit(1)
+
+pathlib.Path("approach.py").write_text(
+    f"# {prompt}\\nclass GeneratedApproach:\\n    pass\\n"
+)
+emit({"type": "result", "subtype": "success", "is_error": False,
+      "result": "done", "total_cost_usd": 1.0, "modelUsage": {}})
+"""
+
+
 def test_end_to_end_resume_with_fake_cli(tmp_path: Path, monkeypatch) -> None:
     """A rate-limited first attempt is resumed and completes on retry."""
     fake = tmp_path / "fake_claude.py"
@@ -90,3 +141,45 @@ def test_end_to_end_resume_with_fake_cli(tmp_path: Path, monkeypatch) -> None:
     assert final.generation_metrics.rate_limit_retries == 1
     assert final.generation_metrics.aborted_cost_usd == 0.5
     assert counter.read_text() == "2"  # exactly one rate-limit, then one resume
+
+
+def test_parallel_runs_resume_only_their_own_session(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Concurrent rate-limited runs have disjoint --continue lookup stores."""
+    fake = tmp_path / "parallel_fake_claude.py"
+    fake.write_text(_PARALLEL_FAKE_CLAUDE)
+    fake.chmod(0o755)
+    gate = tmp_path / "gate"
+    gate.mkdir()
+    monkeypatch.setenv("ROBOCODE_CLAUDE_CMD", str(fake))
+    monkeypatch.setenv("FAKE_CLAUDE_PARALLEL_GATE", str(gate))
+    monkeypatch.setattr(rate_limit.time, "sleep", lambda _s: None)
+
+    configs = [
+        SandboxConfig(
+            sandbox_dir=tmp_path / f"sandbox-{name}",
+            prompt=name,
+            output_filename="approach.py",
+            max_budget_usd=5.0,
+            mcp_tools=(),
+        )
+        for name in ("alpha", "beta")
+    ]
+
+    def run(config: SandboxConfig) -> SandboxResult:
+        """Run one independently configured generation."""
+        return run_with_rate_limit_retry(
+            None, config, backend=ClaudeBackend(DEFAULT_BACKEND_CFG)
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(run, configs))
+
+    assert all(result.success for result in results)
+    for config, result in zip(configs, results, strict=True):
+        assert result.output_file is not None
+        assert result.output_file.read_text().startswith(f"# {config.prompt}\n")
+        assert (config.sandbox_dir / "fake_counter.txt").read_text() == "2"
+        assert result.generation_metrics is not None
+        assert result.generation_metrics.rate_limit_retries == 1

--- a/tests/utils/test_sandbox.py
+++ b/tests/utils/test_sandbox.py
@@ -29,7 +29,9 @@ def test_generation_metrics_to_dict_flat_keys() -> None:
         cache_read_tokens=2000,
         cache_creation_tokens=10,
         num_tool_calls=9,
+        output_token_limit_hit=True,
         rate_limit_retries=2,
+        output_token_retries=1,
         aborted_tokens=300,
         aborted_cost_usd=1.5,
     )
@@ -39,6 +41,8 @@ def test_generation_metrics_to_dict_flat_keys() -> None:
     assert d["gen_num_tool_calls"] == 9
     assert d["gen_total_tokens"] == 2160
     assert d["gen_rate_limit_retries"] == 2
+    assert d["gen_output_token_limit_hit"] is True
+    assert d["gen_output_token_retries"] == 1
     assert d["gen_aborted_tokens"] == 300
     assert d["gen_aborted_cost_usd"] == 1.5
     assert all(k.startswith("gen_") for k in d)
@@ -68,6 +72,26 @@ def test_stream_result_carries_generation_metrics(tmp_path: Path) -> None:
     assert result.generation_metrics.num_turns == 4
     assert result.generation_metrics.num_autocompactions == 2
     assert result.generation_metrics.stop_reason == "end_turn"
+
+
+def test_output_token_limit_ignores_partial_output_for_retry(tmp_path: Path) -> None:
+    """An oversized response is resumed rather than evaluating partial code."""
+    (tmp_path / "approach.py").write_text("partial = True\n")
+    stream = _StreamParseResult(
+        is_error=True,
+        error_text="Claude response exceeded the output token maximum",
+        num_turns=1,
+        total_cost=0.5,
+        output_token_limit_hit=True,
+    )
+
+    result = _stream_result_to_sandbox_result(stream, tmp_path, "approach.py")
+
+    assert not result.success
+    assert result.output_file is None
+    assert result.output_token_limit_hit
+    assert result.generation_metrics is not None
+    assert result.generation_metrics.output_token_limit_hit
 
 
 def test_sandbox_claude_config_copies_then_removes_creds(

--- a/tests/utils/test_sandbox.py
+++ b/tests/utils/test_sandbox.py
@@ -30,8 +30,10 @@ def test_generation_metrics_to_dict_flat_keys() -> None:
         cache_creation_tokens=10,
         num_tool_calls=9,
         output_token_limit_hit=True,
+        prompt_too_long_hit=True,
         rate_limit_retries=2,
         output_token_retries=1,
+        prompt_too_long_retries=1,
         aborted_tokens=300,
         aborted_cost_usd=1.5,
     )
@@ -43,6 +45,8 @@ def test_generation_metrics_to_dict_flat_keys() -> None:
     assert d["gen_rate_limit_retries"] == 2
     assert d["gen_output_token_limit_hit"] is True
     assert d["gen_output_token_retries"] == 1
+    assert d["gen_prompt_too_long_hit"] is True
+    assert d["gen_prompt_too_long_retries"] == 1
     assert d["gen_aborted_tokens"] == 300
     assert d["gen_aborted_cost_usd"] == 1.5
     assert all(k.startswith("gen_") for k in d)
@@ -92,6 +96,26 @@ def test_output_token_limit_ignores_partial_output_for_retry(tmp_path: Path) -> 
     assert result.output_token_limit_hit
     assert result.generation_metrics is not None
     assert result.generation_metrics.output_token_limit_hit
+
+
+def test_prompt_too_long_ignores_partial_output_for_compaction(tmp_path: Path) -> None:
+    """An oversized context is compacted rather than evaluating partial code."""
+    (tmp_path / "approach.py").write_text("partial = True\n")
+    stream = _StreamParseResult(
+        is_error=True,
+        error_text="Prompt is too long",
+        num_turns=1,
+        total_cost=0.5,
+        prompt_too_long_hit=True,
+    )
+
+    result = _stream_result_to_sandbox_result(stream, tmp_path, "approach.py")
+
+    assert not result.success
+    assert result.output_file is None
+    assert result.prompt_too_long_hit
+    assert result.generation_metrics is not None
+    assert result.generation_metrics.prompt_too_long_hit
 
 
 def test_sandbox_claude_config_copies_then_removes_creds(

--- a/tests/utils/test_sandbox.py
+++ b/tests/utils/test_sandbox.py
@@ -7,6 +7,7 @@ from robocode.utils.sandbox import (
     SandboxConfig,
     SandboxResult,
     _is_path_within_sandbox,
+    _redirect_claude_config_to_sandbox,
     _stream_result_to_sandbox_result,
 )
 from robocode.utils.sandbox_types import GenerationMetrics, _StreamParseResult
@@ -61,6 +62,40 @@ def test_stream_result_carries_generation_metrics(tmp_path: Path) -> None:
     assert result.generation_metrics.num_turns == 4
     assert result.generation_metrics.num_autocompactions == 2
     assert result.generation_metrics.stop_reason == "end_turn"
+
+
+def test_redirect_claude_config_symlinks_creds(tmp_path: Path, monkeypatch) -> None:
+    """The sandbox-local config dir is created with host creds symlinked in."""
+    host = tmp_path / "host_claude"
+    host.mkdir()
+    (host / ".credentials.json").write_text("{}")
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(host))
+    sandbox = tmp_path / "sandbox"
+    sandbox.mkdir()
+
+    result = _redirect_claude_config_to_sandbox(sandbox)
+
+    agent_home = sandbox / ".agent_home"
+    assert result == str(agent_home)
+    assert agent_home.is_dir()
+    link = agent_home / ".credentials.json"
+    assert link.is_symlink()
+    assert link.resolve() == (host / ".credentials.json").resolve()
+
+
+def test_redirect_claude_config_without_creds_file(tmp_path: Path, monkeypatch) -> None:
+    """No symlink when the host has no credentials file (token-env auth)."""
+    host = tmp_path / "host_claude"
+    host.mkdir()
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(host))
+    sandbox = tmp_path / "sandbox"
+    sandbox.mkdir()
+
+    _redirect_claude_config_to_sandbox(sandbox)
+
+    agent_home = sandbox / ".agent_home"
+    assert agent_home.is_dir()
+    assert not (agent_home / ".credentials.json").exists()
 
 
 def test_path_within_sandbox(tmp_path: Path) -> None:

--- a/tests/utils/test_sandbox.py
+++ b/tests/utils/test_sandbox.py
@@ -3,11 +3,11 @@
 from pathlib import Path
 
 from robocode.utils.backends.claude import _RATE_LIMIT_RE
+from robocode.utils.claude_auth import sandbox_claude_config
 from robocode.utils.sandbox import (
     SandboxConfig,
     SandboxResult,
     _is_path_within_sandbox,
-    _redirect_claude_config_to_sandbox,
     _stream_result_to_sandbox_result,
 )
 from robocode.utils.sandbox_types import GenerationMetrics, _StreamParseResult
@@ -64,8 +64,10 @@ def test_stream_result_carries_generation_metrics(tmp_path: Path) -> None:
     assert result.generation_metrics.stop_reason == "end_turn"
 
 
-def test_redirect_claude_config_symlinks_creds(tmp_path: Path, monkeypatch) -> None:
-    """The sandbox-local config dir is created with host creds symlinked in."""
+def test_sandbox_claude_config_copies_then_removes_creds(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Host credentials cannot be modified and do not remain in run output."""
     host = tmp_path / "host_claude"
     host.mkdir()
     (host / ".credentials.json").write_text("{}")
@@ -73,14 +75,16 @@ def test_redirect_claude_config_symlinks_creds(tmp_path: Path, monkeypatch) -> N
     sandbox = tmp_path / "sandbox"
     sandbox.mkdir()
 
-    result = _redirect_claude_config_to_sandbox(sandbox)
+    with sandbox_claude_config(sandbox) as agent_home:
+        copied = agent_home / ".credentials.json"
+        assert copied.read_text() == "{}"
+        assert not copied.is_symlink()
+        copied.write_text('{"refreshed": true}')
+        (agent_home / "projects").mkdir()
 
-    agent_home = sandbox / ".agent_home"
-    assert result == str(agent_home)
-    assert agent_home.is_dir()
-    link = agent_home / ".credentials.json"
-    assert link.is_symlink()
-    assert link.resolve() == (host / ".credentials.json").resolve()
+    assert (host / ".credentials.json").read_text() == "{}"
+    assert not copied.exists()
+    assert (agent_home / "projects").is_dir()
 
 
 def test_redirect_claude_config_without_creds_file(tmp_path: Path, monkeypatch) -> None:
@@ -91,11 +95,9 @@ def test_redirect_claude_config_without_creds_file(tmp_path: Path, monkeypatch) 
     sandbox = tmp_path / "sandbox"
     sandbox.mkdir()
 
-    _redirect_claude_config_to_sandbox(sandbox)
-
-    agent_home = sandbox / ".agent_home"
-    assert agent_home.is_dir()
-    assert not (agent_home / ".credentials.json").exists()
+    with sandbox_claude_config(sandbox) as agent_home:
+        assert agent_home.is_dir()
+        assert not (agent_home / ".credentials.json").exists()
 
 
 def test_path_within_sandbox(tmp_path: Path) -> None:

--- a/tests/utils/test_sandbox.py
+++ b/tests/utils/test_sandbox.py
@@ -2,8 +2,14 @@
 
 from pathlib import Path
 
+import pytest
+
 from robocode.utils.backends.claude import _RATE_LIMIT_RE
-from robocode.utils.claude_auth import sandbox_claude_config
+from robocode.utils.claude_auth import (
+    host_claude_config_dir,
+    sandbox_claude_config,
+    sandbox_claude_session_store,
+)
 from robocode.utils.sandbox import (
     SandboxConfig,
     SandboxResult,
@@ -85,6 +91,37 @@ def test_sandbox_claude_config_copies_then_removes_creds(
     assert (host / ".credentials.json").read_text() == "{}"
     assert not copied.exists()
     assert (agent_home / "projects").is_dir()
+
+
+def test_host_claude_config_dir_expands_user(monkeypatch) -> None:
+    """A literal tilde in CLAUDE_CONFIG_DIR resolves like a normal user path."""
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", "~/custom-claude")
+    assert host_claude_config_dir() == Path.home() / "custom-claude"
+
+
+def test_sandbox_claude_config_rejects_symlink(tmp_path: Path) -> None:
+    """A prior agent cannot redirect credential operations outside its sandbox."""
+    sandbox = tmp_path / "sandbox"
+    sandbox.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (sandbox / ".agent_home").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(RuntimeError, match="symlinked Claude state"):
+        with sandbox_claude_config(sandbox):
+            pass
+
+
+def test_sandbox_claude_session_store_rejects_symlink(tmp_path: Path) -> None:
+    """Container session mounts cannot be redirected to an arbitrary host path."""
+    sandbox = tmp_path / "sandbox"
+    sandbox.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (sandbox / ".agent_sessions").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(RuntimeError, match="symlinked Claude state"):
+        sandbox_claude_session_store(sandbox)
 
 
 def test_redirect_claude_config_without_creds_file(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Base status

#121 (`runtime-metrics`) was squash-merged into `main` as `48aa4ed`. This branch has been rebased onto that updated `main`, and the PR targets `main`. The former stacked-PR dependency is satisfied.

## Problems

### Subscription usage caps

When Claude Code hits the subscription usage cap, the experiment runner sleeps until the reset and launches a new CLI/container process. Previously that process:

- started without the interrupted conversation context;
- received a fresh `--max-budget-usd` and `--max-turns`, making a timing-dependent retry a different experimental condition; and
- discarded the interrupted attempt's spend and retry signal (the underlying runtime metrics landed in #121).

The sandbox files survived, but the agent had to reconstruct its reasoning from disk.

### Output-token overflows

Claude can also abort a run with `Claude's response exceeded the 32768 output token maximum`. Raising `CLAUDE_CODE_MAX_OUTPUT_TOKENS` is not a reliable fix: the model can consume the larger allowance and still exceed it. Previously this error could leave a partial `approach.py` and fail the entire experiment.

### Context exhaustion and current reset messages

Auto-compaction normally protects Claude's context window, but runs have also stopped with `Prompt is too long`. Separately, the current subscription message includes minutes (`You've hit your session limit · resets 1:30pm (UTC)`), which the old hour-only regex did not match or schedule correctly.

## What this PR changes

### Resume Claude Code context

- Claude sessions are persisted from the first attempt so they are available if a retry becomes necessary.
- A retry uses `--continue`. Every generation has its own sandbox working directory and isolated session store, so “most recent session in this directory” identifies that generation.
- Docker and Apptainer persist `/home/node/.claude/projects` under the generation's sandbox directory, across ephemeral container recreation.
- The local backend places Claude state under sandbox-local `.agent_home`.

### Preserve the experimental budget

- Interrupted attempts' reported cost and turns are subtracted from the original limits before resuming.
- A finite exhausted budget is never converted to `0`, because both CLI limits interpret zero as unlimited.
- If a finite-budget interrupted attempt does not report its cost, the runner stops rather than silently granting an unknowable remaining budget.
- Retry counts and aborted spend remain visible through generation metrics.

Resuming is intentionally not claimed to be identical to an uninterrupted run: rebuilding context can consume uncached transcript input tokens. The retry metrics let analyses identify or exclude these runs.

### Recover output-token overflows

- The exact observed overflow is detected in assistant text, result errors, or stderr.
- A partial output file is not evaluated after this interruption.
- The same isolated conversation resumes immediately, without the rate-limit sleep, using only the remaining dollar and turn budget.
- The continuation prompt asks Claude to avoid repeating reasoning, use tools directly, and finish concisely.
- At most two output-overflow resumptions are allowed, preventing an infinite loop for unlimited-budget configurations.
- `gen_output_token_limit_hit` and `gen_output_token_retries` make the condition visible in `results.json`; aborted tokens and cost use the existing interruption metrics.

### Compact an oversized prompt before resuming

- `Prompt is too long` is detected in assistant text, result errors, or stderr, and partial output is not evaluated.
- The runner resumes the same isolated session with `/compact` and focused instructions to retain requirements, decisions, failed approaches, and current implementation state while dropping verbose tool output.
- Work resumes only after Claude emits a real `compact_boundary` event. A normal sandbox “output file not found” result from the local slash command is not treated as failure when that confirmation exists; conversely, an unconfirmed/failed compaction is never assumed to have worked.
- Compaction tokens, turns, and cost count against the original budget. The subsequent work process receives only what remains.
- At most two successful compact-and-resume cycles are allowed. `gen_prompt_too_long_hit` and `gen_prompt_too_long_retries` expose the condition in results.

### Parse minute-bearing usage resets

- The current `resets 1:30pm (UTC)` format is recognized.
- Both hour and minute are retained, timezone interpretation is preserved, and the sleep targets five minutes after the stated reset (13:35 UTC in this example).
- Existing hour-only messages such as `resets 3am` retain their prior behavior.

### Keep experiments out of the operator's Claude state

Session persistence must not add experiment conversations to the operator's normal `~/.claude` history or session picker.

- Local runs set `CLAUDE_CONFIG_DIR` to the sandbox-local state directory.
- Host credentials are copied for the lifetime of one local CLI process, never symlinked, and removed immediately afterward.
- Docker and Apptainer receive a writable throwaway config containing only copied credentials when an OAuth environment token is unavailable.
- Host transcripts, history, memory, settings, file history, and job artifacts are neither copied nor live-mounted.
- Token refreshes and other CLI writes cannot modify the live host Claude directory.

Only the experiment's isolated transcript state survives between retry attempts.

## Scope: OpenCode

Conversation resume is implemented only for Claude Code. OpenCode is currently used with local/open-source models in this project, where Claude subscription caps and these Claude-specific errors do not apply. OpenCode session persistence/resume semantics are deliberately out of scope rather than being guessed at in this PR.

## Validation

- Full repository suite: **544 passed**
- Focused sandbox/backend suite: **144 passed**
- A local end-to-end fake-CLI test reproduces the exact output-overflow message and exercises subprocess launch, isolated state, stream parsing, budget carry, the concise continuation prompt, `--continue`, and completion.
- A second end-to-end fake-CLI test reproduces `Prompt is too long`, requires the isolated `/compact` continuation and `compact_boundary`, then requires a separate resumed work process before it completes.
- The existing local rate-limit end-to-end test exercises detection, budget carry, `--continue`, and completion.
- A parallel end-to-end test forces two independent generations to hit a synthetic cap together and proves each `--continue` retry recovers only its own prompt-specific session marker.
- The Docker integration test recreates the container with `--rm` and proves the first container's session marker reaches the resumed container.
- Unit coverage includes assistant/result/stderr detection, partial-output rejection, successful and failed compaction, bounded overflow/compaction retries, exact minute-bearing reset parsing and sleep calculation, host-state exclusion, credentials-only mounts, credential cleanup, retry metrics, budget/turn carry, exhausted limits, and missing interrupted cost.
- Black, isort, mypy, pylint on touched files, and `git diff --check` pass.

## Limitations / not tested

- Real Claude subscription caps, real 32k output overflows, and real context exhaustion cannot be triggered deterministically. Automated end-to-end tests inject a fake Claude CLI while exercising the real runner, parser, retry, compaction orchestration, and local session-persistence paths. We did not spend subscription quota trying to force these failures.
- The overflow recovery depends on Claude Code persisting enough conversation state to make `--continue` useful after the API abort. The automated test proves our state and invocation plumbing, not the proprietary CLI/API's handling of every real mid-response failure.
- [Anthropic documents](https://code.claude.com/docs/en/errors#prompt-is-too-long) that `/compact` can itself fail if the context is already too full to generate its summary. In that case this PR records the failure and stops safely; it does not silently clear the session or restart without context. The automated test covers both confirmed and failed compaction, but not a real Claude-generated summary.
- If Claude does not report interrupted cost and the run has a finite dollar budget, recovery stops safely; guessing would risk granting extra experimental budget.
- After two resumed output overflows, the run remains failed rather than looping forever.
- Apptainer command construction, auth isolation, and bind arguments are unit-tested, but there is no SIF image in this worktree. A live resumed Apptainer run was not possible here. Apptainer is used on a separate cluster and should be smoke-tested there; the implementation mirrors the Docker mount that passed end to end, but writable-tmpfs/nested-bind behavior remains the main platform-specific assumption.
- The agent's transient todo/task UI state is not separately persisted. Conversation transcripts and sandbox files are the state required for reasoning continuity.
- Resume overhead can change token allocation versus an uninterrupted run even though it does not grant a new configured budget. This is why interrupted runs remain explicitly marked in results.

## Worktree note

Two unrelated pre-existing formatter-only edits in `integration_tests/red_team_sandbox.py` and `tests/utils/test_env_in_sandbox.py` were intentionally left out of every commit in this PR.
