### PR TITLE
Depend on pybullet-arm64 instead of building pybullet from source

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,32 +1,4 @@
 #!/bin/bash
 set -e
 git submodule update --init --recursive
-
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    echo "macOS detected: building PyBullet from source (workaround for macOS compatibility)..."
-
-    # Initialize the virtual environment first so we can use its Python
-    uv venv
-
-    VENV_PYTHON="$(pwd)/.venv/bin/python"
-    BULLET_TMP=$(mktemp -d)
-    trap 'rm -rf "$BULLET_TMP"' EXIT
-
-    git clone https://github.com/bulletphysics/bullet3 "$BULLET_TMP/bullet3"
-
-    # Comment out the line that causes build failure on recent macOS
-    sed -i '' \
-        's|^#define fdopen(fd, mode) NULL|// #define fdopen(fd, mode) NULL|' \
-        "$BULLET_TMP/bullet3/examples/ThirdPartyLibs/zlib/zutil.h"
-
-    uv pip install setuptools
-    pushd "$BULLET_TMP/bullet3"
-    "$VENV_PYTHON" setup.py build
-    "$VENV_PYTHON" setup.py install
-    popd
-
-    # Sync everything else; pybullet is already installed from source above
-    uv sync --all-extras --dev --no-install-package pybullet
-else
-    uv sync --all-extras --dev
-fi
+uv sync --all-extras --dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
    "hydra-joblib-launcher",
    "omegaconf",
    "kindergarden>=0.2.0",
-   "pybullet",
+   "pybullet-arm64>=3.2.8",
    "types-shapely",
    "scipy-stubs",
    "imageio",

--- a/uv.lock
+++ b/uv.lock
@@ -2869,15 +2869,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pybullet"
-version = "3.2.7"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/de/95/b9a98cd4ed948d4f25a7d0b13cb0c1f87e58dc6d113be9e18940641eb25f/pybullet-3.2.7.tar.gz", hash = "sha256:042879db8d101ac7590dee475fc6aded508b85fe1273fdbbfde1d88bd200e14f", size = 80508379, upload-time = "2025-01-30T00:34:00.527Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/78/a23a300110968586a9dbfd516ccd66906450d57567c9f60cddaeaaf10fa6/pybullet-3.2.7-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d858abf7c12a21ef3ed351cf81dac1b5e486ec25c9ab59bfc84beb89034edff", size = 103196742, upload-time = "2025-01-30T00:19:07.063Z" },
-]
-
-[[package]]
 name = "pybullet-arm64"
 version = "3.2.8"
 source = { registry = "https://pypi.org/simple" }
@@ -3539,7 +3530,7 @@ dependencies = [
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "pandas", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
     { name = "pandas-stubs" },
-    { name = "pybullet" },
+    { name = "pybullet-arm64" },
     { name = "scipy-stubs" },
     { name = "types-shapely" },
 ]
@@ -3599,7 +3590,7 @@ requires-dist = [
     { name = "openai" },
     { name = "pandas" },
     { name = "pandas-stubs" },
-    { name = "pybullet" },
+    { name = "pybullet-arm64", specifier = ">=3.2.8" },
     { name = "pylint", marker = "extra == 'develop'", specifier = ">=2.14.5" },
     { name = "pytest", marker = "extra == 'develop'", specifier = ">=7.2.2,<9.1" },
     { name = "pytest-pylint", marker = "extra == 'develop'", specifier = ">=0.18.0" },


### PR DESCRIPTION
## Problem

PyPI's `pybullet` ships an sdist plus a single manylinux x86_64 wheel, and no macOS wheel at all. Installing on macOS therefore has to compile from source, and that compile fails against recent macOS SDKs: the vendored zlib's `zutil.h` does `#define fdopen(fd, mode) NULL`, which collides with the real `fdopen` the newer SDK headers declare.

`install.sh` worked around this with a 30-line macOS-only branch that cloned bullet3, `sed`-patched that header, built and installed it by hand, then ran `uv sync --no-install-package pybullet`.

That build was redundant. `kindergarden` already depends on `pybullet-arm64>=3.2.8`, a republish of the same upstream Bullet source that ships prebuilt wheels for every platform we support (including a macOS `universal2` wheel), so it was being installed transitively regardless of what robocode declared.

Both distributions install the **same file** (`pybullet.cpython-311-darwin.so`). `pybullet-arm64` lands second and overwrites the hand-compiled binary, leaving a stale `pybullet` dist-info behind describing files it no longer owns. `import pybullet` in that state reports the 3.2.8 arm64 build, not the one `install.sh` just spent several minutes compiling. It is also a live hazard rather than only cosmetic: because the two distributions claim overlapping files, uninstalling either one deletes files the other needs.

## Change

- `pyproject.toml`: `"pybullet"` becomes `"pybullet-arm64>=3.2.8"`, matching what kindergarden already depends on.
- `install.sh`: the entire macOS branch is gone. It is now submodule init plus `uv sync --all-extras --dev` on every platform (32 lines to 4).
- `uv.lock`: drops the now-unreferenced `pybullet 3.2.7` package block and repoints robocode's two references.

No other resolved versions change. The `pybullet` *module* name is unchanged, so no source, imports, or mypy overrides needed touching.

## Note on the lockfile

Running `uv lock` produces the correct result (`Removed pybullet v3.2.7`, nothing else), but current uv bumps the lockfile format from `revision = 2` to `revision = 3`, which drags in roughly 70 lines of unrelated marker normalization. I discarded that and hand-edited the three affected references instead, keeping the diff to 2 insertions / 11 deletions. Happy to swap in the fully regenerated lock if you would rather take the format bump now.

Validated with `uv export --frozen --all-extras`, which resolves the whole graph from the lock and lists `pybullet-arm64==3.2.8` with no plain `pybullet`.

Separately worth flagging: `uv lock --check` already fails on `main` before this change, because the committed lock predates a `prpl-kinematics` extra added to the kindergarden submodule. Untouched here, but it likely wants a standalone relock.

## Testing

macOS arm64 (M-series), Python 3.11, all extras except `libero`:

- `pytest tests/ --ignore=tests/mcp` gives **598 passed, 18 skipped**
- `pip check` reports no broken requirements, and exactly one distribution now owns the `pybullet` module
- `pybullet`, `pybullet_utils`, `pybullet_data`, and `pybullet_helpers` all import from the single 3.2.8 build

`mypy` reports one pre-existing error on macOS (`src/robocode/utils/sandbox.py:126: Statement is unreachable`), which reproduces on unmodified `main`. It is a platform artifact: mypy narrows `sys.platform != "linux"` to always-true on darwin, so the final return is unreachable there but fine on the Linux CI runner. Unrelated to this change and left alone.

I do not have a Linux or Windows box to verify on, so CI is the real check for those. The risk is low since `pybullet-arm64` publishes manylinux x86_64 and win_amd64 wheels for 3.11 through 3.13, and Linux previously took the plain `uv sync` path that this change preserves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
