### PR TITLE
Instrument the 3D env class for telemetry

### DIFF
--- a/src/robocode/utils/telemetry.py
+++ b/src/robocode/utils/telemetry.py
@@ -261,6 +261,7 @@ def _emit_set_state(
 INSTRUMENTED_ENVS: tuple[str, ...] = (
     "robocode.environments.variable_object_count_env:VariableObjectCountEnv",
     "robocode.environments.kinder_geom2d_env:KinderGeom2DEnv",
+    "robocode.environments.kinder_geom3d_env:KinderGeom3DEnv",
 )
 
 

--- a/tests/utils/test_telemetry.py
+++ b/tests/utils/test_telemetry.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import importlib
 import json
 import os
 import subprocess
@@ -302,3 +303,16 @@ def test_set_state_captures_keyword_state(sink: Callable[[], list[dict]]) -> Non
     env.set_state(state=np.array([2.0], dtype=np.float32))
     events = [e for e in sink() if e["kind"] == "set_state"]
     assert len(events) == 1 and events[0]["state"] is not None
+
+
+def test_registered_envs_resolve_and_expose_wrapped_methods() -> None:
+    """Every INSTRUMENTED_ENVS entry names a real class with the wrapped methods.
+
+    instrument_registered_envs() imports these by name, so a typo or a renamed class
+    would only surface when a telemetry run reaches the sandbox hook.
+    """
+    for target in tel.INSTRUMENTED_ENVS:
+        module_name, class_name = target.split(":")
+        cls = getattr(importlib.import_module(module_name), class_name)
+        for method in ("reset", "step", "set_state"):
+            assert callable(getattr(cls, method, None)), f"{target} lacks {method}"


### PR DESCRIPTION
`KinderGeom3DEnv` was missing from `INSTRUMENTED_ENVS`, so any run combining `approach.telemetry=true` with a 3D environment aborted at launch, before any agent work:

```
TelemetryNotInstrumentedError: Telemetry is on but env
'robocode.environments.kinder_geom3d_env.KinderGeom3DEnv' is not registered
for instrumentation; add it to INSTRUMENTED_ENVS in robocode.utils.telemetry.
```

Found by hitting it: four queued Opus 5 runs on `packing3d`, `shelf3d`, `constrainedcupboard3d` and `motion3d` each died three seconds in. Nothing was spent, since `require_registered` fires before the sandbox starts, but the runs were lost.

## Fix

One line. `KinderGeom3DEnv` already exposes the `reset` / `step` / `set_state` that `instrument_class` wraps, so registering it is all that is needed. Verified a 3D reset now emits a real `reset` event carrying a state fingerprint, the same as the 2D envs.

## Test

Also adds a test that every `INSTRUMENTED_ENVS` entry resolves to a real class exposing those three methods.

The existing tests monkeypatch `INSTRUMENTED_ENVS` (`monkeypatch.setattr(tel, "INSTRUMENTED_ENVS", (f"{__name__}:_ToyEnv",))`), so nothing guarded the tuple's real contents. A typo or a renamed class would have surfaced only once a telemetry run reached the sandbox hook. This does not catch a *missing* entry, which is what happened here, but it does guard the entries that are present.

## Testing

- `tests/utils/test_telemetry.py`: 23 passed
- black, isort, mypy clean on both files