### PR TITLE
Prompt agents to search for unsolved instances

### DIFF
--- a/src/robocode/prompts.py
+++ b/src/robocode/prompts.py
@@ -324,7 +324,8 @@ interface:
 Write the best approach you can — ideally one that solves the environment \
 optimally. Your `approach.py` should only use packages available in the \
 current environment. Write test scripts that use the real environment to \
-verify your approach works.
+verify your approach works. Once you have a strong candidate, search for \
+instances it does not yet solve, then use those failures to improve it.
 
 IMPORTANT: Use `{python_executable}` to run your test scripts, since that \
 interpreter has all required packages installed. For example:

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -259,6 +259,10 @@ def test_interface_spec_shared_wrapper_across_approaches():
     for spec in (agentic, cdl):
         assert "Write the best approach you can" in spec
         assert "Write test scripts that use the real environment" in spec
+        assert (
+            "Once you have a strong candidate, search for instances it does not yet "
+            "solve, then use those failures to improve it."
+        ) in spec
     # Structural slots still differ.
     assert "test_behavior_[behavior_name].py" in cdl
     assert "test_behavior_[behavior_name].py" not in agentic


### PR DESCRIPTION
## Summary

- prompt agents to search for instances their strong candidate does not yet solve and use those failures to improve it
- assert that the instruction is included in the shared agentic interface prompt

## Motivation

This adds the lightweight counterexample-search loop discussed in the 2026-08-07 GenPlan sync. The wording stays domain-general and does not prescribe what constitutes an edge case, how to search, or how to repair the program.

## Impact

All agentic and CDL synthesis runs receive the additional instruction through the shared interface-spec template. The faithful GenPlan baseline prompt is unchanged.

## Validation

- `pytest tests/test_prompts.py -q` (52 passed)
- mypy on the changed files
- pylint on the prompt tests
- Black and isort checks on the changed files
