### PR TITLE
Add eval_seed to pin the evaluation suite independently of the training seed

### DIFF
--- a/experiments/conf/config.yaml
+++ b/experiments/conf/config.yaml
@@ -4,6 +4,8 @@ defaults:
   - _self_
 
 seed: 42
+# Eval-suite seed; defaults to `seed`. Pin it to score different runs on one suite.
+eval_seed: null
 max_steps: 1000
 num_eval_tasks: 100
 # Per-instance eval wall-clock budget (seconds), shared by every approach.

--- a/experiments/run_experiment.py
+++ b/experiments/run_experiment.py
@@ -47,7 +47,10 @@ logger = logging.getLogger(__name__)
 
 def resolve_eval_seed(cfg: DictConfig) -> int:
     """Eval-suite seed: ``eval_seed`` when set, else ``seed``."""
-    return int(cfg.seed if cfg.get("eval_seed") is None else cfg.eval_seed)
+    value = cfg.seed if cfg.get("eval_seed") is None else cfg.eval_seed
+    if value != int(value):
+        raise ValueError(f"eval_seed must be an integer, got {value!r}")
+    return int(value)
 
 
 @hydra.main(version_base=None, config_path="conf", config_name="config")

--- a/experiments/run_experiment.py
+++ b/experiments/run_experiment.py
@@ -45,6 +45,11 @@ from robocode.utils.episode import (
 logger = logging.getLogger(__name__)
 
 
+def resolve_eval_seed(cfg: DictConfig) -> int:
+    """Eval-suite seed: ``eval_seed`` when set, else ``seed``."""
+    return int(cfg.seed if cfg.get("eval_seed") is None else cfg.eval_seed)
+
+
 @hydra.main(version_base=None, config_path="conf", config_name="config")
 def _main(cfg: DictConfig) -> float:
     """Run a single experiment."""
@@ -107,7 +112,8 @@ def _main(cfg: DictConfig) -> float:
     )
     approach = approach_ctor(primitives=primitives)
 
-    task_rng = np.random.default_rng(cfg.seed)
+    eval_seed = resolve_eval_seed(cfg)
+    task_rng = np.random.default_rng(eval_seed)
     num_eval = cfg.num_eval_tasks
     eval_seeds = [int(task_rng.integers(0, 2**63)) for _ in range(num_eval)]
 
@@ -261,6 +267,7 @@ def _main(cfg: DictConfig) -> float:
     gen_metrics = getattr(approach, "generation_metrics", None)
     if gen_metrics is not None:
         results.update(gen_metrics.to_dict())
+    results["eval_seed"] = eval_seed
     results_path = output_dir / "results.json"
     with open(results_path, "w", encoding="utf-8") as results_file:
         json.dump(results, results_file, indent=2)

--- a/tests/experiments/test_run_experiment.py
+++ b/tests/experiments/test_run_experiment.py
@@ -2,7 +2,7 @@
 
 experiments/ is a scripts directory, not an installed package, so the module is
 loaded from its path. Covers eval-suite seed resolution: `eval_seed` pins the
-suite independently of `seed`, and unset it follows `seed`.
+suite independently of `seed`; when unset, it follows `seed`.
 """
 
 import importlib.util
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
+import pytest
 from omegaconf import OmegaConf
 
 _MODULE_PATH = Path(__file__).resolve().parents[2] / "experiments" / "run_experiment.py"
@@ -26,7 +27,7 @@ def _suite(seed: int, num_eval: int = 5) -> list[int]:
 
 
 def test_eval_seed_defaults_to_seed() -> None:
-    """Unset eval_seed follows seed."""
+    """When unset, eval_seed follows seed."""
     cfg = OmegaConf.create({"seed": 42, "eval_seed": None})
     assert run_experiment.resolve_eval_seed(cfg) == 42
 
@@ -52,10 +53,16 @@ def test_pinned_eval_seed_yields_identical_suite_across_training_seeds() -> None
     assert suite_a == suite_b
 
 
-def test_unpinned_suites_differ_across_training_seeds() -> None:
-    """Without a pin, each training seed draws its own eval suite."""
+def test_non_integer_eval_seed_rejected() -> None:
+    """A fractional seed raises instead of silently truncating."""
+    cfg = OmegaConf.create({"seed": 42, "eval_seed": 42.5})
+    with pytest.raises(ValueError, match="integer"):
+        run_experiment.resolve_eval_seed(cfg)
+
+
+def test_unpinned_eval_seed_tracks_training_seed() -> None:
+    """Without a pin, the eval seed is the training seed, so runs differ."""
     cfg_a = OmegaConf.create({"seed": 24, "eval_seed": None})
     cfg_b = OmegaConf.create({"seed": 424, "eval_seed": None})
-    suite_a = _suite(run_experiment.resolve_eval_seed(cfg_a))
-    suite_b = _suite(run_experiment.resolve_eval_seed(cfg_b))
-    assert suite_a != suite_b
+    assert run_experiment.resolve_eval_seed(cfg_a) == 24
+    assert run_experiment.resolve_eval_seed(cfg_b) == 424

--- a/tests/experiments/test_run_experiment.py
+++ b/tests/experiments/test_run_experiment.py
@@ -1,0 +1,61 @@
+"""Tests for run_experiment helpers.
+
+experiments/ is a scripts directory, not an installed package, so the module is
+loaded from its path. Covers eval-suite seed resolution: `eval_seed` pins the
+suite independently of `seed`, and unset it follows `seed`.
+"""
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from omegaconf import OmegaConf
+
+_MODULE_PATH = Path(__file__).resolve().parents[2] / "experiments" / "run_experiment.py"
+_SPEC = importlib.util.spec_from_file_location("run_experiment", _MODULE_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+run_experiment: Any = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(run_experiment)
+
+
+def _suite(seed: int, num_eval: int = 5) -> list[int]:
+    """Derive the eval seed list the way _main does."""
+    rng = np.random.default_rng(seed)
+    return [int(rng.integers(0, 2**63)) for _ in range(num_eval)]
+
+
+def test_eval_seed_defaults_to_seed() -> None:
+    """Unset eval_seed follows seed."""
+    cfg = OmegaConf.create({"seed": 42, "eval_seed": None})
+    assert run_experiment.resolve_eval_seed(cfg) == 42
+
+
+def test_eval_seed_missing_key_defaults_to_seed() -> None:
+    """A config without the key behaves like eval_seed: null."""
+    cfg = OmegaConf.create({"seed": 42})
+    assert run_experiment.resolve_eval_seed(cfg) == 42
+
+
+def test_eval_seed_overrides_seed() -> None:
+    """A set eval_seed wins over seed."""
+    cfg = OmegaConf.create({"seed": 42, "eval_seed": 1000})
+    assert run_experiment.resolve_eval_seed(cfg) == 1000
+
+
+def test_pinned_eval_seed_yields_identical_suite_across_training_seeds() -> None:
+    """Pinning eval_seed gives differently-seeded runs the same eval suite."""
+    cfg_a = OmegaConf.create({"seed": 24, "eval_seed": 1000})
+    cfg_b = OmegaConf.create({"seed": 424, "eval_seed": 1000})
+    suite_a = _suite(run_experiment.resolve_eval_seed(cfg_a))
+    suite_b = _suite(run_experiment.resolve_eval_seed(cfg_b))
+    assert suite_a == suite_b
+
+
+def test_unpinned_suites_differ_across_training_seeds() -> None:
+    """Without a pin, each training seed draws its own eval suite."""
+    cfg_a = OmegaConf.create({"seed": 24, "eval_seed": None})
+    cfg_b = OmegaConf.create({"seed": 424, "eval_seed": None})
+    suite_a = _suite(run_experiment.resolve_eval_seed(cfg_a))
+    suite_b = _suite(run_experiment.resolve_eval_seed(cfg_b))
+    assert suite_a != suite_b


### PR DESCRIPTION
Unset, `eval_seed` follows `seed`, so existing behavior is unchanged. Pinning it makes separately-trained policies face an identical evaluation suite, which cross-evaluation between conditions requires. The resolved value is recorded in `results.json` so a suite can be rebuilt from a run directory alone.

Extracted from `exp/stickbutton-reset-distribution`, where it ran the 2026-08 cross-evaluation campaigns; the seed resolution is factored into `resolve_eval_seed()` with tests, including the property the campaigns rely on: two runs with different training seeds and the same pinned `eval_seed` are scored on the same suite.