### PR TITLE
Stop the env card asserting a concrete evaluation count

### DIFF
--- a/src/robocode/environments/variable_object_count_env.py
+++ b/src/robocode/environments/variable_object_count_env.py
@@ -396,8 +396,10 @@ class VariableObjectCountEnv(BaseEnv[ObjectCentricState, NDArray[Any]]):
             f'    count_kwarg="{self._count_kwarg}",\n'
             f'    count_object_prefix="{self._count_object_prefix}",\n'
             f"{bilevel_example_arg}"
-            "    # Counts an unpinned reset draws from; use whichever you want to\n"
-            "    # develop against.\n"
+            "    # Example values. These args only choose which counts an unpinned\n"
+            "    # reset draws from while you develop; they are NOT the counts used\n"
+            "    # at evaluation, which are not disclosed. Your program must handle\n"
+            "    # any object count.\n"
             "    design_counts=[1],\n"
             "    eval_counts=[1],\n"
             ")\n\n"

--- a/src/robocode/environments/variable_object_count_env.py
+++ b/src/robocode/environments/variable_object_count_env.py
@@ -396,12 +396,9 @@ class VariableObjectCountEnv(BaseEnv[ObjectCentricState, NDArray[Any]]):
             f'    count_kwarg="{self._count_kwarg}",\n'
             f'    count_object_prefix="{self._count_object_prefix}",\n'
             f"{bilevel_example_arg}"
-            "    # Example values. These args only choose which counts an unpinned\n"
-            "    # reset draws from while you develop; they are NOT the counts used\n"
-            "    # at evaluation, which are not disclosed. Your program must handle\n"
-            "    # any object count.\n"
-            "    design_counts=[1],\n"
-            "    eval_counts=[1],\n"
+            "    # Any counts you like; the evaluation counts are not disclosed.\n"
+            "    design_counts=[<count list>],\n"
+            "    eval_counts=[<count list>],\n"
             ")\n\n"
             "# Pin a count to build an instance of that size, for any count:\n"
             "state, info = env.reset(seed=0, options={'object_count': 3})\n"

--- a/src/robocode/environments/variable_object_count_env.py
+++ b/src/robocode/environments/variable_object_count_env.py
@@ -396,7 +396,6 @@ class VariableObjectCountEnv(BaseEnv[ObjectCentricState, NDArray[Any]]):
             f'    count_kwarg="{self._count_kwarg}",\n'
             f'    count_object_prefix="{self._count_object_prefix}",\n'
             f"{bilevel_example_arg}"
-            "    # Any counts you like; the evaluation counts are not disclosed.\n"
             "    design_counts=[<count list>],\n"
             "    eval_counts=[<count list>],\n"
             ")\n\n"

--- a/tests/environments/test_variable_object_count_env.py
+++ b/tests/environments/test_variable_object_count_env.py
@@ -263,6 +263,23 @@ def test_card_hides_the_configured_counts(
     other.close()
 
 
+def test_usage_example_names_no_concrete_count() -> None:
+    """The usage example must not put a runnable count list in the count arguments.
+
+    A concrete literal there reads as the configured value even when it is not:
+    agents took `eval_counts=[1]` from this snippet as the evaluation size and
+    developed programs that only handled one object. The neighbouring
+    count-hiding test does not catch it, since a hard-coded literal differs from
+    whatever counts the env was built with.
+    """
+    env = VariableObjectCountEnv(**OBSTRUCTION2D)
+    usage = _section(env.env_description, "## Example Usage")
+    for key in ("design_counts=", "eval_counts="):
+        arg = usage.split(key, 1)[1].split("\n", 1)[0]
+        assert not any(ch.isdigit() for ch in arg), f"{key}{arg}"
+    env.close()
+
+
 def test_family_prose_drops_count_specific_claims() -> None:
     """StickButton2D's family description states the instance's button count ("there are
     always 3 buttons").


### PR DESCRIPTION
The variable-count env card ends with a runnable usage example. It hard-coded
`design_counts=[1], eval_counts=[1]` whatever the env was actually configured
with, so the card contradicted itself: the Generalization section promises an
unbounded object count, while the snippet below asserts the evaluation size is
one.

Agents believe the snippet. Two Opus 5 runs in the 2026-08-05 comparison quoted
it back while planning ("count=1 (the evaluated size): 1600/1600 seeds solved"),
validated almost exclusively at count 1, and collapsed on the held-out counts 11
and 15. The same failure appears once in the July sweep.

This replaces the literals with a non-runnable `[<count list>]` placeholder and
drops the comment above them, so the example shows the call shape without
claiming a value.

The existing `test_card_hides_the_configured_counts` does not cover this: it
asserts the card omits the counts the env was built with, and a hard-coded `[1]`
is a different literal, so it passed throughout. The added test asserts the count
arguments contain no digits at all; it fails on the old text and passes on the
new.