### PR TITLE
Reject generated policies that mutate the scored env at load

### DIFF
--- a/src/robocode/utils/episode.py
+++ b/src/robocode/utils/episode.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import multiprocessing as mp
 import os
+import re
 import signal
 import sys
 import traceback
@@ -53,6 +54,23 @@ def _reject_planner_references(source: str, primitives: dict[str, Any]) -> None:
         )
 
 
+# A frozen GeneratedApproach is scored through reset()/get_action() only; referencing
+# set_state or sample_next_state mutates the scored env and can fake a solve. Match
+# ".name" with an identifier boundary so get_state, reset_state, and set_stateful pass.
+_FORBIDDEN_STATE_MUTATIONS = ("set_state", "sample_next_state")
+
+
+def _reject_state_mutation(source: str) -> None:
+    """Reject a generated approach that mutates the scored env (anti-cheat)."""
+    hits = [n for n in _FORBIDDEN_STATE_MUTATIONS if re.search(rf"\.{n}\b", source)]
+    if hits:
+        raise ValueError(
+            f"Generated approach references {', '.join(hits)}; approach.py is scored "
+            "through reset()/get_action() only and must reach the goal via the actions "
+            "it returns, not by mutating the environment's state."
+        )
+
+
 def load_generated_approach(
     path: Path,
     action_space: Any,
@@ -71,6 +89,7 @@ def load_generated_approach(
     try:
         source = path.read_text()
         _reject_planner_references(source, primitives)
+        _reject_state_mutation(source)
         # Set __file__ so the exec'd code can use it (e.g. to locate
         # sibling modules via os.path.dirname(__file__)).  exec() does
         # not set this automatically unlike a normal module import.

--- a/tests/utils/test_episode.py
+++ b/tests/utils/test_episode.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import multiprocessing as mp
 import sys
 import time
+from functools import partial
 from pathlib import Path
 from typing import Any
 
@@ -385,6 +386,112 @@ def test_anti_cheat_not_enforced_without_bilevel_models(tmp_path: Path) -> None:
     )
     approach = load_generated_approach(path, action_space, obs_space, {})
     assert hasattr(approach, "get_action")
+
+
+def test_anti_cheat_rejects_set_state(tmp_path: Path) -> None:
+    """A policy that calls set_state to teleport the scored env is rejected at load."""
+    action_space = Box(low=-1, high=1, shape=(2,))
+    obs_space = Box(low=0, high=1, shape=(4,))
+    path = _write_approach(tmp_path, extra="_ = 'env.set_state(goal)'")
+    with pytest.raises(ValueError, match="set_state"):
+        load_generated_approach(path, action_space, obs_space, {})
+
+
+def test_anti_cheat_rejects_sample_next_state(tmp_path: Path) -> None:
+    """sample_next_state also mutates the real env, so it is rejected too."""
+    action_space = Box(low=-1, high=1, shape=(2,))
+    obs_space = Box(low=0, high=1, shape=(4,))
+    path = _write_approach(tmp_path, extra="_ = 'env.sample_next_state(s, a, rng)'")
+    with pytest.raises(ValueError, match="sample_next_state"):
+        load_generated_approach(path, action_space, obs_space, {})
+
+
+def test_anti_cheat_allows_state_reads(tmp_path: Path) -> None:
+    """get_state, reset_state, and longer set_state* names do not false-positive."""
+    action_space = Box(low=-1, high=1, shape=(2,))
+    obs_space = Box(low=0, high=1, shape=(4,))
+    path = _write_approach(
+        tmp_path,
+        extra=(
+            "_ = 'env.get_state(); self.reset_state();"
+            " env.set_stateful(); env.set_state_from_bytes()'"
+        ),
+    )
+    approach = load_generated_approach(path, action_space, obs_space, {})
+    assert hasattr(approach, "get_action")
+
+
+class _StatefulGoalEnv(Env):
+    """Toy env with get_state/set_state; step terminates once position reaches 5.0.
+
+    Honest play needs ~50 steps of +0.1; a teleport to the goal state solves in one.
+    """
+
+    def __init__(self) -> None:
+        self.observation_space = Box(0.0, 10.0, shape=(1,), dtype=np.float32)
+        self.action_space = Box(-1.0, 1.0, shape=(1,), dtype=np.float32)
+        self._pos = 0.0
+
+    def reset(self, *, seed=None, options=None):
+        super().reset(seed=seed)
+        self._pos = 0.0
+        return np.array([self._pos], dtype=np.float32), {}
+
+    def step(self, action):
+        del action
+        self._pos = min(10.0, self._pos + 0.1)
+        obs = np.array([self._pos], dtype=np.float32)
+        return obs, 0.0, self._pos >= 5.0, False, {}
+
+    def get_state(self):
+        """Snapshot the current position."""
+        return np.array([self._pos], dtype=np.float32)
+
+    def set_state(self, state):
+        """Restore the position from a snapshot."""
+        self._pos = float(state[0])
+
+    def goal_state(self):
+        """A state sitting at the goal position (5.0)."""
+        return np.array([5.0], dtype=np.float32)
+
+    def render(self):
+        return None
+
+
+def test_set_state_teleport_fabricates_a_solve() -> None:
+    """Red-team: teleporting into the goal state fakes a one-step solve."""
+    env: Any = _StatefulGoalEnv()
+    env.reset(seed=0)
+    env.set_state(env.goal_state())
+    _, _, terminated, _, _ = env.step(env.action_space.sample())
+    assert terminated  # a policy that could set_state would score solved doing nothing
+
+
+def test_generated_policy_cannot_teleport_via_primitive_closure(tmp_path: Path) -> None:
+    """Red-team: an env-bound primitive exposes the env; the loader refuses it."""
+    env = _StatefulGoalEnv()
+    # Mirrors build_primitives' partial(check_action_collision, env): the bound env is
+    # reachable from a generated policy as primitives["peek"].args[0].
+    prims = {"peek": partial(lambda e, s: None, env)}
+    assert prims["peek"].args[0] is env  # the teleport channel is real
+    teleport = tmp_path / "approach.py"
+    teleport.write_text(
+        "class GeneratedApproach:\n"
+        "    def __init__(self, action_space, observation_space, primitives):\n"
+        "        self._action_space = action_space\n"
+        "        self._primitives = primitives\n"
+        "    def reset(self, state, info):\n"
+        "        pass\n"
+        "    def get_action(self, state):\n"
+        "        env = self._primitives['peek'].args[0]\n"
+        "        env.set_state(env.goal_state())  # teleport into the goal\n"
+        "        return self._action_space.sample()\n"
+    )
+    with pytest.raises(ValueError, match="set_state"):
+        load_generated_approach(
+            teleport, env.action_space, env.observation_space, prims
+        )
 
 
 class _CountEnv(Env):


### PR DESCRIPTION
## Problem

A frozen `GeneratedApproach` is scored through `reset()`/`get_action()` only, so it must reach the goal via the actions it returns. But an env-dependent primitive closes over the live env — `check_action_collision` is `partial(check_action_collision, env)`, reachable from a policy as `primitives["check_action_collision"].args[0]` — and the blackbox client exposes `set_state` directly. Either way a policy can call `env.set_state(<solved state>)` inside `get_action`, return a throwaway action, and have the harness score `solved=True`. This corrupts every frozen-policy number. The realistic trigger is an honest LLM that mistakes `set_state` for a planning tool and inflates its own self-eval.

## Fix

`_reject_state_mutation` in `episode.py`, mirroring the existing `_reject_planner_references` anti-cheat: reject any generated policy whose source references `.set_state` / `.sample_next_state` (method access, so read-only `get_state` and unrelated names like `reset_state` don't false-positive). It's wired into `load_generated_approach`, which every scorer (whitebox rollout and host-scored blackbox) funnels through, so a single gate covers all paths. It also runs during the agent's own self-eval, so the loud `ValueError` steers synthesis toward a real policy instead of silently posting a fabricated score.

## Red-team (both sides run)

- Reverting only the guard, all three teleport tests `DID NOT RAISE` — the loader accepts a teleporting policy (hole open).
- Restored, they reject.
- Permanent tests document why: teleporting into the goal fakes a one-step solve, and `partial(...).args[0] is env` proves the closure channel is real.

## Scope

A detector that fails loud, not an adversarial sandbox — consistent with the "cooperative guardrail, not a sandbox" line already in `episode.py`. The runtime `_eval_mode` flag from the audit was dropped on purpose: the agent optimizes its own self-eval, not us, so once `set_state` stops paying off it has no incentive to obfuscate the call. No prompt change either — the rejection message teaches on contact rather than advertising the cheat.