### PR TITLE
Fix/sandbox env config count leak

### DIFF
--- a/src/robocode/environments/variable_object_count_env.py
+++ b/src/robocode/environments/variable_object_count_env.py
@@ -523,8 +523,8 @@ class VariableObjectCountEnv(BaseEnv[ObjectCentricState, NDArray[Any]]):
             f'    count_object_prefix="{self._count_object_prefix}",\n'
             f"{fixed_kwargs_example_arg}"
             f"{bilevel_example_arg}"
-            "    design_counts=[<count list>],\n"
-            "    eval_counts=[<count list>],\n"
+            "    design_counts=[<count list>],  # counts of your choice\n"
+            "    eval_counts=[<count list>],  # counts of your choice\n"
             ")\n\n"
             "# Pin a count to build an instance of that size, for any count:\n"
             "state, info = env.reset(seed=0, options={'object_count': 3})\n"

--- a/src/robocode/mcp/__init__.py
+++ b/src/robocode/mcp/__init__.py
@@ -240,23 +240,16 @@ def mcp_tool_cli_names(tool_names: tuple[str, ...]) -> tuple[str, ...]:
     return tuple(f"mcp__{MCP_SERVER_NAME}__{t}" for t in tool_names)
 
 
-# Env-config fields listing the object counts a run is configured for. The sandbox
-# copy of the config keeps a single count in each: the render server needs a
-# constructible env, and its tools pin the object count per call.
+# Count-range fields are dropped from the sandbox copy; the render server
+# re-inserts a placeholder (see local_render._build_env).
 _COUNT_RANGE_KEYS = ("design_counts", "eval_counts")
-_SANDBOX_COUNTS = [1]
 
 
 def _write_sandbox_env_config(source: Path, dest: Path) -> None:
-    """Write the env config the in-sandbox render server instantiates.
-
-    The sandbox copy is readable from inside the sandbox, so it carries only what the
-    server needs: the count-range fields are reduced to a single count.
-    """
+    """Write the env config the in-sandbox render server instantiates."""
     config = json.loads(source.read_text(encoding="utf-8"))
     for key in _COUNT_RANGE_KEYS:
-        if key in config:
-            config[key] = _SANDBOX_COUNTS
+        config.pop(key, None)
     dest.write_text(json.dumps(config, indent=2), encoding="utf-8")
 
 

--- a/src/robocode/mcp/local_render.py
+++ b/src/robocode/mcp/local_render.py
@@ -54,7 +54,6 @@ from robocode.rendering.render_policy import render_policy as _render_policy_fn
 from robocode.rendering.render_state import render_state as _render_state_fn
 from robocode.utils.render_paths import safe_label, unique_path
 
-
 # Placeholder counts, temporary so the env is constructible for rendering; the
 # render tools pin the actual object count per call.
 _PLACEHOLDER_COUNTS = [1]

--- a/src/robocode/mcp/local_render.py
+++ b/src/robocode/mcp/local_render.py
@@ -55,9 +55,17 @@ from robocode.rendering.render_state import render_state as _render_state_fn
 from robocode.utils.render_paths import safe_label, unique_path
 
 
+# Placeholder counts, temporary so the env is constructible for rendering; the
+# render tools pin the actual object count per call.
+_PLACEHOLDER_COUNTS = [1]
+
+
 def _build_env(env_config: dict[str, Any]) -> Any:
     """Instantiate the environment and reset it once."""
     logger.info("Building environment from config")
+    if "count_kwarg" in env_config:
+        for key in ("design_counts", "eval_counts"):
+            env_config.setdefault(key, _PLACEHOLDER_COUNTS)
     cfg = OmegaConf.create(env_config)
     env = instantiate(cfg)
     env.reset(seed=0)

--- a/tests/utils/test_mcp_sandbox_config.py
+++ b/tests/utils/test_mcp_sandbox_config.py
@@ -3,10 +3,8 @@
 import json
 from pathlib import Path
 
-from hydra.utils import instantiate
-from omegaconf import OmegaConf
-
 from robocode.mcp import setup_mcp_config
+from robocode.mcp.local_render import _build_env
 
 STICKBUTTON2D_CFG = {
     "_target_": "robocode.environments.variable_object_count_env.VariableObjectCountEnv",
@@ -48,8 +46,8 @@ def test_sandbox_env_config_holds_no_count_range(tmp_path: Path) -> None:
     written = json.loads(
         (sandbox_dir / ".mcp" / "env_config.json").read_text(encoding="utf-8")
     )
-    assert written["design_counts"] == [1]
-    assert written["eval_counts"] == [1]
+    assert "design_counts" not in written
+    assert "eval_counts" not in written
 
     for path in sandbox_dir.rglob("*"):
         if path.is_file():
@@ -59,14 +57,14 @@ def test_sandbox_env_config_holds_no_count_range(tmp_path: Path) -> None:
 
 
 def test_sandbox_env_config_still_instantiates(tmp_path: Path) -> None:
-    """The reduced config builds an env, and a pinned count still resets to that
-    size."""
+    """The reduced config builds an env through the render server, and a pinned
+    count still resets to that size."""
     sandbox_dir = _write_sandbox(tmp_path, STICKBUTTON2D_CFG)
     written = json.loads(
         (sandbox_dir / ".mcp" / "env_config.json").read_text(encoding="utf-8")
     )
 
-    env = instantiate(OmegaConf.create(written))
+    env = _build_env(written)
     state, info = env.reset(seed=0, options={"object_count": 4})
     assert info["object_count"] == 4
     assert sum(1 for n in state.get_object_names() if n.startswith("button")) == 4


### PR DESCRIPTION
This was a big thing holding opus runs back, it was just a placeholder [1] in the mcp tools config to be able to instantiate the env, but many opus runs found it and interpreted it as "we just need to eval on 1 object" and they collapsed because of it. I tested some runs with this and it seems to not happen anymore but let's keep a close eye on it