### PR TITLE
Add variable-object-count Kinder 3D environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,6 @@ All environments are available as Hydra configs via `environment=<config_name>`.
 
 | Config | Kinder ID | Difficulty |
 |---|---|---|
-| `motion3d` | `kinder/Motion3D-v0` | Single variant |
 | `obstruction3d_easy` | `kinder/Obstruction3D-o0-v0` | Easy (0 obstructions) |
 | `obstruction3d_medium` | `kinder/Obstruction3D-o2-v0` | Medium (2 obstructions) |
 | `obstruction3d_hard` | `kinder/Obstruction3D-o4-v0` | Hard (4 obstructions) |

--- a/experiments/conf/environment/constrainedcupboard3d_generalized.yaml
+++ b/experiments/conf/environment/constrainedcupboard3d_generalized.yaml
@@ -2,8 +2,8 @@ _target_: robocode.environments.variable_object_count_env.VariableObjectCountEnv
 constant_object_env_path: robocode.environments.constrained_cupboard3d:ConstrainedCupboard3DEnv
 count_kwarg: num_objects
 count_object_prefix: cuboid_
-design_counts: [1, 2]
-eval_counts: [1, 2, 6]
+design_counts: [1, 2, 3]
+eval_counts: [1, 2, 3, 4, 5, 6]
 constant_object_env_kwargs:
   scene_bg: mimiclabs-lab2
 base_steps: 400

--- a/experiments/conf/environment/constrainedcupboard3d_generalized.yaml
+++ b/experiments/conf/environment/constrainedcupboard3d_generalized.yaml
@@ -1,0 +1,10 @@
+_target_: robocode.environments.variable_object_count_env.VariableObjectCountEnv
+constant_object_env_path: robocode.environments.constrained_cupboard3d:ConstrainedCupboard3DEnv
+count_kwarg: num_objects
+count_object_prefix: cuboid
+design_counts: [1, 2]
+eval_counts: [1, 2, 6]
+constant_object_env_kwargs:
+  scene_bg: mimiclabs-lab2
+base_steps: 400
+steps_per_object: 400

--- a/experiments/conf/environment/constrainedcupboard3d_generalized.yaml
+++ b/experiments/conf/environment/constrainedcupboard3d_generalized.yaml
@@ -1,7 +1,7 @@
 _target_: robocode.environments.variable_object_count_env.VariableObjectCountEnv
 constant_object_env_path: robocode.environments.constrained_cupboard3d:ConstrainedCupboard3DEnv
 count_kwarg: num_objects
-count_object_prefix: cuboid
+count_object_prefix: cuboid_
 design_counts: [1, 2]
 eval_counts: [1, 2, 6]
 constant_object_env_kwargs:

--- a/experiments/conf/environment/motion3d.yaml
+++ b/experiments/conf/environment/motion3d.yaml
@@ -1,2 +1,0 @@
-_target_: robocode.environments.kinder_geom3d_env.KinderGeom3DEnv
-env_id: kinder/Motion3D-v0

--- a/experiments/conf/environment/obstruction3d_generalized.yaml
+++ b/experiments/conf/environment/obstruction3d_generalized.yaml
@@ -1,0 +1,6 @@
+_target_: robocode.environments.variable_object_count_env.VariableObjectCountEnv
+constant_object_env_path: kinder.envs.kinematic3d.obstruction3d:Obstruction3DEnv
+count_kwarg: num_obstructions
+count_object_prefix: obstruction
+design_counts: [0, 1, 2]
+eval_counts: [0, 1, 2, 3, 4]

--- a/experiments/conf/environment/packing3d_generalized.yaml
+++ b/experiments/conf/environment/packing3d_generalized.yaml
@@ -1,0 +1,6 @@
+_target_: robocode.environments.variable_object_count_env.VariableObjectCountEnv
+constant_object_env_path: kinder.envs.kinematic3d.packing3d:Packing3DEnv
+count_kwarg: num_parts
+count_object_prefix: part
+design_counts: [1, 2]
+eval_counts: [1, 2, 3]

--- a/experiments/conf/environment/shelf3d_generalized.yaml
+++ b/experiments/conf/environment/shelf3d_generalized.yaml
@@ -1,0 +1,6 @@
+_target_: robocode.environments.variable_object_count_env.VariableObjectCountEnv
+constant_object_env_path: kinder.envs.kinematic3d.shelf3d:Shelf3DEnv
+count_kwarg: num_cubes
+count_object_prefix: cube
+design_counts: [1, 2, 3]
+eval_counts: [1, 2, 3, 5, 10]

--- a/experiments/conf/environment/table3d_generalized.yaml
+++ b/experiments/conf/environment/table3d_generalized.yaml
@@ -1,0 +1,6 @@
+_target_: robocode.environments.variable_object_count_env.VariableObjectCountEnv
+constant_object_env_path: kinder.envs.kinematic3d.table3d:Table3DEnv
+count_kwarg: num_cubes
+count_object_prefix: cube
+design_counts: [1, 2, 3, 4]
+eval_counts: [1, 2, 3, 4, 6, 8, 10]

--- a/experiments/conf/environment/transport3d_generalized.yaml
+++ b/experiments/conf/environment/transport3d_generalized.yaml
@@ -1,0 +1,11 @@
+_target_: robocode.environments.variable_object_count_env.VariableObjectCountEnv
+constant_object_env_path: kinder.envs.kinematic3d.transport3d:Transport3DEnv
+count_kwarg: num_cubes
+count_object_prefix: cube
+design_counts: [1, 2]
+eval_counts: [1, 2, 3, 4]
+constant_object_env_kwargs:
+  num_boxes: 1
+
+base_steps: 500
+steps_per_object: 400

--- a/scripts/render_generalized_3d_initial_states.py
+++ b/scripts/render_generalized_3d_initial_states.py
@@ -28,12 +28,21 @@ _DEFAULT_CONFIGS = (
 
 
 def _annotate(
-    frame: NDArray[np.uint8], env_name: str, seed: int, count: int
+    frame: NDArray[np.uint8],
+    env_name: str,
+    phase: str,
+    index: int,
+    total: int,
+    seed: int,
+    count: int,
 ) -> NDArray[np.uint8]:
     rgb = frame[..., :3]
     image = Image.fromarray(rgb)
     draw = ImageDraw.Draw(image)
-    label = f"{env_name} | seed={seed:03d} | object_count={count}"
+    label = (
+        f"{env_name} | {phase} {index:03d}/{total:03d} | "
+        f"seed={seed} | object_count={count}"
+    )
     _, _, _, text_height = draw.textbbox((0, 0), label)
     draw.rectangle((0, 0, image.width, text_height + 8), fill=(0, 0, 0))
     draw.text((6, 4), label, fill=(255, 255, 255))
@@ -43,7 +52,9 @@ def _annotate(
 def _render_config(
     env_name: str,
     output_dir: Path,
-    num_seeds: int,
+    num_train_seeds: int,
+    num_eval_seeds: int,
+    eval_seed: int,
     fps: int,
     render_dpi: int,
 ) -> dict[str, Any]:
@@ -51,18 +62,44 @@ def _render_config(
     config.render_dpi = render_dpi
     env = instantiate(config)
     frames: list[NDArray[np.uint8]] = []
-    counts: Counter[int] = Counter()
+    phase_counts: dict[str, Counter[int]] = {
+        "train": Counter(),
+        "eval": Counter(),
+    }
     try:
-        for seed in range(num_seeds):
-            _, info = env.reset(seed=seed)
-            count = int(info["object_count"])
-            counts[count] += 1
-            frame = env.render()
-            if not isinstance(frame, np.ndarray):
-                raise TypeError(f"{env_name}.render() returned {type(frame).__name__}")
-            frames.append(_annotate(frame, env_name, seed, count))
-            if (seed + 1) % 10 == 0 or seed + 1 == num_seeds:
-                print(f"{env_name}: rendered {seed + 1}/{num_seeds}", flush=True)
+        train_seeds = list(range(num_train_seeds))
+        eval_rng = np.random.default_rng(eval_seed)
+        eval_seeds = [int(eval_rng.integers(0, 2**63)) for _ in range(num_eval_seeds)]
+        eval_counts = [
+            env.eval_counts[i % len(env.eval_counts)] for i in range(num_eval_seeds)
+        ]
+        phases = (
+            ("train", train_seeds, [None] * num_train_seeds),
+            ("eval", eval_seeds, eval_counts),
+        )
+        for phase, seeds, pinned_counts in phases:
+            total = len(seeds)
+            for index, (seed, pinned_count) in enumerate(
+                zip(seeds, pinned_counts, strict=True), start=1
+            ):
+                options = (
+                    None
+                    if pinned_count is None
+                    else {"object_count": int(pinned_count)}
+                )
+                _, info = env.reset(seed=seed, options=options)
+                count = int(info["object_count"])
+                phase_counts[phase][count] += 1
+                frame = env.render()
+                if not isinstance(frame, np.ndarray):
+                    raise TypeError(
+                        f"{env_name}.render() returned {type(frame).__name__}"
+                    )
+                frames.append(
+                    _annotate(frame, env_name, phase, index, total, seed, count)
+                )
+                if index % 10 == 0 or index == total:
+                    print(f"{env_name} {phase}: rendered {index}/{total}", flush=True)
     finally:
         env.close()
 
@@ -70,8 +107,11 @@ def _render_config(
     save_video(frames, gif_path, fps=fps)
     return {
         "gif": gif_path.name,
-        "num_seeds": num_seeds,
-        "sampled_counts": dict(sorted(counts.items())),
+        "num_train_seeds": num_train_seeds,
+        "num_eval_seeds": num_eval_seeds,
+        "eval_seed": eval_seed,
+        "train_counts": dict(sorted(phase_counts["train"].items())),
+        "eval_counts": dict(sorted(phase_counts["eval"].items())),
         "frame_shape": list(frames[0].shape),
         "size_bytes": gif_path.stat().st_size,
     }
@@ -85,7 +125,9 @@ def main() -> None:
         type=Path,
         default=Path("outputs/generalized_3d_initial_states"),
     )
-    parser.add_argument("--num-seeds", type=int, default=100)
+    parser.add_argument("--num-train-seeds", type=int, default=100)
+    parser.add_argument("--num-eval-seeds", type=int, default=100)
+    parser.add_argument("--eval-seed", type=int, default=42)
     parser.add_argument("--fps", type=int, default=5)
     parser.add_argument("--render-dpi", type=int, default=60)
     parser.add_argument("--configs", nargs="*", default=_DEFAULT_CONFIGS)
@@ -96,7 +138,9 @@ def main() -> None:
         env_name: _render_config(
             env_name,
             args.output_dir,
-            args.num_seeds,
+            args.num_train_seeds,
+            args.num_eval_seeds,
+            args.eval_seed,
             args.fps,
             args.render_dpi,
         )

--- a/scripts/render_generalized_3d_initial_states.py
+++ b/scripts/render_generalized_3d_initial_states.py
@@ -35,9 +35,12 @@ def _annotate(
     total: int,
     seed: int,
     count: int,
+    render_width: int,
 ) -> NDArray[np.uint8]:
     rgb = frame[..., :3]
     image = Image.fromarray(rgb)
+    render_height = round(image.height * render_width / image.width)
+    image = image.resize((render_width, render_height), Image.Resampling.LANCZOS)
     draw = ImageDraw.Draw(image)
     label = (
         f"{env_name} | {phase} {index:03d}/{total:03d} | "
@@ -56,10 +59,17 @@ def _render_config(
     num_eval_seeds: int,
     eval_seed: int,
     fps: int,
-    render_dpi: int,
+    render_width: int,
 ) -> dict[str, Any]:
+    if num_train_seeds < 0 or num_eval_seeds < 0:
+        raise ValueError("Seed counts must be non-negative")
+    if num_train_seeds + num_eval_seeds == 0:
+        raise ValueError("At least one train or eval seed is required")
+    if fps <= 0:
+        raise ValueError("fps must be positive")
+    if render_width <= 0:
+        raise ValueError("render_width must be positive")
     config = OmegaConf.load(_CONFIG_DIR / f"{env_name}.yaml")
-    config.render_dpi = render_dpi
     env = instantiate(config)
     frames: list[NDArray[np.uint8]] = []
     phase_counts: dict[str, Counter[int]] = {
@@ -96,7 +106,16 @@ def _render_config(
                         f"{env_name}.render() returned {type(frame).__name__}"
                     )
                 frames.append(
-                    _annotate(frame, env_name, phase, index, total, seed, count)
+                    _annotate(
+                        frame,
+                        env_name,
+                        phase,
+                        index,
+                        total,
+                        seed,
+                        count,
+                        render_width,
+                    )
                 )
                 if index % 10 == 0 or index == total:
                     print(f"{env_name} {phase}: rendered {index}/{total}", flush=True)
@@ -129,7 +148,7 @@ def main() -> None:
     parser.add_argument("--num-eval-seeds", type=int, default=100)
     parser.add_argument("--eval-seed", type=int, default=42)
     parser.add_argument("--fps", type=int, default=5)
-    parser.add_argument("--render-dpi", type=int, default=60)
+    parser.add_argument("--render-width", type=int, default=480)
     parser.add_argument("--configs", nargs="*", default=_DEFAULT_CONFIGS)
     args = parser.parse_args()
 
@@ -142,7 +161,7 @@ def main() -> None:
             args.num_eval_seeds,
             args.eval_seed,
             args.fps,
-            args.render_dpi,
+            args.render_width,
         )
         for env_name in args.configs
     }

--- a/scripts/render_generalized_3d_initial_states.py
+++ b/scripts/render_generalized_3d_initial_states.py
@@ -1,0 +1,111 @@
+"""Render seeded initial-state GIFs for generalized 3D environments."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from hydra.utils import instantiate
+from numpy.typing import NDArray
+from omegaconf import OmegaConf
+from PIL import Image, ImageDraw
+
+from robocode.utils.episode import save_video
+
+_CONFIG_DIR = Path(__file__).parents[1] / "experiments" / "conf" / "environment"
+_DEFAULT_CONFIGS = (
+    "table3d_generalized",
+    "transport3d_generalized",
+    "shelf3d_generalized",
+    "obstruction3d_generalized",
+    "packing3d_generalized",
+    "constrainedcupboard3d_generalized",
+)
+
+
+def _annotate(
+    frame: NDArray[np.uint8], env_name: str, seed: int, count: int
+) -> NDArray[np.uint8]:
+    rgb = frame[..., :3]
+    image = Image.fromarray(rgb)
+    draw = ImageDraw.Draw(image)
+    label = f"{env_name} | seed={seed:03d} | object_count={count}"
+    _, _, _, text_height = draw.textbbox((0, 0), label)
+    draw.rectangle((0, 0, image.width, text_height + 8), fill=(0, 0, 0))
+    draw.text((6, 4), label, fill=(255, 255, 255))
+    return np.asarray(image)
+
+
+def _render_config(
+    env_name: str,
+    output_dir: Path,
+    num_seeds: int,
+    fps: int,
+    render_dpi: int,
+) -> dict[str, Any]:
+    config = OmegaConf.load(_CONFIG_DIR / f"{env_name}.yaml")
+    config.render_dpi = render_dpi
+    env = instantiate(config)
+    frames: list[NDArray[np.uint8]] = []
+    counts: Counter[int] = Counter()
+    try:
+        for seed in range(num_seeds):
+            _, info = env.reset(seed=seed)
+            count = int(info["object_count"])
+            counts[count] += 1
+            frame = env.render()
+            if not isinstance(frame, np.ndarray):
+                raise TypeError(f"{env_name}.render() returned {type(frame).__name__}")
+            frames.append(_annotate(frame, env_name, seed, count))
+            if (seed + 1) % 10 == 0 or seed + 1 == num_seeds:
+                print(f"{env_name}: rendered {seed + 1}/{num_seeds}", flush=True)
+    finally:
+        env.close()
+
+    gif_path = output_dir / f"{env_name}.gif"
+    save_video(frames, gif_path, fps=fps)
+    return {
+        "gif": gif_path.name,
+        "num_seeds": num_seeds,
+        "sampled_counts": dict(sorted(counts.items())),
+        "frame_shape": list(frames[0].shape),
+        "size_bytes": gif_path.stat().st_size,
+    }
+
+
+def main() -> None:
+    """Render all requested generalized 3D initial-state distributions."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("outputs/generalized_3d_initial_states"),
+    )
+    parser.add_argument("--num-seeds", type=int, default=100)
+    parser.add_argument("--fps", type=int, default=5)
+    parser.add_argument("--render-dpi", type=int, default=60)
+    parser.add_argument("--configs", nargs="*", default=_DEFAULT_CONFIGS)
+    args = parser.parse_args()
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        env_name: _render_config(
+            env_name,
+            args.output_dir,
+            args.num_seeds,
+            args.fps,
+            args.render_dpi,
+        )
+        for env_name in args.configs
+    }
+    manifest_path = args.output_dir / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    print(json.dumps(manifest, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/robocode/environments/constrained_cupboard3d.py
+++ b/src/robocode/environments/constrained_cupboard3d.py
@@ -10,7 +10,7 @@ from kinder.envs.dynamic3d.envs import TidyBot3DEnv
 class ConstrainedCupboard3DEnv(TidyBot3DEnv):
     """Select a ConstrainedCupboard3D task by its number of rods."""
 
-    supported_counts = frozenset({1, 2, 6})
+    supported_counts = frozenset(range(1, 7))
 
     def __init__(self, num_objects: int = 1, **kwargs: Any) -> None:
         if num_objects not in self.supported_counts:

--- a/src/robocode/environments/constrained_cupboard3d.py
+++ b/src/robocode/environments/constrained_cupboard3d.py
@@ -18,6 +18,11 @@ class ConstrainedCupboard3DEnv(TidyBot3DEnv):
                 f"ConstrainedCupboard3D supports counts "
                 f"{sorted(self.supported_counts)}, got {num_objects}"
             )
+        if "task_config_path" in kwargs:
+            raise ValueError(
+                "ConstrainedCupboard3D selects task_config_path from num_objects"
+            )
+        kwargs.setdefault("scene_render_camera", "task_view")
         tasks_dir = Path(dynamic3d_envs.__file__).parent / "tasks"
         task_path = (
             tasks_dir
@@ -27,6 +32,5 @@ class ConstrainedCupboard3DEnv(TidyBot3DEnv):
         super().__init__(
             num_objects=num_objects,
             task_config_path=str(task_path),
-            scene_render_camera="task_view",
             **kwargs,
         )

--- a/src/robocode/environments/constrained_cupboard3d.py
+++ b/src/robocode/environments/constrained_cupboard3d.py
@@ -1,0 +1,32 @@
+"""Count-parameterized access to the registered ConstrainedCupboard3D tasks."""
+
+from pathlib import Path
+from typing import Any
+
+from kinder.envs.dynamic3d import envs as dynamic3d_envs
+from kinder.envs.dynamic3d.envs import TidyBot3DEnv
+
+
+class ConstrainedCupboard3DEnv(TidyBot3DEnv):
+    """Select a ConstrainedCupboard3D task by its number of rods."""
+
+    supported_counts = frozenset({1, 2, 6})
+
+    def __init__(self, num_objects: int = 1, **kwargs: Any) -> None:
+        if num_objects not in self.supported_counts:
+            raise ValueError(
+                f"ConstrainedCupboard3D supports counts "
+                f"{sorted(self.supported_counts)}, got {num_objects}"
+            )
+        tasks_dir = Path(dynamic3d_envs.__file__).parent / "tasks"
+        task_path = (
+            tasks_dir
+            / "ConstrainedCupboard3D"
+            / f"ConstrainedCupboard3D-o{num_objects}.json"
+        )
+        super().__init__(
+            num_objects=num_objects,
+            task_config_path=str(task_path),
+            scene_render_camera="task_view",
+            **kwargs,
+        )

--- a/src/robocode/environments/kinder_geom3d_env.py
+++ b/src/robocode/environments/kinder_geom3d_env.py
@@ -111,7 +111,7 @@ class KinderGeom3DEnv(BaseEnv[NDArray[Any], NDArray[Any]]):
             f"Key files in that directory:\n"
             f"- `base_env.py` \u2014 `step()` transition dynamics and collision "
             f"handling\n"
-            f"- The environment-specific module (e.g. `motion3d.py`) \u2014 "
+            f"- The environment-specific module (e.g. `obstruction3d.py`) \u2014 "
             f"reward function (`_get_reward_and_done`), config, and "
             f"scene generation\n"
             f"- `object_types.py` \u2014 object type definitions and feature names"

--- a/src/robocode/environments/variable_object_count_env.py
+++ b/src/robocode/environments/variable_object_count_env.py
@@ -73,7 +73,6 @@ class VariableObjectCountEnv(BaseEnv[ObjectCentricState, NDArray[Any]]):
         bilevel_env_name: str | None = None,
         base_steps: int = 300,
         steps_per_object: int = 150,
-        render_dpi: int | None = None,
     ) -> None:
         # Lock the GL backend before building any backend env so rendering works;
         # driving the kinder classes directly needs no gym registry.
@@ -92,10 +91,6 @@ class VariableObjectCountEnv(BaseEnv[ObjectCentricState, NDArray[Any]]):
         # scored as failed merely for running out of steps before it could finish.
         self._base_steps = base_steps
         self._steps_per_object = steps_per_object
-        # Optional render-resolution override applied to every backend. Unset, each
-        # family keeps its own default DPI; lowering it (e.g. for gif capture) shrinks
-        # each frame so long, high-object-count rollouts fit in memory.
-        self._render_dpi = render_dpi
         self._design_counts = [int(c) for c in design_counts]
         self._eval_counts = [int(c) for c in eval_counts]
         if not self._design_counts:
@@ -110,17 +105,20 @@ class VariableObjectCountEnv(BaseEnv[ObjectCentricState, NDArray[Any]]):
         self._current_backend: ConstantObjectKinDEREnv | None = None
         self._current_count: int | None = None
         self._current_ocs: ObjectCentricState | None = None
+        self._configured_counts = sorted(
+            set(self._design_counts) | set(self._eval_counts)
+        )
         # prefixed-object-count -> constructor-kwarg value, so a bare state (set_state,
-        # init_state) can be routed to the right backend. Built for every configured
-        # count up front so inference never hits an un-built backend.
+        # init_state) can be routed to the right backend.
         self._prefixed_count_to_kwarg: dict[int, int] = {}
+        self._metadata_by_count: dict[int, dict[str, Any]] = {}
         try:
-            for count in sorted(set(self._design_counts) | set(self._eval_counts)):
-                self._backend_for(count)
-        except BaseException:
-            # In particular, do not leak already-created PyBullet clients when a
-            # later configured 3D count is infeasible or otherwise fails to build.
-            self.close()
+            self._backend_for(max(self._design_counts))
+        except BaseException as exc:
+            try:
+                self.close()
+            except Exception as cleanup_exc:  # pylint: disable=broad-exception-caught
+                exc.add_note(f"Backend cleanup also failed: {cleanup_exc}")
             raise
 
         # Largest design count: a count-0 exemplar omits the count-defining type row.
@@ -146,9 +144,13 @@ class VariableObjectCountEnv(BaseEnv[ObjectCentricState, NDArray[Any]]):
     @staticmethod
     def _close_backend(backend: ConstantObjectKinDEREnv) -> None:
         """Close one kinder backend and its currently unmanaged PyBullet client."""
-        backend.close()
         inner = backend._object_centric_env
-        inner.close()
+        errors: list[Exception] = []
+        for close_fn in (backend.close, inner.close):
+            try:
+                close_fn()
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                errors.append(exc)
         physics_client_id = getattr(inner, "physics_client_id", None)
         if physics_client_id is not None:
             # kinder currently has no kinematic3d close() implementation, so its
@@ -156,8 +158,13 @@ class VariableObjectCountEnv(BaseEnv[ObjectCentricState, NDArray[Any]]):
             # PyBullet only for backends that actually own a client.
             import pybullet as p  # pylint: disable=import-outside-toplevel
 
-            if p.isConnected(physics_client_id):
-                p.disconnect(physicsClientId=physics_client_id)
+            try:
+                if p.isConnected(physics_client_id):
+                    p.disconnect(physicsClientId=physics_client_id)
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                errors.append(exc)
+        if errors:
+            raise ExceptionGroup("Failed to close Kinder backend", errors)
 
     def _backend_for(self, count: int) -> ConstantObjectKinDEREnv:
         """Return (building + caching on first use) the backend for a given count."""
@@ -180,19 +187,10 @@ class VariableObjectCountEnv(BaseEnv[ObjectCentricState, NDArray[Any]]):
                     f"feasible object count. Lower the configured counts."
                 ) from exc
             try:
-                if self._render_dpi is not None:
-                    # The kinematic env's config is a frozen dataclass; set the field
-                    # through object.__setattr__ (render() reads config.render_dpi
-                    # fresh).
-                    object.__setattr__(
-                        backend._object_centric_env.config,
-                        "render_dpi",
-                        self._render_dpi,
-                    )
                 exemplar, _ = backend._object_centric_env.reset(seed=0)
                 prefixed_count = self._count_prefixed(exemplar)
-                if prefixed_count in self._prefixed_count_to_kwarg:
-                    other = self._prefixed_count_to_kwarg[prefixed_count]
+                other = self._prefixed_count_to_kwarg.get(prefixed_count)
+                if other is not None and other != count:
                     raise ValueError(
                         f"Cannot infer {self._count_kwarg} from prefix "
                         f"{self._count_object_prefix!r}: constructor values {other} "
@@ -203,6 +201,7 @@ class VariableObjectCountEnv(BaseEnv[ObjectCentricState, NDArray[Any]]):
                 raise
             self._backends[count] = backend
             self._prefixed_count_to_kwarg[prefixed_count] = count
+            self._metadata_by_count[count] = dict(backend.metadata)
         return backend
 
     def _count_prefixed(self, state: ObjectCentricState) -> int:
@@ -211,6 +210,11 @@ class VariableObjectCountEnv(BaseEnv[ObjectCentricState, NDArray[Any]]):
 
     def _infer_count(self, state: ObjectCentricState) -> int:
         prefixed = self._count_prefixed(state)
+        for count in self._configured_counts:
+            if prefixed in self._prefixed_count_to_kwarg:
+                break
+            if count not in self._prefixed_count_to_kwarg.values():
+                self._backend_for(count)
         try:
             return self._prefixed_count_to_kwarg[prefixed]
         except KeyError as exc:
@@ -317,9 +321,9 @@ class VariableObjectCountEnv(BaseEnv[ObjectCentricState, NDArray[Any]]):
             count = self._infer_count(state)
             backend = self._backend_for(count)
             state = self._coerce_state_for_backend(state, backend)
-            backend._object_centric_env.set_state(state)
-            ocs = backend._object_centric_env.get_state()
-            info = {}
+            ocs, info = backend._object_centric_env.reset(
+                seed=seed, options={"init_state": state}
+            )
         else:
             count = self._count_for_seed(seed)
             backend = self._backend_for(count)
@@ -371,12 +375,18 @@ class VariableObjectCountEnv(BaseEnv[ObjectCentricState, NDArray[Any]]):
 
     def close(self) -> None:
         """Close every cached backend, including kinematic3d PyBullet clients."""
-        for backend in self._backends.values():
-            self._close_backend(backend)
+        errors: list[Exception] = []
+        for backend in tuple(self._backends.values()):
+            try:
+                self._close_backend(backend)
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                errors.append(exc)
         self._backends.clear()
         self._current_backend = None
         self._current_count = None
         self._current_ocs = None
+        if errors:
+            raise ExceptionGroup("Failed to close variable-count backends", errors)
 
     # -- per-count Box view for the bilevel planner -------------------------
 
@@ -471,9 +481,12 @@ class VariableObjectCountEnv(BaseEnv[ObjectCentricState, NDArray[Any]]):
         and each wrapper writes it for its own fixed count, so a paragraph that differs
         between counts does not describe this env.
         """
+        for count in self._configured_counts:
+            if count not in self._metadata_by_count:
+                self._backend_for(count)
         per_count = [
-            self._backends[count].metadata[metadata_key].split("\n\n")
-            for count in sorted(self._backends)
+            self._metadata_by_count[count][metadata_key].split("\n\n")
+            for count in self._configured_counts
         ]
         first, *others = per_count
         return "\n\n".join(p for p in first if all(p in other for other in others))

--- a/src/robocode/environments/variable_object_count_env.py
+++ b/src/robocode/environments/variable_object_count_env.py
@@ -30,6 +30,7 @@ import importlib
 from typing import Any, SupportsFloat
 
 import numpy as np
+import pybullet as p
 from gymnasium.core import RenderFrame
 from kinder.core import ConstantObjectKinDEREnv
 from numpy.typing import NDArray
@@ -154,10 +155,7 @@ class VariableObjectCountEnv(BaseEnv[ObjectCentricState, NDArray[Any]]):
         physics_client_id = getattr(inner, "physics_client_id", None)
         if physics_client_id is not None:
             # kinder currently has no kinematic3d close() implementation, so its
-            # DIRECT clients otherwise survive for the process lifetime. Import
-            # PyBullet only for backends that actually own a client.
-            import pybullet as p  # pylint: disable=import-outside-toplevel
-
+            # DIRECT clients otherwise survive for the process lifetime.
             try:
                 if p.isConnected(physics_client_id):
                     p.disconnect(physicsClientId=physics_client_id)

--- a/src/robocode/environments/variable_object_count_env.py
+++ b/src/robocode/environments/variable_object_count_env.py
@@ -33,7 +33,7 @@ import numpy as np
 from gymnasium.core import RenderFrame
 from kinder.core import ConstantObjectKinDEREnv
 from numpy.typing import NDArray
-from relational_structs import ObjectCentricState
+from relational_structs import Object, ObjectCentricState
 
 from robocode.environments.base_env import BaseEnv
 from robocode.environments.mujoco_gl import configure_gl_backend
@@ -69,6 +69,7 @@ class VariableObjectCountEnv(BaseEnv[ObjectCentricState, NDArray[Any]]):
         count_object_prefix: str,
         design_counts: list[int],
         eval_counts: list[int],
+        constant_object_env_kwargs: dict[str, Any] | None = None,
         bilevel_env_name: str | None = None,
         base_steps: int = 300,
         steps_per_object: int = 150,
@@ -81,6 +82,12 @@ class VariableObjectCountEnv(BaseEnv[ObjectCentricState, NDArray[Any]]):
         self._env_cls = _load_constant_object_env_class(constant_object_env_path)
         self._count_kwarg = count_kwarg
         self._count_object_prefix = count_object_prefix
+        self._constant_object_env_kwargs = dict(constant_object_env_kwargs or {})
+        if self._count_kwarg in self._constant_object_env_kwargs:
+            raise ValueError(
+                f"constant_object_env_kwargs must not contain count_kwarg "
+                f"{self._count_kwarg!r}"
+            )
         # Evaluation horizon grows with the object count, so a larger instance is not
         # scored as failed merely for running out of steps before it could finish.
         self._base_steps = base_steps
@@ -100,12 +107,21 @@ class VariableObjectCountEnv(BaseEnv[ObjectCentricState, NDArray[Any]]):
         self.bilevel_env_name = bilevel_env_name
 
         self._backends: dict[int, ConstantObjectKinDEREnv] = {}
+        self._current_backend: ConstantObjectKinDEREnv | None = None
+        self._current_count: int | None = None
+        self._current_ocs: ObjectCentricState | None = None
         # prefixed-object-count -> constructor-kwarg value, so a bare state (set_state,
         # init_state) can be routed to the right backend. Built for every configured
         # count up front so inference never hits an un-built backend.
         self._prefixed_count_to_kwarg: dict[int, int] = {}
-        for count in sorted(set(self._design_counts) | set(self._eval_counts)):
-            self._backend_for(count)
+        try:
+            for count in sorted(set(self._design_counts) | set(self._eval_counts)):
+                self._backend_for(count)
+        except BaseException:
+            # In particular, do not leak already-created PyBullet clients when a
+            # later configured 3D count is infeasible or otherwise fails to build.
+            self.close()
+            raise
 
         # Largest design count: a count-0 exemplar omits the count-defining type row.
         ref_env = self._backend_for(max(self._design_counts))._object_centric_env
@@ -123,18 +139,35 @@ class VariableObjectCountEnv(BaseEnv[ObjectCentricState, NDArray[Any]]):
         setattr(self.observation_space, "get_type", self._type_by_name.__getitem__)
         self._reference_state, _ = ref_env.reset(seed=0)
 
-        self._current_backend: ConstantObjectKinDEREnv | None = None
-        self._current_count: int | None = None
-        self._current_ocs: ObjectCentricState | None = None
         super().__init__()
 
     # -- backends & count inference -----------------------------------------
+
+    @staticmethod
+    def _close_backend(backend: ConstantObjectKinDEREnv) -> None:
+        """Close one kinder backend and its currently unmanaged PyBullet client."""
+        backend.close()
+        inner = backend._object_centric_env
+        inner.close()
+        physics_client_id = getattr(inner, "physics_client_id", None)
+        if physics_client_id is not None:
+            # kinder currently has no kinematic3d close() implementation, so its
+            # DIRECT clients otherwise survive for the process lifetime. Import
+            # PyBullet only for backends that actually own a client.
+            import pybullet as p  # pylint: disable=import-outside-toplevel
+
+            if p.isConnected(physics_client_id):
+                p.disconnect(physicsClientId=physics_client_id)
 
     def _backend_for(self, count: int) -> ConstantObjectKinDEREnv:
         """Return (building + caching on first use) the backend for a given count."""
         backend = self._backends.get(count)
         if backend is None:
-            kwargs = {self._count_kwarg: count}
+            kwargs = {
+                **self._constant_object_env_kwargs,
+                self._count_kwarg: count,
+                "allow_state_access": True,
+            }
             try:
                 backend = self._env_cls(**kwargs)  # type: ignore[arg-type]
             except RuntimeError as exc:
@@ -146,15 +179,30 @@ class VariableObjectCountEnv(BaseEnv[ObjectCentricState, NDArray[Any]]):
                     f"{self._count_kwarg}={count}; it likely exceeds the family's "
                     f"feasible object count. Lower the configured counts."
                 ) from exc
+            try:
+                if self._render_dpi is not None:
+                    # The kinematic env's config is a frozen dataclass; set the field
+                    # through object.__setattr__ (render() reads config.render_dpi
+                    # fresh).
+                    object.__setattr__(
+                        backend._object_centric_env.config,
+                        "render_dpi",
+                        self._render_dpi,
+                    )
+                exemplar, _ = backend._object_centric_env.reset(seed=0)
+                prefixed_count = self._count_prefixed(exemplar)
+                if prefixed_count in self._prefixed_count_to_kwarg:
+                    other = self._prefixed_count_to_kwarg[prefixed_count]
+                    raise ValueError(
+                        f"Cannot infer {self._count_kwarg} from prefix "
+                        f"{self._count_object_prefix!r}: constructor values {other} "
+                        f"and {count} both create {prefixed_count} matching object(s)"
+                    )
+            except BaseException:
+                self._close_backend(backend)
+                raise
             self._backends[count] = backend
-            if self._render_dpi is not None:
-                # The kinematic env's config is a frozen dataclass; set the field
-                # through object.__setattr__ (render() reads config.render_dpi fresh).
-                object.__setattr__(
-                    backend._object_centric_env.config, "render_dpi", self._render_dpi
-                )
-            exemplar, _ = backend._object_centric_env.reset(seed=0)
-            self._prefixed_count_to_kwarg[self._count_prefixed(exemplar)] = count
+            self._prefixed_count_to_kwarg[prefixed_count] = count
         return backend
 
     def _count_prefixed(self, state: ObjectCentricState) -> int:
@@ -179,6 +227,56 @@ class VariableObjectCountEnv(BaseEnv[ObjectCentricState, NDArray[Any]]):
         ``options={"object_count": k}``.
         """
         return int(np.random.default_rng(seed).choice(self._design_counts))
+
+    @staticmethod
+    def _coerce_state_for_backend(
+        state: ObjectCentricState, backend: ConstantObjectKinDEREnv
+    ) -> ObjectCentricState:
+        """Rebuild *state* as the object-centric backend's concrete state class.
+
+        Kinematic3D uses ObjectCentricState subclasses with helpers such as
+        ``base_pose`` and ``joint_positions``. A state decoded from the black-box wire
+        is deliberately a plain ObjectCentricState, so passing it directly to the 3D
+        backend would fail during reset. Rebuilding it here is safe and generic: 2D
+        backends expect the base class and therefore take the fast path, while 3D
+        backends recover their family-specific class.
+
+        Object/type identities are also canonicalized to the backend schema. This
+        avoids coupling state restoration to the independently reconstructed Type
+        instances carried by the wire codec.
+        """
+        inner = backend._object_centric_env
+        state_cls = getattr(inner, "state_cls", ObjectCentricState)
+        canonical_features = inner.type_features
+        if isinstance(state, state_cls) and state.type_features is canonical_features:
+            return state
+
+        canonical_types = {typ.name: typ for typ in canonical_features}
+        data: dict[Object, NDArray[Any]] = {}
+        for source_obj in state:
+            try:
+                canonical_type = canonical_types[source_obj.type.name]
+            except KeyError as exc:
+                raise ValueError(
+                    f"State object {source_obj.name!r} has unknown type "
+                    f"{source_obj.type.name!r}"
+                ) from exc
+            source_features = state.type_features[source_obj.type]
+            source_values = {
+                name: state.get(source_obj, name) for name in source_features
+            }
+            expected_features = canonical_features[canonical_type]
+            missing = [name for name in expected_features if name not in source_values]
+            if missing:
+                raise ValueError(
+                    f"State object {source_obj.name!r} is missing feature(s): "
+                    f"{', '.join(missing)}"
+                )
+            canonical_obj = Object(source_obj.name, canonical_type)
+            data[canonical_obj] = np.asarray(
+                [source_values[name] for name in expected_features], dtype=np.float32
+            )
+        return state_cls(data, canonical_features)
 
     @property
     def design_counts(self) -> list[int]:
@@ -218,9 +316,10 @@ class VariableObjectCountEnv(BaseEnv[ObjectCentricState, NDArray[Any]]):
             state = options["init_state"]
             count = self._infer_count(state)
             backend = self._backend_for(count)
-            ocs, info = backend._object_centric_env.reset(
-                seed=seed, options={"init_state": state}
-            )
+            state = self._coerce_state_for_backend(state, backend)
+            backend._object_centric_env.set_state(state)
+            ocs = backend._object_centric_env.get_state()
+            info = {}
         else:
             count = self._count_for_seed(seed)
             backend = self._backend_for(count)
@@ -258,7 +357,9 @@ class VariableObjectCountEnv(BaseEnv[ObjectCentricState, NDArray[Any]]):
     def set_state(self, state: ObjectCentricState) -> None:
         count = self._infer_count(state)
         backend = self._backend_for(count)
-        ocs, _ = backend._object_centric_env.reset(options={"init_state": state})
+        state = self._coerce_state_for_backend(state, backend)
+        backend._object_centric_env.set_state(state)
+        ocs = backend._object_centric_env.get_state()
         self._current_backend = backend
         self._current_count = count
         self._current_ocs = ocs
@@ -267,6 +368,15 @@ class VariableObjectCountEnv(BaseEnv[ObjectCentricState, NDArray[Any]]):
         assert self._current_backend is not None, "Must call reset()"
         inner = self._current_backend._object_centric_env
         return inner.render()  # type: ignore[no-untyped-call,return-value]
+
+    def close(self) -> None:
+        """Close every cached backend, including kinematic3d PyBullet clients."""
+        for backend in self._backends.values():
+            self._close_backend(backend)
+        self._backends.clear()
+        self._current_backend = None
+        self._current_count = None
+        self._current_ocs = None
 
     # -- per-count Box view for the bilevel planner -------------------------
 
@@ -386,6 +496,11 @@ class VariableObjectCountEnv(BaseEnv[ObjectCentricState, NDArray[Any]]):
             if self.bilevel_env_name is not None
             else ""
         )
+        fixed_kwargs_example_arg = (
+            f"    constant_object_env_kwargs={self._constant_object_env_kwargs!r},\n"
+            if self._constant_object_env_kwargs
+            else ""
+        )
         return description + (
             "## Example Usage\n\n"
             "```python\n"
@@ -395,6 +510,7 @@ class VariableObjectCountEnv(BaseEnv[ObjectCentricState, NDArray[Any]]):
             f'    constant_object_env_path="{self._env_path}",\n'
             f'    count_kwarg="{self._count_kwarg}",\n'
             f'    count_object_prefix="{self._count_object_prefix}",\n'
+            f"{fixed_kwargs_example_arg}"
             f"{bilevel_example_arg}"
             "    design_counts=[<count list>],\n"
             "    eval_counts=[<count list>],\n"
@@ -403,7 +519,8 @@ class VariableObjectCountEnv(BaseEnv[ObjectCentricState, NDArray[Any]]):
             "state, info = env.reset(seed=0, options={'object_count': 3})\n"
             "for name in state.get_object_names():\n"
             "    obj = state.get_object_from_name(name)\n"
-            "    x = state.get(obj, 'x')  # read a feature of an object\n\n"
+            "    feature = env.type_features[obj.type][0]\n"
+            "    value = state.get(obj, feature)  # read a feature of an object\n\n"
             "action = env.action_space.sample()\n"
             "state, reward, terminated, truncated, info = env.step(action)\n"
             "saved = env.get_state()      # an ObjectCentricState\n"

--- a/src/robocode/utils/env_server.py
+++ b/src/robocode/utils/env_server.py
@@ -125,8 +125,21 @@ def encode(obj: Any) -> Any:
         return {key: encode(value) for key, value in obj.items()}
     if isinstance(obj, (list, tuple)):
         return [encode(value) for value in obj]
-    if type(obj) in _ENCODERS:
-        tag, encode_fn = _ENCODERS[type(obj)]
+    # Prefer an exact registration, then allow a codec registered for a base class.
+    # Kinematic3D observations are family-specific ObjectCentricState subclasses and
+    # intentionally share the ObjectCentricState wire format.
+    codec = _ENCODERS.get(type(obj))
+    if codec is None:
+        codec = next(
+            (
+                registered_codec
+                for cls, registered_codec in _ENCODERS.items()
+                if isinstance(obj, cls)
+            ),
+            None,
+        )
+    if codec is not None:
+        tag, encode_fn = codec
         return {tag: encode_fn(obj)}
     raise TypeError(
         f"No codec for type {type(obj).__name__}; register one with "

--- a/tests/environments/test_kinder_geom3d_env.py
+++ b/tests/environments/test_kinder_geom3d_env.py
@@ -10,7 +10,6 @@ import pytest
 from robocode.environments.kinder_geom3d_env import KinderGeom3DEnv
 
 ALL_3D_ENV_IDS = [
-    "kinder/Motion3D-v0",
     "kinder/Obstruction3D-o0-v0",
     "kinder/Obstruction3D-o2-v0",
     "kinder/Obstruction3D-o4-v0",

--- a/tests/environments/test_variable_object_count_3d_env.py
+++ b/tests/environments/test_variable_object_count_3d_env.py
@@ -82,7 +82,7 @@ def test_kinematic3d_family_supports_variable_count_roundtrip(
         constant_object_env_kwargs={"realistic_bg": False, **fixed_kwargs},
     )
     physics_client_ids = [
-        backend._object_centric_env.physics_client_id  # pylint: disable=protected-access
+        getattr(backend._object_centric_env, "physics_client_id")
         for backend in env._backends.values()  # pylint: disable=protected-access
     ]
     try:

--- a/tests/environments/test_variable_object_count_3d_env.py
+++ b/tests/environments/test_variable_object_count_3d_env.py
@@ -8,6 +8,7 @@ import pybullet as p
 import pytest
 from relational_structs import ObjectCentricState
 
+from robocode.environments.constrained_cupboard3d import ConstrainedCupboard3DEnv
 from robocode.environments.variable_object_count_env import VariableObjectCountEnv
 from robocode.utils.object_centric_codec import (
     decode_object_centric_state,
@@ -81,10 +82,7 @@ def test_kinematic3d_family_supports_variable_count_roundtrip(
         eval_counts=[1, 2],
         constant_object_env_kwargs={"realistic_bg": False, **fixed_kwargs},
     )
-    physics_client_ids = [
-        getattr(getattr(backend, "_object_centric_env"), "physics_client_id")
-        for backend in env._backends.values()  # pylint: disable=protected-access
-    ]
+    physics_client_ids = []
     try:
         state, info = env.reset(seed=2, options={"object_count": 2})
         assert info["object_count"] == 2
@@ -104,10 +102,8 @@ def test_kinematic3d_family_supports_variable_count_roundtrip(
         if exact_roundtrip:
             assert restored.allclose(state)
         else:
-            # The pending fix/packing3d-geometry-validity-stacked branch must make
-            # triangle poses and randomized part geometry round-trip exactly. Until
-            # then, test the shared routing/rehydration path without claiming that
-            # the upstream simulator restored the same physical state.
+            # The pinned Kinder revision does not preserve Packing3D's randomized
+            # part geometry during restoration, so this checks only shared routing.
             assert restored.get_object_names() == state.get_object_names()
 
         next_state, _, _, _, step_info = env.step(env.action_space.sample())
@@ -126,6 +122,10 @@ def test_kinematic3d_family_supports_variable_count_roundtrip(
         assert "constant_object_env_kwargs=" in card
         assert "state.get(obj, 'x')" not in card  # invalid for most 3D types
     finally:
+        physics_client_ids.extend(
+            getattr(getattr(backend, "_object_centric_env"), "physics_client_id")
+            for backend in env._backends.values()  # pylint: disable=protected-access
+        )
         env.close()
 
     # The wrapper owns all per-count PyBullet clients and must release them.
@@ -171,7 +171,7 @@ def test_constrainedcupboard3d_uses_registered_object_counts() -> None:
             "robocode.environments.constrained_cupboard3d:ConstrainedCupboard3DEnv"
         ),
         count_kwarg="num_objects",
-        count_object_prefix="cuboid",
+        count_object_prefix="cuboid_",
         design_counts=[1, 2],
         eval_counts=[1, 2, 6],
         constant_object_env_kwargs={"scene_bg": False},
@@ -180,7 +180,9 @@ def test_constrainedcupboard3d_uses_registered_object_counts() -> None:
         for count in env.eval_counts:
             state, info = env.reset(seed=0, options={"object_count": count})
             assert info["object_count"] == count
-            assert _num_prefixed(state, "cuboid") == count
+            assert _num_prefixed(state, "cuboid_") == count
+
+        assert "`cuboid_0`, `cuboid_1`, ..." in env.env_description
 
         decoded = decode_object_centric_state(encode_object_centric_state(state))
         env.set_state(decoded)
@@ -188,3 +190,23 @@ def test_constrainedcupboard3d_uses_registered_object_counts() -> None:
         assert env.get_state().allclose(state)
     finally:
         env.close()
+
+
+def test_constrainedcupboard3d_adapter_kwargs() -> None:
+    """The adapter owns its task path while allowing a camera override."""
+    with pytest.raises(ValueError, match="selects task_config_path"):
+        ConstrainedCupboard3DEnv(
+            num_objects=1,
+            task_config_path="ignored.json",
+        )
+
+    env = ConstrainedCupboard3DEnv(
+        num_objects=1,
+        scene_bg=False,
+        scene_render_camera="task_view",
+    )
+    try:
+        env.reset(seed=0)
+    finally:
+        env.close()
+        getattr(env, "_object_centric_env").close()

--- a/tests/environments/test_variable_object_count_3d_env.py
+++ b/tests/environments/test_variable_object_count_3d_env.py
@@ -21,7 +21,6 @@ _FAMILY_CASES = [
         "num_cubes",
         "cube",
         {},
-        True,
         id="table3d-cubes",
     ),
     pytest.param(
@@ -29,7 +28,6 @@ _FAMILY_CASES = [
         "num_cubes",
         "cube",
         {"num_boxes": 1},
-        True,
         id="transport3d-cubes",
     ),
     pytest.param(
@@ -37,7 +35,6 @@ _FAMILY_CASES = [
         "num_cubes",
         "cube",
         {},
-        True,
         id="shelf3d-cubes",
     ),
     pytest.param(
@@ -45,7 +42,6 @@ _FAMILY_CASES = [
         "num_obstructions",
         "obstruction",
         {},
-        True,
         id="obstruction3d-obstructions",
     ),
     pytest.param(
@@ -53,7 +49,6 @@ _FAMILY_CASES = [
         "num_parts",
         "part",
         {},
-        False,
         id="packing3d-parts",
     ),
 ]
@@ -63,15 +58,12 @@ def _num_prefixed(state: ObjectCentricState, prefix: str) -> int:
     return sum(name.startswith(prefix) for name in state.get_object_names())
 
 
-@pytest.mark.parametrize(
-    "path,count_kwarg,prefix,fixed_kwargs,exact_roundtrip", _FAMILY_CASES
-)
+@pytest.mark.parametrize("path,count_kwarg,prefix,fixed_kwargs", _FAMILY_CASES)
 def test_kinematic3d_family_supports_variable_count_roundtrip(
     path: str,
     count_kwarg: str,
     prefix: str,
     fixed_kwargs: dict[str, Any],
-    exact_roundtrip: bool,
 ) -> None:
     """Every 3D count axis supports pinned reset, wire-style restore, and step."""
     env = VariableObjectCountEnv(
@@ -99,12 +91,7 @@ def test_kinematic3d_family_supports_variable_count_roundtrip(
         env.set_state(decoded)
         restored = env.get_state()
         assert restored.__class__ is state.__class__
-        if exact_roundtrip:
-            assert restored.allclose(state)
-        else:
-            # The pinned Kinder revision does not preserve Packing3D's randomized
-            # part geometry during restoration, so this checks only shared routing.
-            assert restored.get_object_names() == state.get_object_names()
+        assert restored.allclose(state)
 
         next_state, _, _, _, step_info = env.step(env.action_space.sample())
         assert next_state.__class__ is state.__class__

--- a/tests/environments/test_variable_object_count_3d_env.py
+++ b/tests/environments/test_variable_object_count_3d_env.py
@@ -82,7 +82,7 @@ def test_kinematic3d_family_supports_variable_count_roundtrip(
         eval_counts=[1, 2],
         constant_object_env_kwargs={"realistic_bg": False, **fixed_kwargs},
     )
-    physics_client_ids = []
+    physics_client_ids: list[int] = []
     try:
         state, info = env.reset(seed=2, options={"object_count": 2})
         assert info["object_count"] == 2

--- a/tests/environments/test_variable_object_count_3d_env.py
+++ b/tests/environments/test_variable_object_count_3d_env.py
@@ -165,15 +165,15 @@ def test_transport3d_varies_cubes_with_one_box() -> None:
 
 
 def test_constrainedcupboard3d_uses_registered_object_counts() -> None:
-    """ConstrainedCupboard3D selects its existing one, two, and six-rod tasks."""
+    """ConstrainedCupboard3D selects its registered one-through-six-rod tasks."""
     env = VariableObjectCountEnv(
         constant_object_env_path=(
             "robocode.environments.constrained_cupboard3d:ConstrainedCupboard3DEnv"
         ),
         count_kwarg="num_objects",
         count_object_prefix="cuboid_",
-        design_counts=[1, 2],
-        eval_counts=[1, 2, 6],
+        design_counts=[1, 2, 3],
+        eval_counts=[1, 2, 3, 4, 5, 6],
         constant_object_env_kwargs={"scene_bg": False},
     )
     try:

--- a/tests/environments/test_variable_object_count_3d_env.py
+++ b/tests/environments/test_variable_object_count_3d_env.py
@@ -82,7 +82,7 @@ def test_kinematic3d_family_supports_variable_count_roundtrip(
         constant_object_env_kwargs={"realistic_bg": False, **fixed_kwargs},
     )
     physics_client_ids = [
-        getattr(backend._object_centric_env, "physics_client_id")
+        getattr(getattr(backend, "_object_centric_env"), "physics_client_id")
         for backend in env._backends.values()  # pylint: disable=protected-access
     ]
     try:

--- a/tests/environments/test_variable_object_count_3d_env.py
+++ b/tests/environments/test_variable_object_count_3d_env.py
@@ -1,0 +1,190 @@
+"""Kinematic3D coverage for the shared variable-object-count environment."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pybullet as p
+import pytest
+from relational_structs import ObjectCentricState
+
+from robocode.environments.variable_object_count_env import VariableObjectCountEnv
+from robocode.utils.object_centric_codec import (
+    decode_object_centric_state,
+    encode_object_centric_state,
+)
+
+_FAMILY_CASES = [
+    pytest.param(
+        "kinder.envs.kinematic3d.table3d:Table3DEnv",
+        "num_cubes",
+        "cube",
+        {},
+        True,
+        id="table3d-cubes",
+    ),
+    pytest.param(
+        "kinder.envs.kinematic3d.transport3d:Transport3DEnv",
+        "num_cubes",
+        "cube",
+        {"num_boxes": 1},
+        True,
+        id="transport3d-cubes",
+    ),
+    pytest.param(
+        "kinder.envs.kinematic3d.shelf3d:Shelf3DEnv",
+        "num_cubes",
+        "cube",
+        {},
+        True,
+        id="shelf3d-cubes",
+    ),
+    pytest.param(
+        "kinder.envs.kinematic3d.obstruction3d:Obstruction3DEnv",
+        "num_obstructions",
+        "obstruction",
+        {},
+        True,
+        id="obstruction3d-obstructions",
+    ),
+    pytest.param(
+        "kinder.envs.kinematic3d.packing3d:Packing3DEnv",
+        "num_parts",
+        "part",
+        {},
+        False,
+        id="packing3d-parts",
+    ),
+]
+
+
+def _num_prefixed(state: ObjectCentricState, prefix: str) -> int:
+    return sum(name.startswith(prefix) for name in state.get_object_names())
+
+
+@pytest.mark.parametrize(
+    "path,count_kwarg,prefix,fixed_kwargs,exact_roundtrip", _FAMILY_CASES
+)
+def test_kinematic3d_family_supports_variable_count_roundtrip(
+    path: str,
+    count_kwarg: str,
+    prefix: str,
+    fixed_kwargs: dict[str, Any],
+    exact_roundtrip: bool,
+) -> None:
+    """Every 3D count axis supports pinned reset, wire-style restore, and step."""
+    env = VariableObjectCountEnv(
+        constant_object_env_path=path,
+        count_kwarg=count_kwarg,
+        count_object_prefix=prefix,
+        design_counts=[1],
+        eval_counts=[1, 2],
+        constant_object_env_kwargs={"realistic_bg": False, **fixed_kwargs},
+    )
+    physics_client_ids = [
+        backend._object_centric_env.physics_client_id  # pylint: disable=protected-access
+        for backend in env._backends.values()  # pylint: disable=protected-access
+    ]
+    try:
+        state, info = env.reset(seed=2, options={"object_count": 2})
+        assert info["object_count"] == 2
+        assert env.current_count == 2
+        assert _num_prefixed(state, prefix) == 2
+        assert state.__class__ is not ObjectCentricState
+        assert env.observation_space.contains(state)
+
+        # The black-box codec intentionally reconstructs the portable base class.
+        # set_state() must rehydrate the backend's specialized 3D state class before
+        # its robot/grasp helpers are used.
+        decoded = decode_object_centric_state(encode_object_centric_state(state))
+        assert decoded.__class__ is ObjectCentricState
+        env.set_state(decoded)
+        restored = env.get_state()
+        assert restored.__class__ is state.__class__
+        if exact_roundtrip:
+            assert restored.allclose(state)
+        else:
+            # The pending fix/packing3d-geometry-validity-stacked branch must make
+            # triangle poses and randomized part geometry round-trip exactly. Until
+            # then, test the shared routing/rehydration path without claiming that
+            # the upstream simulator restored the same physical state.
+            assert restored.get_object_names() == state.get_object_names()
+
+        next_state, _, _, _, step_info = env.step(env.action_space.sample())
+        assert next_state.__class__ is state.__class__
+        assert step_info["object_count"] == 2
+        assert env.to_box(next_state).ndim == 1
+
+        # The init_state reset route needs the same rehydration as set_state().
+        reset_state, reset_info = env.reset(options={"init_state": decoded})
+        assert reset_state.__class__ is state.__class__
+        assert reset_info["object_count"] == 2
+
+        card = env.env_description
+        assert "VARIABLE number of objects" in card
+        assert prefix in card
+        assert "constant_object_env_kwargs=" in card
+        assert "state.get(obj, 'x')" not in card  # invalid for most 3D types
+    finally:
+        env.close()
+
+    # The wrapper owns all per-count PyBullet clients and must release them.
+    assert all(not p.isConnected(client_id) for client_id in physics_client_ids)
+
+
+def test_transport3d_varies_cubes_with_one_box() -> None:
+    """Transport3D keeps one box while varying its cube count."""
+    env = VariableObjectCountEnv(
+        constant_object_env_path=("kinder.envs.kinematic3d.transport3d:Transport3DEnv"),
+        count_kwarg="num_cubes",
+        count_object_prefix="cube",
+        design_counts=[1],
+        eval_counts=[1, 4],
+        constant_object_env_kwargs={
+            "num_boxes": 1,
+            "realistic_bg": False,
+        },
+    )
+    try:
+        design_state, _ = env.reset(seed=0, options={"object_count": 1})
+        assert _num_prefixed(design_state, "cube") == 1
+        assert _num_prefixed(design_state, "box") == 1
+
+        eval_state, info = env.reset(seed=0, options={"object_count": 4})
+        assert info["object_count"] == 4
+        assert _num_prefixed(eval_state, "cube") == 4
+        assert _num_prefixed(eval_state, "box") == 1
+
+        decoded = decode_object_centric_state(encode_object_centric_state(eval_state))
+        env.set_state(decoded)
+        assert env.current_count == 4
+        assert env.get_state().allclose(eval_state)
+
+    finally:
+        env.close()
+
+
+def test_constrainedcupboard3d_uses_registered_object_counts() -> None:
+    """ConstrainedCupboard3D selects its existing one, two, and six-rod tasks."""
+    env = VariableObjectCountEnv(
+        constant_object_env_path=(
+            "robocode.environments.constrained_cupboard3d:ConstrainedCupboard3DEnv"
+        ),
+        count_kwarg="num_objects",
+        count_object_prefix="cuboid",
+        design_counts=[1, 2],
+        eval_counts=[1, 2, 6],
+        constant_object_env_kwargs={"scene_bg": False},
+    )
+    try:
+        for count in env.eval_counts:
+            state, info = env.reset(seed=0, options={"object_count": count})
+            assert info["object_count"] == count
+            assert _num_prefixed(state, "cuboid") == count
+
+        decoded = decode_object_centric_state(encode_object_centric_state(state))
+        env.set_state(decoded)
+        assert env.current_count == 6
+        assert env.get_state().allclose(state)
+    finally:
+        env.close()

--- a/tests/environments/test_variable_object_count_env.py
+++ b/tests/environments/test_variable_object_count_env.py
@@ -113,11 +113,15 @@ def test_sample_next_state_with_object_centric_state() -> None:
 
 
 def test_infeasible_count_raises_clearly() -> None:
-    """A configured count the scene cannot fit fails with an informative error."""
-    with pytest.raises(ValueError, match="feasible object count|could not build"):
-        VariableObjectCountEnv(
-            **{**OBSTRUCTION2D, "design_counts": [0], "eval_counts": [0, 8]}
-        )
+    """A requested count the scene cannot fit fails with an informative error."""
+    env = VariableObjectCountEnv(
+        **{**OBSTRUCTION2D, "design_counts": [0], "eval_counts": [0, 8]}
+    )
+    try:
+        with pytest.raises(ValueError, match="feasible object count|could not build"):
+            env.reset(seed=0, options={"object_count": 8})
+    finally:
+        env.close()
 
 
 def test_fixed_constructor_kwargs_cannot_override_count_kwarg() -> None:
@@ -131,15 +135,74 @@ def test_fixed_constructor_kwargs_cannot_override_count_kwarg() -> None:
 
 def test_ambiguous_count_prefix_is_rejected() -> None:
     """Two count values may not map to the same number of prefixed objects."""
-    with pytest.raises(ValueError, match="Cannot infer.*constructor values"):
-        VariableObjectCountEnv(
-            **{
-                **OBSTRUCTION2D,
-                "count_object_prefix": "robot",  # always exactly one
-                "design_counts": [0, 1],
-                "eval_counts": [0, 1],
-            }
-        )
+    env = VariableObjectCountEnv(
+        **{
+            **OBSTRUCTION2D,
+            "count_object_prefix": "robot",  # always exactly one
+            "design_counts": [0, 1],
+            "eval_counts": [0, 1],
+        }
+    )
+    try:
+        with pytest.raises(ValueError, match="Cannot infer.*constructor values"):
+            env.reset(seed=0, options={"object_count": 0})
+    finally:
+        env.close()
+
+
+def test_backends_are_built_lazily() -> None:
+    """Construction opens only the design-reference backend."""
+    env = VariableObjectCountEnv(**OBSTRUCTION2D)
+    backends = getattr(env, "_backends")
+    assert set(backends) == {max(env.design_counts)}
+    env.reset(seed=0, options={"object_count": 4})
+    assert set(backends) == {max(env.design_counts), 4}
+    env.close()
+
+
+def test_init_state_reset_preserves_seed() -> None:
+    """Restoring an initial state still reseeds the selected Kinder backend."""
+    env = VariableObjectCountEnv(**OBSTRUCTION2D)
+    state, _ = env.reset(seed=0, options={"object_count": 1})
+    env.reset(seed=99, options={"object_count": 1})
+    env.reset(seed=7, options={"init_state": state})
+    backend = getattr(env, "_current_backend")
+    inner = getattr(backend, "_object_centric_env")
+    actual = int(inner.np_random.integers(2**31))
+    expected = int(np.random.default_rng(7).integers(2**31))
+    assert actual == expected
+    env.close()
+
+
+def test_close_allows_reuse_and_description() -> None:
+    """Closing releases backends without corrupting routing or metadata."""
+    env = VariableObjectCountEnv(**OBSTRUCTION2D)
+    description = env.env_description
+    env.close()
+    assert env.env_description == description
+    state, info = env.reset(seed=0, options={"object_count": 1})
+    assert info["object_count"] == 1
+    assert env.infer_count(state) == 1
+    env.close()
+
+
+def test_close_attempts_every_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failing backend close does not prevent cleanup of the others."""
+    env = VariableObjectCountEnv(**OBSTRUCTION2D)
+    env.reset(seed=0, options={"object_count": 0})
+    backends = list(getattr(env, "_backends").values())
+    attempted: list[Any] = []
+
+    def _close(backend: Any) -> None:
+        attempted.append(backend)
+        if backend is backends[0]:
+            raise RuntimeError("close failed")
+
+    monkeypatch.setattr(env, "_close_backend", _close)
+    with pytest.raises(ExceptionGroup, match="Failed to close"):
+        env.close()
+    assert attempted == backends
+    assert not getattr(env, "_backends")
 
 
 def test_description_is_object_centric() -> None:

--- a/tests/environments/test_variable_object_count_env.py
+++ b/tests/environments/test_variable_object_count_env.py
@@ -120,6 +120,28 @@ def test_infeasible_count_raises_clearly() -> None:
         )
 
 
+def test_fixed_constructor_kwargs_cannot_override_count_kwarg() -> None:
+    """The varying constructor argument has one unambiguous source."""
+    with pytest.raises(ValueError, match="must not contain count_kwarg"):
+        VariableObjectCountEnv(
+            **OBSTRUCTION2D,
+            constant_object_env_kwargs={"num_obstructions": 3},
+        )
+
+
+def test_ambiguous_count_prefix_is_rejected() -> None:
+    """Two count values may not map to the same number of prefixed objects."""
+    with pytest.raises(ValueError, match="Cannot infer.*constructor values"):
+        VariableObjectCountEnv(
+            **{
+                **OBSTRUCTION2D,
+                "count_object_prefix": "robot",  # always exactly one
+                "design_counts": [0, 1],
+                "eval_counts": [0, 1],
+            }
+        )
+
+
 def test_description_is_object_centric() -> None:
     """The env card describes an object-centric, variable-count observation."""
     env = VariableObjectCountEnv(**OBSTRUCTION2D)

--- a/tests/scripts/test_render_generalized_3d_initial_states.py
+++ b/tests/scripts/test_render_generalized_3d_initial_states.py
@@ -1,0 +1,30 @@
+"""Tests for the generalized 3D initial-state GIF renderer."""
+
+import importlib.util
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+_SCRIPT_PATH = (
+    Path(__file__).parents[2] / "scripts" / "render_generalized_3d_initial_states.py"
+)
+_SPEC = importlib.util.spec_from_file_location("generalized_3d_renderer", _SCRIPT_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+_annotate = getattr(_MODULE, "_annotate")
+_render_config = getattr(_MODULE, "_render_config")
+
+
+def test_render_config_requires_a_seed(tmp_path: Path) -> None:
+    """An empty train-and-eval request fails before any environment is built."""
+    with pytest.raises(ValueError, match="At least one"):
+        _render_config("unused", tmp_path, 0, 0, 42, 5, 480)
+
+
+def test_annotate_resizes_frame() -> None:
+    """The render-width option changes the stored frame resolution."""
+    frame = np.zeros((100, 200, 3), dtype=np.uint8)
+    annotated = _annotate(frame, "test", "eval", 1, 1, 42, 3, 480)
+    assert annotated.shape == (240, 480, 3)

--- a/tests/utils/test_bilevel.py
+++ b/tests/utils/test_bilevel.py
@@ -67,7 +67,6 @@ def test_infer_bilevel_mapping_none_for_unsupported() -> None:
     """Envs with no bilevel model (pushpullhook, 3D) infer to (None, {})."""
     for env_id in (
         "kinder/PushPullHook2D-v0",
-        "kinder/Motion3D-v0",
         "kinder/Obstruction3D-o2-v0",
     ):
         assert infer_bilevel_mapping(env_id) == (None, {})

--- a/tests/utils/test_object_centric_codec.py
+++ b/tests/utils/test_object_centric_codec.py
@@ -36,6 +36,19 @@ _OBSTRUCTION2D_CFG = (
     / "environment"
     / "obstruction2d_generalized.yaml"
 )
+_OBSTRUCTION3D_CFG = {
+    "_target_": (
+        "robocode.environments.variable_object_count_env.VariableObjectCountEnv"
+    ),
+    "constant_object_env_path": (
+        "kinder.envs.kinematic3d.obstruction3d:Obstruction3DEnv"
+    ),
+    "count_kwarg": "num_obstructions",
+    "count_object_prefix": "obstruction",
+    "design_counts": [0, 1],
+    "eval_counts": [0, 1, 2],
+    "constant_object_env_kwargs": {"realistic_bg": False},
+}
 
 
 def _env() -> VariableObjectCountEnv:
@@ -140,13 +153,19 @@ def _load_env_client(metadata_path: pathlib.Path):
 
 
 @contextmanager
-def _blackbox_client(primitive_names: list[str]):
-    """Serve obstruction2d_generalized over the wire; yield (client_module, client_env).
+def _blackbox_client(
+    primitive_names: list[str], env_config: dict[str, Any] | None = None
+):
+    """Serve a variable-count env over the wire; yield (client_module, client_env).
 
     Mirrors what a black-box sandbox sees: a live env server plus an ``env_client``
     built from ``env_spaces.json`` with the requested primitives.
     """
-    cfg = OmegaConf.load(_OBSTRUCTION2D_CFG)
+    cfg = (
+        OmegaConf.load(_OBSTRUCTION2D_CFG)
+        if env_config is None
+        else OmegaConf.create(env_config)
+    )
     container = OmegaConf.to_container(cfg, resolve=True)
     assert isinstance(container, dict)
     kwargs: dict[str, Any] = {
@@ -154,25 +173,28 @@ def _blackbox_client(primitive_names: list[str]):
     }
     host_env = VariableObjectCountEnv(**kwargs)
     env_cfg_json = json.dumps(container)
-    with tempfile.TemporaryDirectory() as tmp:
-        sandbox = pathlib.Path(tmp) / "sandbox"
-        sandbox.mkdir()
-        with env_server_running(env_cfg_json, sandbox) as (port, token):
-            write_env_spaces(
-                sandbox,
-                container_backend="local",
-                port=port,
-                token=token,
-                observation_space=host_env.observation_space,
-                action_space=host_env.action_space,
-                max_steps=200,
-                primitives_manifest=blackbox_primitive_manifest(primitive_names),
-            )
-            client_mod, env = _load_env_client(sandbox / "env_spaces.json")
-            try:
-                yield client_mod, env
-            finally:
-                env.close()
+    try:
+        with tempfile.TemporaryDirectory() as tmp:
+            sandbox = pathlib.Path(tmp) / "sandbox"
+            sandbox.mkdir()
+            with env_server_running(env_cfg_json, sandbox) as (port, token):
+                write_env_spaces(
+                    sandbox,
+                    container_backend="local",
+                    port=port,
+                    token=token,
+                    observation_space=host_env.observation_space,
+                    action_space=host_env.action_space,
+                    max_steps=200,
+                    primitives_manifest=blackbox_primitive_manifest(primitive_names),
+                )
+                client_mod, env = _load_env_client(sandbox / "env_spaces.json")
+                try:
+                    yield client_mod, env
+                finally:
+                    env.close()
+    finally:
+        host_env.close()
 
 
 def test_blackbox_object_centric_loop() -> None:
@@ -203,6 +225,27 @@ def test_blackbox_object_centric_loop() -> None:
             env.get_state(), env.action_space.sample()
         )
         assert isinstance(collision, bool)
+
+
+def test_blackbox_kinematic3d_state_restore() -> None:
+    """A sandbox-local state is rehydrated to its specialized 3D class on restore."""
+    with _blackbox_client([], _OBSTRUCTION3D_CFG) as (client_mod, env):
+        state, info = env.reset(seed=3, options={"object_count": 2})
+        # pylint: disable-next=protected-access
+        assert isinstance(state, client_mod._ObjectCentricState)
+        assert info["object_count"] == 2
+
+        env.step(env.action_space.sample())
+        env.set_state(state)
+        restored = env.get_state()
+        assert state.allclose(restored)
+
+        # Stepping proves the host reconstructed Obstruction3DObjectCentricState;
+        # the plain decoded base class lacks the robot pose helpers step/reset use.
+        next_state, _, _, _, step_info = env.step(env.action_space.sample())
+        # pylint: disable-next=protected-access
+        assert isinstance(next_state, client_mod._ObjectCentricState)
+        assert step_info["object_count"] == 2
 
 
 def test_blackbox_crv_remote_module_receives_local_ocs() -> None:


### PR DESCRIPTION
## Summary

This extends the existing variable-object-count infrastructure from Kinder 2D to the Kinder 3D kinematic families where the count parameter produces meaningful, sampleable instances.

A single generated program now receives variable-length `ObjectCentricState` observations and can be evaluated across different 3D object counts without changing its observation schema.

## Environment configurations

| Environment | Design counts | Evaluation counts | Design choice |
| --- | --- | --- | --- |
| Table3D | 1, 2, 3, 4 | 1, 2, 3, 4, 6, 8, 10 | Train on modest table occupancy and test increasingly dense scenes. |
| Transport3D | 1, 2 cubes | 1, 2, 3, 4 cubes | Keep exactly one box and vary only cubes, so this remains one experiment and isolates count generalization. |
| Shelf3D | 1, 2, 3 | 1, 2, 3, 5, 10 | Include substantially larger held-out shelf populations. |
| Obstruction3D | 0, 1, 2 | 0, 1, 2, 3, 4 | Include the zero-obstruction base case and held-out clutter. |
| Packing3D | 1, 2 | 1, 2, 3 | Use the largest currently geometry-valid count as the held-out case. |
| ConstrainedCupboard3D | 1, 2, 3 | 1, 2, 3, 4, 5, 6 | Train on small cupboards, then evaluate across the full progressive one-through-six-rod family. |

PRPLLab3D is intentionally omitted. ConstrainedCupboard3D gives us a more useful variable-count generalization setting.

## Infrastructure choices

- Reuse `VariableObjectCountEnv` and cache one fixed-count Kinder backend per configured count.
- Allow fixed backend kwargs independently of the count. Transport uses this to keep `num_boxes=1`, and Cupboard uses a fixed scene background.
- Support the specialized kinematic-3D state subclasses:
  - the environment-server codec now accepts subclasses of registered object-centric state types;
  - states reconstructed from the black-box wire are canonicalized to the selected backend's types/features and rebuilt as its concrete state class before restoration.
- Enable state access on each Kinder backend, so reset/get/set state works consistently.
- Close every cached backend and explicitly disconnect its PyBullet client. Partial initialization also cleans up already-created clients.
- Validate configured counts eagerly and reject ambiguous count-prefix mappings or infeasible instances with count-specific errors.
- Scale the episode horizon with object count, with larger budgets for Transport3D and ConstrainedCupboard3D.

The ConstrainedCupboard adapter selects the registered task JSON by rod count. Following Tom’s feedback, merged [Kinder PR #146](https://github.com/Princeton-Robot-Planning-and-Learning/kindergarden/pull/146) adds upstream tasks for counts 3, 4, and 5, so Robocode now supports the full one-through-six-rod family. Counts 3 and 4 use a moderately wider cupboard; counts 5 and 6 use the largest cupboard layout. The submodule is pinned to current Kinder `main` at `c9b747c`, which also includes the Packing3D state-restoration fix and the physics-backend separation.

## Initial-state distributions

Each GIF has 200 initial states:

- **train, frames 1–100:** seeds 0–99, with counts sampled from `design_counts`;
- **eval, frames 101–200:** the exact evaluation seed construction used by `run_experiment.py` with `eval_seed=42`, while cycling through every configured `eval_count`.

Every frame is labeled with the phase, seed, and realized count. The optimized PR copies preserve all 200 frames.

<table>
<tr>
<th>Table3D</th>
<th>Transport3D</th>
</tr>
<tr>
<td><img src="https://raw.githubusercontent.com/tomsilver/robocode/pr-assets-generalized-3d-envs/docs/pr-assets/generalized-3d-envs/table3d_generalized.gif" width="480"></td>
<td><img src="https://raw.githubusercontent.com/tomsilver/robocode/pr-assets-generalized-3d-envs/docs/pr-assets/generalized-3d-envs/transport3d_generalized.gif" width="480"></td>
</tr>
<tr>
<th>Shelf3D</th>
<th>Obstruction3D</th>
</tr>
<tr>
<td><img src="https://raw.githubusercontent.com/tomsilver/robocode/pr-assets-generalized-3d-envs/docs/pr-assets/generalized-3d-envs/shelf3d_generalized.gif" width="480"></td>
<td><img src="https://raw.githubusercontent.com/tomsilver/robocode/pr-assets-generalized-3d-envs/docs/pr-assets/generalized-3d-envs/obstruction3d_generalized.gif" width="480"></td>
</tr>
<tr>
<th>Packing3D</th>
<th>ConstrainedCupboard3D</th>
</tr>
<tr>
<td><img src="https://raw.githubusercontent.com/tomsilver/robocode/pr-assets-generalized-3d-envs/docs/pr-assets/generalized-3d-envs/packing3d_generalized.gif" width="480"></td>
<td><img src="https://raw.githubusercontent.com/tomsilver/robocode/pr-assets-generalized-3d-envs/docs/pr-assets/generalized-3d-envs/constrainedcupboard3d_generalized.gif" width="480"></td>
</tr>
</table>

## Scope boundaries

This PR does not add 3D bilevel-planner models or collision-checking primitives; those will be a separate follow-up.

It also does not fold in the ongoing upstream environment-validity work:

- [kinematic3d motion validity](https://github.com/merlerm/kindergarden/tree/fix/kinematic3d-motion-validity)
- [Transport3D table collision](https://github.com/merlerm/kindergarden/tree/fix/transport3d-table-collision-stacked)
- [Obstruction3D goal containment](https://github.com/merlerm/kindergarden/tree/fix/obstruction3d-goal-containment-stacked)
- [Packing3D geometry validity](https://github.com/merlerm/kindergarden/tree/fix/packing3d-geometry-validity-stacked)

The count choices here assume those fixes land upstream.

## Validation

- Full GitHub Actions CI: formatting, isort, pylint, mypy, and unit tests all pass.
- New tests instantiate every generalized 3D configuration, exercise every configured count, restore specialized 3D states exactly through the black-box client (including Packing3D randomized triangle geometry), reject unsupported/infeasible configurations, and verify PyBullet clients are released.
- All six distribution GIFs were checked for exactly 200 frames and visually inspected at the train/eval boundary and maximum evaluation count.
